### PR TITLE
Remove define direct dirent workarounds.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -255,7 +255,6 @@ typedef signed char s_char;
 #undef HAS_GETHOSTID
 #define BSD_COMP 1
 #define SYSVSIGNALS 1
-#define L_SET SEEK_SET
 #define NOFORN
 #define LOCK_X_UPDATES 1
 #endif /* OS5 */

--- a/src/dir.c
+++ b/src/dir.c
@@ -23,8 +23,6 @@ static char *id = "$Id: dir.c,v 1.4 2001/12/26 22:17:01 sybalsky Exp $ Copyright
 #include <dirent.h>
 #include <pwd.h>
 #include <sys/param.h>
-// TODO: Remove the need for this.
-#define direct dirent
 #else /* DOS, now */
 #include <dos.h>
 #define index strchr
@@ -615,7 +613,7 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
+  register struct dirent *dp;
   register FINFO *prevp;
   register FINFO *nextp;
   int n, len, rval;
@@ -633,7 +631,7 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
   }
 
   for (S_TOUT(dp = readdir(dirp)), nextp = prevp = (FINFO *)NULL, n = 0;
-       dp != (struct direct *)NULL || errno == EINTR;
+       dp != (struct dirent *)NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)), prevp = nextp)
     if (dp) {
       if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0 || dp->d_ino == 0) continue;
@@ -878,7 +876,7 @@ static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 
 static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
+  register struct dirent *dp;
   register FINFO *prevp;
   register FINFO *nextp;
   int n, len, rval;
@@ -895,7 +893,7 @@ static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
   }
 
   for (S_TOUT(dp = readdir(dirp)), nextp = prevp = (FINFO *)NULL, n = 0;
-       dp != (struct direct *)NULL || errno == EINTR;
+       dp != (struct dirent *)NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)), prevp = nextp)
     if (dp) {
       if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0 || dp->d_ino == 0) continue;
@@ -1072,7 +1070,7 @@ static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
+  register struct dirent *dp;
   register FINFO *prevp;
   register FINFO *nextp;
   int n, len, rval;
@@ -1089,7 +1087,7 @@ static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
   }
 
   for (S_TOUT(dp = readdir(dirp)), nextp = prevp = (FINFO *)NULL, n = 0;
-       dp != (struct direct *)NULL || errno == EINTR;
+       dp != (struct dirent *)NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)), prevp = nextp)
     if (dp) {
       if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0 || dp->d_ino == 0) continue;
@@ -1255,7 +1253,7 @@ static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
+  register struct dirent *dp;
   register FINFO *prevp;
   register FINFO *nextp;
   int n, len, rval;
@@ -1271,7 +1269,7 @@ static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
   }
 
   for (S_TOUT(dp = readdir(dirp)), nextp = prevp = (FINFO *)NULL, n = 0;
-       dp != (struct direct *)NULL || errno == EINTR;
+       dp != (struct dirent *)NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)), prevp = nextp)
     if (dp) {
       if (strcmp(dp->d_name, ".") == 0 || strcmp(dp->d_name, "..") == 0 || dp->d_ino == 0) continue;

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -28,15 +28,6 @@ static char *id = "$Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright
 #ifdef sun
 #include <sys/vfs.h>
 #endif /* sun */
-
-// We should be using the POSIX definitions in this file.
-#define direct dirent
-#define d_namlen d_reclen
-#define d_fileno d_ino
-#ifndef LINUX
-#define L_SET SEEK_SET
-#endif
-
 #else /* DOS */
 
 #include <direct.h>
@@ -48,7 +39,6 @@ static char *id = "$Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright
 #define rindex strrchr
 #define MAXPATHLEN _MAX_PATH
 #define MAXNAMLEM _MAX_PATH
-#define L_SET SEEK_SET
 #define alarm(x) 0
 #endif /* DOS */
 
@@ -81,10 +71,7 @@ static char *id = "$Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright
 #include <sys/statfs.h>
 #endif
 #endif /* AIXPS2 */
-
-#define d_fileno d_ino
 #endif /* AIX */
-
 #endif /* MACOSX | FREEBSD */
 
 #ifdef GCC386
@@ -731,7 +718,7 @@ LispPTR COM_closefile(register LispPTR *args)
   char file[MAXPATHLEN], dir[MAXPATHLEN], name[MAXNAMLEN + 1];
   char ver[VERSIONLEN];
   register DIR *dirp;
-  register struct direct *dp;
+  register struct dirent *dp;
   struct stat sbuf;
   struct timeval time[2];
   ino_t ino;
@@ -832,10 +819,10 @@ LispPTR COM_closefile(register LispPTR *args)
       return (NIL);
     }
 
-    for (S_TOUT(dp = readdir(dirp)); dp != (struct direct *)NULL || errno == EINTR;
+    for (S_TOUT(dp = readdir(dirp)); dp != (struct dirent *)NULL || errno == EINTR;
          errno = 0, S_TOUT(dp = readdir(dirp)))
       if (dp) {
-        if (ino == (ino_t)dp->d_fileno) sprintf(file, "%s/%s", dir, dp->d_name);
+        if (ino == (ino_t)dp->d_ino) sprintf(file, "%s/%s", dir, dp->d_name);
       }
     TIMEOUT(closedir(dirp));
   }
@@ -1993,7 +1980,7 @@ LispPTR COM_readpage(register LispPTR *args)
    * file.  If the request file is special file, lseek is not needed.
    */
   sklp:
-    TIMEOUT(rval = lseek(fd, (npage * FDEV_PAGE_SIZE), L_SET));
+    TIMEOUT(rval = lseek(fd, (npage * FDEV_PAGE_SIZE), SEEK_SET));
     if (rval == -1) {
       if (errno == EINTR) goto sklp; /* interrupted, retry */
       *Lisp_errno = errno;
@@ -2065,7 +2052,7 @@ LispPTR COM_writepage(register LispPTR *args)
   count = LispNumToCInt(args[3]);
 
 sklp2:
-  TIMEOUT(rval = lseek(fd, (npage * FDEV_PAGE_SIZE), L_SET));
+  TIMEOUT(rval = lseek(fd, (npage * FDEV_PAGE_SIZE), SEEK_SET));
   if (rval == -1) {
     if (errno == EINTR) goto sklp2; /* interrupted; retry */
     *Lisp_errno = errno;
@@ -2689,7 +2676,7 @@ static int locate_file(char *dir, char *name)
   char nb1[MAXNAMLEN], nb2[MAXNAMLEN];
   register int type, len;
   DIR *dirp;
-  struct direct *dp;
+  struct dirent *dp;
 
   /* First of all, recognize as if. */
   sprintf(path, "%s/%s", dir, name);
@@ -2729,7 +2716,7 @@ static int locate_file(char *dir, char *name)
   for (S_TOUT(dp = readdir(dirp)); dp != NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)))
     if (dp) {
-      if (dp->d_namlen == len) {
+      if (dp->d_reclen == len) {
         strcpy(nb2, dp->d_name);
         UPCASE(nb2);
         if (strcmp(nb1, nb2) == 0) {
@@ -3134,7 +3121,7 @@ static int get_version_array(char *dir, char *file, FileName *varray, CurrentVAr
   char ver[VERSIONLEN];
   register FileName *svarray;
   register DIR *dirp;
-  register struct direct *dp;
+  register struct dirent *dp;
   register int rval;
   struct stat sbuf;
 

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -286,7 +286,7 @@ LispPTR mess_read(LispPTR *args)
     size = MESSAGE_BUFFER_SIZE;
   else
     logChanged = 0; /* only reset msg-pending flg if we cleaned it out! */
-  TIMEOUT(i = lseek(log_id, previous_size, L_SET));
+  TIMEOUT(i = lseek(log_id, previous_size, SEEK_SET));
   if (i == -1) {
     OSMESSAGE_PRINT(printf("seek err\n"));
     return (NIL);
@@ -298,7 +298,7 @@ LispPTR mess_read(LispPTR *args)
     OSMESSAGE_PRINT(printf("read err\n"));
     return (NIL);
   }
-  TIMEOUT(i = lseek(log_id, save_size, L_SET));
+  TIMEOUT(i = lseek(log_id, save_size, SEEK_SET));
   if (i == -1) {
     OSMESSAGE_PRINT(printf("seek err\n"));
     return (NIL);


### PR DESCRIPTION
This also removes a workaround for `L_SET`, as well as some of the
`dirent` member fields.