### PR TITLE
Remove unused BSD_COMP define from SunOS5 config.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -234,7 +234,6 @@ typedef signed char s_char;
 #ifdef OS5
 		/* Solaris, sort of SYSV-ish, but not really */
 #undef HAS_GETHOSTID
-#define BSD_COMP 1
 #define SYSVSIGNALS 1
 #define NOFORN
 #define LOCK_X_UPDATES 1


### PR DESCRIPTION
Same as #56, now that #64 has landed.