### PR TITLE
Remove extra arg to open when loading sysout.

### DIFF
--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -105,7 +105,7 @@ int sysout_loader(char * sysout_file_name, int sys_size)
    */
 
   /* open SysoutFile */
-  sysout = open(sysout_file_name, O_RDONLY, NULL);
+  sysout = open(sysout_file_name, O_RDONLY);
   if (sysout == -1) {
     sprintf(errmsg, "sysout_loader: can't open sysout file: %s", sysout_file_name);
     perror(errmsg);


### PR DESCRIPTION
The `open()` call can take a third argument (for when the mode
is `O_CREAT`). However, it is not needed here as we aren't
using `O_CREAT`. (And if we needed an extra arg, it wouldn't
have been `NULL`.)