### PR TITLE
Use LINUX, not AIX, in medleyfp.h.

### DIFF
--- a/inc/medleyfp.h
+++ b/inc/medleyfp.h
@@ -60,7 +60,7 @@ volatile extern int  FP_error;
 #define FPCLEAR
 #define FPTEST(result) (isinf(result) || isnan(result))
 
-#elif defined(AIX)
+#elif defined(LINUX)
 #define FPCLEAR
 #define FPTEST(result) ((!finite(result)) || isnan(result))
 


### PR DESCRIPTION
AIX was defined by a number of targets, but the only one that
doesn't currently have anything here is LINUX, so we can just
check that instead.