### PR TITLE
Remove getdtablesize calls in favor of sysconf(_SC_OPEN_MAX).

### DIFF
--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -277,11 +277,7 @@ int FindUnixPipes(void) {
   if ((envtmp = getenv("LDEUNIXPID"))) UnixPID = atoi(envtmp);
 
 /* This is a good place to initialize stuff like the UJ table */
-#ifdef SYSVONLY
   NPROCS = sysconf(_SC_OPEN_MAX);
-#else
-  NPROCS = getdtablesize();
-#endif /* SYSVONLY */
 
   UJ = (struct unixjob *)malloc(NPROCS * sizeof(struct unixjob));
   cleareduj.status = -1;

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -446,13 +446,8 @@ int fork_Unix() {
             dup2(sock, 1);
             dup2(sock, 2);
 
-#ifdef SYSVONLY
-            /* Make sure everything else is closed POSIX has no getdtab... */
+            /* Make sure everything else is closed. */
             for (i = 3; i < sysconf(_SC_OPEN_MAX); i++) close(i);
-#else
-            /* Make sure everything else is closed */
-            for (i = 3; i < getdtablesize(); i++) close(i);
-#endif /* SYSVONLY */
 
             /* Run the shell command and get the result */
             status = system(cmdstring);


### PR DESCRIPTION
`getdtablesize()` has long been deprecated in favor of
`sysconf(_SC_OPEN_MAX)`.