### PR TITLE
Missing return type for make_kbd_instance().

### DIFF
--- a/src/kbdif.c
+++ b/src/kbdif.c
@@ -27,7 +27,7 @@ extern void ExitDosKbd();
 extern unsigned long GenericReturnT();
 #endif /* DOS */
 
-make_kbd_instance(KbdInterface kbd) {
+void make_kbd_instance(KbdInterface kbd) {
 #ifdef DOS
   kbd->device_event = &Kbd_event; /*  */
   kbd->device.enter = &EnterDosKbd;


### PR DESCRIPTION
We don't fill in other missing types here as the code relies
upon missing types for the arguments to the various callbacks.