### PR TITLE
Remove USE_UTIME.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -201,7 +201,6 @@ error Must specify RELEASE to build Medley.
 #define UNALIGNED_FETCH_OK
 #define REGISTER register
 #define HAS_GETHOSTID
-#undef USE_UTIME
 #define UNSIGNED unsigned long
 #define INT long
 

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -818,11 +818,7 @@ LispPTR COM_closefile(register LispPTR *args)
     return (NIL);
   }
 
-#ifdef USE_UTIME
-  TIMEOUT(rval = utime(file, time));
-#else
   TIMEOUT(rval = utimes(file, time));
-#endif
   if (rval != 0) {
     *Lisp_errno = errno;
     return (NIL);
@@ -1879,11 +1875,7 @@ LispPTR COM_setfileinfo(register LispPTR *args)
       time[0].tv_usec = 0L;
       time[1].tv_sec = (long)ToUnixTime(date);
       time[1].tv_usec = 0L;
-#ifdef USE_UTIME
-      TIMEOUT(rval = utime(file, time));
-#else
       TIMEOUT(rval = utimes(file, time));
-#endif /* USE_UTIME */
 #endif /* DOS */
       if (rval != 0) {
         *Lisp_errno = errno;


### PR DESCRIPTION
This wasn't enabled and the corresponding code wouldn't have
compiled. The `utime()` function is also deprecated in POSIX.

This used to be enabled for HPUX and RISCOS.