### PR TITLE
Use tcgetattr/tcsetattr in termios code, not ioctl.

### DIFF
--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -165,17 +165,9 @@ int ForkUnixShell(int slot, char ltr, char numb, char *termtype, char *shellarg)
    kill processing, echo, backspace to erase, echo ctrl
    chars as ^x, kill line by backspacing */
 
-#if defined(MACOSX) || defined(FREEBSD)
     tcgetattr(SlaveFD, &tio);
-#else
-    ioctl(SlaveFD, TCGETS, (char *)&tio);
-#endif
     tio.c_lflag |= ICANON | ECHO | ECHOE | ECHOCTL | ECHOKE;
-#if defined(MACOSX) || defined(FREEBSD)
     tcsetattr(SlaveFD, TCSANOW, &tio);
-#else
-    ioctl(SlaveFD, TCSETS, (char *)&tio);
-#endif
 #endif /* USETERMIOS */
 
     (void)dup2(SlaveFD, 0);


### PR DESCRIPTION
Previously, we were using ioctl directly on some platforms rather
than always going through termios. This complicates portability.