### PR TITLE
timer.c: Remove _BSD_SOURCE.

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -62,7 +62,6 @@ extern int ether_fd;
 
 #ifdef LINUX
 #include <sys/ioctl.h>
-#define _BSD_SOURCE
 #include <signal.h>
 #include <sys/times.h>
 #endif


### PR DESCRIPTION
This isn't needed to build, so let's not have it.