### PR TITLE
Update old makefiles for renaming of byteswapfns.c

### DIFF
--- a/bin/makefile-sunos3.mc68020-x
+++ b/bin/makefile-sunos3.mc68020-x
@@ -40,7 +40,7 @@ INLINE = $(SRCDIR)disp68K.il
 BITBLTFILE = $(OBJECTDIR)bitblt68K.o
 
 OBJECTDIR = ../sunos3.mc68020-x/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether
 

--- a/bin/makefile-sunos4.1.i386
+++ b/bin/makefile-sunos4.1.i386
@@ -10,7 +10,7 @@ LDFLAGS = -lsuntool -lsunwindow -lpixrect -lc -lm
 INLINE = $(SRCDIR)disp386i.il
 
 OBJECTDIR = ../sunos4.i386/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o 
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 COLORFILES = $(OBJECTDIR)colorbltfns.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether

--- a/bin/makefile-sunos4.1.i386-multi
+++ b/bin/makefile-sunos4.1.i386-multi
@@ -12,7 +12,7 @@ INLINE = $(SRCDIR)disp386i.il
 BITBLTFILE=$(OBJECTDIR)bitblt386i.o
 
 OBJECTDIR = ../sunos4.i386-multi/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o 
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 COLORFILES = $(OBJECTDIR)colorbltfns.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether

--- a/bin/makefile-sunos4.1.mc68020-x
+++ b/bin/makefile-sunos4.1.mc68020-x
@@ -45,7 +45,7 @@ INLINE = $(SRCDIR)disp68K.il
 BITBLTFILE = $(OBJECTDIR)bitblt68K.o
 
 OBJECTDIR = ../sunos4.mc68020-x/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether
 

--- a/bin/makefile-sunos4.i386
+++ b/bin/makefile-sunos4.i386
@@ -10,7 +10,7 @@ LDFLAGS = -lsuntool -lsunwindow -lpixrect -lc -lm
 INLINE = $(SRCDIR)disp386i.il
 
 OBJECTDIR = ../sunos4.i386/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o 
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 COLORFILES = $(OBJECTDIR)colorbltfns.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether

--- a/bin/makefile-sunos4.i386-multi
+++ b/bin/makefile-sunos4.i386-multi
@@ -14,7 +14,7 @@ CC=gcc
 AS=/users/sybalsky/gcc/gas/gas-1.35/a386
 
 OBJECTDIR = ../sunos4.i386-multi/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o 
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 COLORFILES = $(OBJECTDIR)colorbltfns.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether

--- a/bin/makefile-sunos4.mc68020-x
+++ b/bin/makefile-sunos4.mc68020-x
@@ -46,7 +46,7 @@ INLINE = $(SRCDIR)disp68K.il
 BITBLTFILE = $(OBJECTDIR)bitblt68K.o
 
 OBJECTDIR = ../sunos4.mc68020-x/
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 default	: $(OBJECTDIR)lde $(OBJECTDIR)ldeether
 

--- a/bin/makefile-sunos4.sparc-x-3
+++ b/bin/makefile-sunos4.sparc-x-3
@@ -39,7 +39,7 @@ LDFLAGS = -lX11 -lpixrect -lc -lm
 # -Dsparc?
 INLINE = $(SRCDIR)dispSPARC.il
 BITBLTFILE = $(OBJECTDIR)bitbltSPARC.o
-BYTESWAPFILES = $(OBJECTDIR)byteswapfns.o
+BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 OBJECTDIR = ../$(RELEASENAME)/
 


### PR DESCRIPTION
This was renamed long ago for the DOS port, but not all of
the makefiles were updated.