### PR TITLE
Remove FUJI compile flag.

### DIFF
--- a/bin/compile-flags
+++ b/bin/compile-flags
@@ -143,9 +143,6 @@ RECLAIMINC	If true, then the RECLAIMCELL opcode calls gcreclaimcell in
 		and is not in any system.  Probably fairly easy to debug??
 KB_SUN4		The kbd type for the Type-4 keyboard.  Defined only because
 		older OS versions of the compiler don't define it automatically.
-FUJI		If true, and you don't set the LDEKBDTYPE environment variable,
-		you'll get a nasty message asking you to set it before
-		running lisp.  Otherwise, you'll default to a type-3 kbd.
 FLTINT		If true, use the floating-point exception interrupts to detect
 		errors and overflows on FP operations.  The interrupt sets a
 		global error flag.  Otherwise, calls library routines to see

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -574,19 +574,9 @@ void keyboardtype(int fd)
 
   /* Get keytype from LDEKBDTYPE  */
   if ((key = getenv("LDEKBDTYPE")) == 0) {
-#ifdef FUJI
-    /* obnoxious behavior */
-    mess_reset();
-    printf("!!CAUTION: LDEKBDTYPE is not set.\n");
-    printf("Please retry after setting LDEKBDTYPE correctly.\n");
-    printf("Usage: setenv LDEKBDTYPE <kbdtype>\n");
-    printf("       (one of type2, type3, type4, jle, or as3000j)");
-    exit(0); /* exit to shell */
-#else
 #ifdef RS6000
     type = KB_RS6000;
-#else
-#ifdef XWINDOW
+#elif XWINDOW
     type = KB_X;
 #elif DOS
     type = KB_DOS;
@@ -596,15 +586,6 @@ void keyboardtype(int fd)
       type = KB_SUN3;
     } /* otherwise, type is set */
 #endif /* XWINDOW */
-
-#endif /* RS6000 */
-
-#endif /* FUJI */
-
-#ifdef XWINDOW
-#undef FUJI
-#endif /* XWINDOW */
-
   } /* if end */
   else {
     if (strcmp("as3000j", key) == 0)


### PR DESCRIPTION
This was only used for a keyboard warning that doesn't seem
relevant any longer.