### PR TITLE
initkbd: Fix warning about missing decl for strcmp.

### DIFF
--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -12,10 +12,8 @@ static char *id = "$Id: initkbd.c,v 1.2 1999/01/03 02:07:09 sybalsky Exp $ Copyr
 #include "version.h"
 
 #include <stdio.h>
-#include <sys/types.h>
-#if defined(MACOSX) || defined(FREEBSD)
 #include <string.h>
-#endif
+#include <sys/types.h>
 #ifndef DOS
 #include <sys/file.h>
 #include <sys/select.h>


### PR DESCRIPTION
Instead of adding more stuff to the `#ifdef` around the inclusion
of `<string.h>`, we remove that `#ifdef` entirely.

There are many instances of `<string.h>` being included in the
code without any `#ifdef` protection, and `strcmp` is defined to
be declared in `<string.h>`, so all platforms from the last 20
years and into the future will need this.