### PR TITLE
The error() function may return under exceptional circumstances

### DIFF
--- a/src/car-cdr.c
+++ b/src/car-cdr.c
@@ -79,6 +79,7 @@ LispPTR car(register LispPTR datum)
       return (NIL);
     else
       error("car : ARG not list");
+    return (NIL); /* NOT REACHED */
   }
 } /* end of car */
 
@@ -151,6 +152,7 @@ LispPTR rplaca(register LispPTR x, register LispPTR y)
         return (NIL_PTR);
     } else
       error("ARG not List");
+      return (NIL_PTR); /* NOT REACHED */
   }
 
   else {

--- a/src/gchtfind.c
+++ b/src/gchtfind.c
@@ -95,6 +95,7 @@ static char *id = "$Id: gchtfind.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ Copy
         IncAllocCnt(1);                                               \
         return ptr; /* new 0 entry */                                 \
       default: error("GC error: new entry touches stack bit");        \
+        return NIL; /* NOT REACHED */                                 \
     }                                                                 \
   }
 
@@ -115,6 +116,7 @@ static char *id = "$Id: gchtfind.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ Copy
         GETGC(entry) = hiptr | (1 << HTCNTSHIFT) | HTSTKMASK;           \
         return NIL;                                                     \
       default: error("GC error: new entry when turning off stack bit"); \
+        return NIL; /* NOT REACHED */                                   \
     }                                                                   \
   }
 

--- a/src/hardrtn.c
+++ b/src/hardrtn.c
@@ -251,7 +251,8 @@ retry: /* this is retry entry after MAKE_FXCOPY etc */
     else
       error("Shouldn't");
   }
-
+  error("Control reached end of slowreturn()!");
+  return (NIL); /* NOT REACHED */
 } /* slowreturn end */
 
 #define MAXSAFEUSECOUNT 200


### PR DESCRIPTION

There is no practical difference between the old and new code, but we avoid
compiler warnings for reaching the end of a non-void function.
Attempting to return to Lisp after entering uRaid from one of these
error() calls will result in undefined behavior in Lisp.