### PR TITLE
Cleanup mkvdate.c includes.

### DIFF
--- a/src/mkvdate.c
+++ b/src/mkvdate.c
@@ -28,14 +28,10 @@ static char *id = "$Id: mkvdate.c,v 1.5 2001/12/26 22:17:03 sybalsky Exp $ Copyr
 /*									*/
 /************************************************************************/
 
-#if defined(LINUX)
-#include "time.h"
-#endif
-
 #include <stdio.h>
-#ifdef DOS
 #include <time.h>
-#else
+
+#ifndef DOS
 #include <sys/time.h>
 #endif /* DOS */
 


### PR DESCRIPTION
All platforms need `<time.h>` for `time` / `ctime`.
All non-DOS platforms need `<sys/time.h>` for `gettimeofday()`.