### PR TITLE
main.c has no dependency upon unixfork.h.

### DIFF
--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -230,7 +230,7 @@ $(OBJECTDIR)main.o : $(SRCDIR)main.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h \
 	 $(INCDIR)emlglob.h  $(INCDIR)address.h $(INCDIR)lsptypes.h \
 	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
 	 $(INCDIR)lispmap.h  $(INCDIR)ifpage.h  $(INCDIR)iopage.h \
-	 $(INCDIR)return.h $(INCDIR)debug.h $(INCDIR)profile.h $(INCDIR)unixfork.h
+	 $(INCDIR)return.h $(INCDIR)debug.h $(INCDIR)profile.h
 	$(CC) $(RFLAGS) $(SRCDIR)main.c $(INLINE) -o $(OBJECTDIR)main$(OEXT)
 
 $(OBJECTDIR)dbgtool.o :  $(SRCDIR)dbgtool.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  \

--- a/src/main.c
+++ b/src/main.c
@@ -17,7 +17,6 @@ static char *id = "$Id: main.c,v 1.4 2001/12/26 22:17:03 sybalsky Exp $ Copyrigh
 
 #include "lispemul.h"
 #include "dbprint.h"
-#include "unixfork.h"
 
 #include <errno.h>
 #include <setjmp.h>


### PR DESCRIPTION
This avoids a bit of confusion, since unixfork.c isn't built into
the same executable as main.c. (It is part of `lde` instead.)