### PR TITLE
Remove commented out directives for SunOS4 dispatch loop hacks.

### DIFF
--- a/bin/makefile-freebsd.386-x
+++ b/bin/makefile-freebsd.386-x
@@ -37,56 +37,6 @@ OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
 
-# Special rules to create xc.c on Sun4
-
-#run cpp to expand macros
-#$(OBJECTDIR)xc.i:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-#	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-#	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-#	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-#	 $(INCDIR)arith.h $(INCDIR)stream.h \
-#	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-#	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-#	 $(INCDIR)inln68k.h
-#	cc -Qproduce .i $(DFLAGS) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.i
-
-#run c compiler to produce first pass assembly
-$(OBJECTDIR)xc.s1:	$(OBJECTDIR)xc.i
-	rm -f $(OBJECTDIR)xc.s1
-	/lib/ccom - $(FPFLAGS) <$(OBJECTDIR)xc.i >$(OBJECTDIR)xc.s1
-
-#generate C program to remove dispatch loop, optimize
-$(OBJECTDIR)dsphack.c: $(SRCDIR)dsphack.lex
-	rm -f $(OBJECTDIR)dsphack.c
-	lex -t $(SRCDIR)dsphack.lex > $(OBJECTDIR)dsphack.c
-
-#uses this program to find dispatch
-$(OBJECTDIR)find-dsp.c: $(SRCDIR)find-dsp.lex
-	rm -f $(OBJECTDIR)find-dsp.c
-	lex -t $(SRCDIR)find-dsp.lex > $(OBJECTDIR)find-dsp.c
-
-$(OBJECTDIR)find-dsp: $(OBJECTDIR)find-dsp.c
-	cc -o $(OBJECTDIR)find-dsp $(OBJECTDIR)find-dsp.c -ll
-
-$(OBJECTDIR)dispatch-label.c: $(OBJECTDIR)find-dsp $(OBJECTDIR)xc.s1
-	rm -f $(OBJECTDIR)dispatch-label.c
-	$(OBJECTDIR)find-dsp < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)dispatch-label.c
-
-$(OBJECTDIR)dsphack: $(OBJECTDIR)dsphack.c $(OBJECTDIR)dispatch-label.c
-	cc -o $(OBJECTDIR)dsphack $(OBJECTDIR)dispatch-label.c $(OBJECTDIR)dsphack.c -ll
-	rm -f $(OBJECTDIR)dispatch-label.o $(OBJECTDIR)dsphack.o
-
-$(OBJECTDIR)xc.s2:	$(OBJECTDIR)xc.s1 $(OBJECTDIR)dsphack
-	rm -f $(OBJECTDIR)xc.s2
-	$(OBJECTDIR)dsphack < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)xc.s2
-
-$(OBJECTDIR)xc.s3:	$(OBJECTDIR)xc.s2 $(INLINE)
-	rm -f $(OBJECTDIR)xc.s3
-	/usr/lib/inline -i $(INLINE) < $(OBJECTDIR)xc.s2 > $(OBJECTDIR)xc.s3
-
-#$(OBJECTDIR)xc.o: $(OBJECTDIR)xc.s3
-#	/bin/as -o $(OBJECTDIR)xc.o -O1 $(OBJECTDIR)xc.s3
-
 ############
 #
 #	SPECIAL xc.o  for debugging

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -37,56 +37,6 @@ OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
 
-# Special rules to create xc.c on Sun4
-
-#run cpp to expand macros
-#$(OBJECTDIR)xc.i:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-#	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-#	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-#	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-#	 $(INCDIR)arith.h $(INCDIR)stream.h \
-#	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-#	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-#	 $(INCDIR)inln68k.h
-#	cc -Qproduce .i $(DFLAGS) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.i
-
-#run c compiler to produce first pass assembly
-$(OBJECTDIR)xc.s1:	$(OBJECTDIR)xc.i
-	rm -f $(OBJECTDIR)xc.s1
-	/lib/ccom - $(FPFLAGS) <$(OBJECTDIR)xc.i >$(OBJECTDIR)xc.s1
-
-#generate C program to remove dispatch loop, optimize
-$(OBJECTDIR)dsphack.c: $(SRCDIR)dsphack.lex
-	rm -f $(OBJECTDIR)dsphack.c
-	lex -t $(SRCDIR)dsphack.lex > $(OBJECTDIR)dsphack.c
-
-#uses this program to find dispatch
-$(OBJECTDIR)find-dsp.c: $(SRCDIR)find-dsp.lex
-	rm -f $(OBJECTDIR)find-dsp.c
-	lex -t $(SRCDIR)find-dsp.lex > $(OBJECTDIR)find-dsp.c
-
-$(OBJECTDIR)find-dsp: $(OBJECTDIR)find-dsp.c
-	cc -o $(OBJECTDIR)find-dsp $(OBJECTDIR)find-dsp.c -ll
-
-$(OBJECTDIR)dispatch-label.c: $(OBJECTDIR)find-dsp $(OBJECTDIR)xc.s1
-	rm -f $(OBJECTDIR)dispatch-label.c
-	$(OBJECTDIR)find-dsp < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)dispatch-label.c
-
-$(OBJECTDIR)dsphack: $(OBJECTDIR)dsphack.c $(OBJECTDIR)dispatch-label.c
-	cc -o $(OBJECTDIR)dsphack $(OBJECTDIR)dispatch-label.c $(OBJECTDIR)dsphack.c -ll
-	rm -f $(OBJECTDIR)dispatch-label.o $(OBJECTDIR)dsphack.o
-
-$(OBJECTDIR)xc.s2:	$(OBJECTDIR)xc.s1 $(OBJECTDIR)dsphack
-	rm -f $(OBJECTDIR)xc.s2
-	$(OBJECTDIR)dsphack < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)xc.s2
-
-$(OBJECTDIR)xc.s3:	$(OBJECTDIR)xc.s2 $(INLINE)
-	rm -f $(OBJECTDIR)xc.s3
-	/usr/lib/inline -i $(INLINE) < $(OBJECTDIR)xc.s2 > $(OBJECTDIR)xc.s3
-
-#$(OBJECTDIR)xc.o: $(OBJECTDIR)xc.s3
-#	/bin/as -o $(OBJECTDIR)xc.o -O1 $(OBJECTDIR)xc.s3
-
 ############
 #
 #	SPECIAL xc.o  for debugging

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -37,56 +37,6 @@ OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
 
-# Special rules to create xc.c on Sun4
-
-#run cpp to expand macros
-#$(OBJECTDIR)xc.i:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-#	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-#	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-#	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-#	 $(INCDIR)arith.h $(INCDIR)stream.h \
-#	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-#	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-#	 $(INCDIR)inln68k.h
-#	cc -Qproduce .i $(DFLAGS) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.i
-
-#run c compiler to produce first pass assembly
-$(OBJECTDIR)xc.s1:	$(OBJECTDIR)xc.i
-	rm -f $(OBJECTDIR)xc.s1
-	/lib/ccom - $(FPFLAGS) <$(OBJECTDIR)xc.i >$(OBJECTDIR)xc.s1
-
-#generate C program to remove dispatch loop, optimize
-$(OBJECTDIR)dsphack.c: $(SRCDIR)dsphack.lex
-	rm -f $(OBJECTDIR)dsphack.c
-	lex -t $(SRCDIR)dsphack.lex > $(OBJECTDIR)dsphack.c
-
-#uses this program to find dispatch
-$(OBJECTDIR)find-dsp.c: $(SRCDIR)find-dsp.lex
-	rm -f $(OBJECTDIR)find-dsp.c
-	lex -t $(SRCDIR)find-dsp.lex > $(OBJECTDIR)find-dsp.c
-
-$(OBJECTDIR)find-dsp: $(OBJECTDIR)find-dsp.c
-	cc -o $(OBJECTDIR)find-dsp $(OBJECTDIR)find-dsp.c -ll
-
-$(OBJECTDIR)dispatch-label.c: $(OBJECTDIR)find-dsp $(OBJECTDIR)xc.s1
-	rm -f $(OBJECTDIR)dispatch-label.c
-	$(OBJECTDIR)find-dsp < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)dispatch-label.c
-
-$(OBJECTDIR)dsphack: $(OBJECTDIR)dsphack.c $(OBJECTDIR)dispatch-label.c
-	cc -o $(OBJECTDIR)dsphack $(OBJECTDIR)dispatch-label.c $(OBJECTDIR)dsphack.c -ll
-	rm -f $(OBJECTDIR)dispatch-label.o $(OBJECTDIR)dsphack.o
-
-$(OBJECTDIR)xc.s2:	$(OBJECTDIR)xc.s1 $(OBJECTDIR)dsphack
-	rm -f $(OBJECTDIR)xc.s2
-	$(OBJECTDIR)dsphack < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)xc.s2
-
-$(OBJECTDIR)xc.s3:	$(OBJECTDIR)xc.s2 $(INLINE)
-	rm -f $(OBJECTDIR)xc.s3
-	/usr/lib/inline -i $(INLINE) < $(OBJECTDIR)xc.s2 > $(OBJECTDIR)xc.s3
-
-#$(OBJECTDIR)xc.o: $(OBJECTDIR)xc.s3
-#	/bin/as -o $(OBJECTDIR)xc.o -O1 $(OBJECTDIR)xc.s3
-
 ############
 #
 #	SPECIAL xc.o  for debugging

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -39,56 +39,6 @@ OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
 
-# Special rules to create xc.c on Sun4
-
-#run cpp to expand macros
-#$(OBJECTDIR)xc.i:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-#	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-#	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-#	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-#	 $(INCDIR)arith.h $(INCDIR)stream.h \
-#	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-#	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-#	 $(INCDIR)inln68k.h
-#	cc -Qproduce .i $(DFLAGS) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.i
-
-#run c compiler to produce first pass assembly
-$(OBJECTDIR)xc.s1:	$(OBJECTDIR)xc.i
-	rm -f $(OBJECTDIR)xc.s1
-	/lib/ccom - $(FPFLAGS) <$(OBJECTDIR)xc.i >$(OBJECTDIR)xc.s1
-
-#generate C program to remove dispatch loop, optimize
-$(OBJECTDIR)dsphack.c: $(SRCDIR)dsphack.lex
-	rm -f $(OBJECTDIR)dsphack.c
-	lex -t $(SRCDIR)dsphack.lex > $(OBJECTDIR)dsphack.c
-
-#uses this program to find dispatch
-$(OBJECTDIR)find-dsp.c: $(SRCDIR)find-dsp.lex
-	rm -f $(OBJECTDIR)find-dsp.c
-	lex -t $(SRCDIR)find-dsp.lex > $(OBJECTDIR)find-dsp.c
-
-$(OBJECTDIR)find-dsp: $(OBJECTDIR)find-dsp.c
-	cc -o $(OBJECTDIR)find-dsp $(OBJECTDIR)find-dsp.c -ll
-
-$(OBJECTDIR)dispatch-label.c: $(OBJECTDIR)find-dsp $(OBJECTDIR)xc.s1
-	rm -f $(OBJECTDIR)dispatch-label.c
-	$(OBJECTDIR)find-dsp < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)dispatch-label.c
-
-$(OBJECTDIR)dsphack: $(OBJECTDIR)dsphack.c $(OBJECTDIR)dispatch-label.c
-	cc -o $(OBJECTDIR)dsphack $(OBJECTDIR)dispatch-label.c $(OBJECTDIR)dsphack.c -ll
-	rm -f $(OBJECTDIR)dispatch-label.o $(OBJECTDIR)dsphack.o
-
-$(OBJECTDIR)xc.s2:	$(OBJECTDIR)xc.s1 $(OBJECTDIR)dsphack
-	rm -f $(OBJECTDIR)xc.s2
-	$(OBJECTDIR)dsphack < $(OBJECTDIR)xc.s1 >$(OBJECTDIR)xc.s2
-
-$(OBJECTDIR)xc.s3:	$(OBJECTDIR)xc.s2 $(INLINE)
-	rm -f $(OBJECTDIR)xc.s3
-	/usr/lib/inline -i $(INLINE) < $(OBJECTDIR)xc.s2 > $(OBJECTDIR)xc.s3
-
-#$(OBJECTDIR)xc.o: $(OBJECTDIR)xc.s3
-#	/bin/as -o $(OBJECTDIR)xc.o -O1 $(OBJECTDIR)xc.s3
-
 ############
 #
 #	SPECIAL xc.o  for debugging


### PR DESCRIPTION
On SunOS4, we build `xc.c` by jumping through a lot of hoops to
perform a particular set of operations. We don't do that on other
platforms and this will help clean up the Linux and FreeBSD makefiles.

These directives were already not present in the macOS makefiles.