### PR TITLE
uutils: Clean up string.h inclusion.

### DIFF
--- a/src/uutils.c
+++ b/src/uutils.c
@@ -28,18 +28,9 @@ static char *id = "$Id: uutils.c,v 1.3 1999/05/31 23:35:47 sybalsky Exp $ Copyri
 #else
 #include <sys/time.h>
 #endif
-#ifndef SYSVONLY
-#if defined(DOS)
-#include <string.h>
-#else
-#include <strings.h>
-#endif /* DOS */
-#endif /* SYSVONLY */
-#if defined(MACOSX) || defined(FREEBSD) /* we compile these with SYSVONLY but... */
-#include <string.h>
-#endif
 
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include "lispemul.h"
 #include "adr68k.h"


### PR DESCRIPTION
This is similar to the change in #27. We can just include <string.h>
rather than doing performative dances and complicating everything.