### PR TITLE
asmbbt: Fix signature for bitblt.

### DIFF
--- a/src/asmbbt.c
+++ b/src/asmbbt.c
@@ -39,7 +39,7 @@ static char *id = "$Id: asmbbt.c,v 1.3 1999/05/31 23:35:23 sybalsky Exp $ Copyri
 #include "bitblt.h"
 #include "pilotbbt.h"
 
-void bitblt(DLword *srcbase, DLword dstbase, int sx, int dx, int w, int h, int srcbpl, int dstbpl,
+void bitblt(DLword *srcbase, DLword *dstbase, int sx, int dx, int w, int h, int srcbpl, int dstbpl,
             int backwardflg, int src_comp, int op, int gray, int num_gray, int curr_gray_line) {
   new_bitblt_code;
 }


### PR DESCRIPTION
This was an error in the conversion from K&R C prototypes.