### PR TITLE
remove uses of deprecated rindex

### DIFF
--- a/src/dir.c
+++ b/src/dir.c
@@ -25,8 +25,6 @@ static char *id = "$Id: dir.c,v 1.4 2001/12/26 22:17:01 sybalsky Exp $ Copyright
 #include <sys/param.h>
 #else /* DOS, now */
 #include <dos.h>
-#define index strchr
-#define rindex strrchr
 #define MAXPATHLEN _MAX_PATH
 #define MAXNAMLEN _MAX_PATH
 #define alarm(x) 1
@@ -79,14 +77,14 @@ extern int Dummy_errno;
                                                      \
     separate_version(tname, tver, 0);                \
                                                      \
-    if ((pp = (char *)rindex(tname, '.')) == NULL) { \
+    if ((pp = (char *)strrchr(tname, '.')) == NULL) { \
       *text = '\0';                                  \
     } else {                                         \
       *pp = '\0';                                    \
       strcpy(text, pp + 1);                          \
     }                                                \
                                                      \
-    if ((pp = (char *)rindex(pname, '.')) == NULL) { \
+    if ((pp = (char *)strrchr(pname, '.')) == NULL) { \
       *pext = '\0';                                  \
     } else {                                         \
       *pp = '\0';                                    \

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -31,8 +31,6 @@ static char *id = "$Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright
 #include <dos.h>
 #include <time.h>
 #include <io.h>
-#define index strchr
-#define rindex strrchr
 #define MAXPATHLEN _MAX_PATH
 #define MAXNAMLEM _MAX_PATH
 #define alarm(x) 0
@@ -2468,7 +2466,7 @@ int unpack_filename(char *file, char *dir, char *name, char *ver, int checkp)
   register char *cp;
 
 #ifdef DOS
-  if ((cp = (char *)max((UNSIGNED)rindex(file, DIRSEP), (UNSIGNED)rindex(file, UNIXDIRSEP))) == 0)
+  if ((cp = (char *)max((UNSIGNED)strrchr(file, DIRSEP), (UNSIGNED)strrchr(file, UNIXDIRSEP))) == 0)
     return (0);
 
   if (file[1] == DRIVESEP) { /* There's a drive spec; copy it and ignore it from here on. */
@@ -2476,7 +2474,7 @@ int unpack_filename(char *file, char *dir, char *name, char *ver, int checkp)
     *dir++ = *file++;
   }
 #else  /* DOS */
-  if ((cp = (char *)rindex(file, UNIXDIRSEP)) == NULL) return (0);
+  if ((cp = (char *)strrchr(file, UNIXDIRSEP)) == NULL) return (0);
 #endif /* DOS */
 
   if (cp == file) {

--- a/src/main.c
+++ b/src/main.c
@@ -34,8 +34,6 @@ static char *id = "$Id: main.c,v 1.4 2001/12/26 22:17:03 sybalsky Exp $ Copyrigh
 #include <i32.h>
 #define MAXPATHLEN 128
 #define R_OK 04
-#define index strchr
-#define rindex strrchr
 #endif /* DOS */
 
 #ifndef NOETHER

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -33,8 +33,6 @@ static char *id = "$Id: ufs.c,v 1.2 1999/01/03 02:07:41 sybalsky Exp $ Copyright
 
 #define MAXPATHLEN _MAX_PATH
 #define MAXNAMLEN _MAX_PATH
-#define index strchr
-#define rindex strrchr
 #define alarm(x) 1
 #endif /* DOS */
 


### PR DESCRIPTION
index/rindex are deprecated in favor of strchr/strrchr so use them directly and remove associated defines,
except in os.h which is a set of shim defines inherited from nfswatch for use in dlpi.c