### PR TITLE
Fixup xdefs.h

### DIFF
--- a/inc/xdefs.h
+++ b/inc/xdefs.h
@@ -8,6 +8,8 @@
 /*	Manufactured in the United States of America.			*/
 /*									*/
 /************************************************************************/
+#ifndef XDEFS_H
+#define XDEFS_H 1
 
 #define DEF_WIN_X       20
 #define DEF_WIN_Y       20
@@ -26,29 +28,27 @@
 #define SCROLL_PITCH      30
 
 
-#ifndef __LDEXDEF__
-
-#define __LDEXDEF__ 1
-#include <signal.h>
 #ifdef LOCK_X_UPDATES
-#define XLOCK { XLocked++; /* printf("L"); fflush(stdout);*/}
+
+#include <unistd.h>
+#include <signal.h>
+extern int XLocked;
+extern int XNeedSignal;
+/* this is !0 if we're locked; it should be 0 or larger always */
+
+#define XLOCK do { XLocked++; /* printf("L"); fflush(stdout);*/} while (0)
 #define XUNLOCK					\
-  { XLocked--;/* printf("U"); fflush(stdout);*/	\
+  do { XLocked--;/* printf("U"); fflush(stdout);*/	\
     if (XNeedSignal)				\
       {						\
 	XNeedSignal = 0;			\
 	kill(getpid(), SIGPOLL);		\
-      };						\
-  }
+      };					\
+  } while (0)
 #else
 #define XLOCK
 #define XUNLOCK
 #endif	/* LOCK_X_UPDATES */
-
-extern int XLocked;
-extern int XNeedSignal;
-/* this is !0 if we're locked; it should be 0 or larger always */
-#endif
 
 #ifdef XWINDOW
 #ifdef XV11R4
@@ -82,3 +82,4 @@ extern int XNeedSignal;
 #define XV11R4			/* newest version */
 #endif
 #endif /* XWINDOW */
+#endif /* XDEFS_H */


### PR DESCRIPTION
Update guard name to match file name and protect entire file
Only declare extern lock variables when doing locking
Include system headers that locking macros depend on
Convert code block  macros to do { } while (0) statement style