### PR TITLE
Remove sccs id lines

### DIFF
--- a/src/Cldeetr.c
+++ b/src/Cldeetr.c
@@ -1,6 +1,5 @@
 /* $Id: Cldeetr.c,v 1.3 1999/01/03 02:06:30 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: Cldeetr.c,v 1.3 1999/01/03 02:06:30 sybalsky Exp $ Copyright (C) Venue";
 
 /*
  *

--- a/src/allocmds.c
+++ b/src/allocmds.c
@@ -1,6 +1,5 @@
 /* $Id: allocmds.c,v 1.4 1999/05/31 23:35:20 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: allocmds.c,v 1.4 1999/05/31 23:35:20 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/arith2.c
+++ b/src/arith2.c
@@ -1,6 +1,5 @@
 /* $Id: arith2.c,v 1.4 2001/12/24 01:08:58 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: arith2.c,v 1.4 2001/12/24 01:08:58 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/arith3.c
+++ b/src/arith3.c
@@ -1,6 +1,5 @@
 /* $Id: arith3.c,v 1.3 1999/05/31 23:35:21 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: arith3.c,v 1.3 1999/05/31 23:35:21 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/arith4.c
+++ b/src/arith4.c
@@ -1,6 +1,5 @@
 /* $Id: arith4.c,v 1.3 1999/05/31 23:35:21 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: arith4.c,v 1.3 1999/05/31 23:35:21 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/array.c
+++ b/src/array.c
@@ -1,5 +1,4 @@
 /* @(#) array.c Version 2.8 (12/23/88). copyright envos & Fuji Xerox  */
-static char *id = "@(#) array.c	2.8 12/23/88		(envos & Fuji Xerox)";
 
 /************************************************************************/
 /*									*/

--- a/src/array2.c
+++ b/src/array2.c
@@ -1,5 +1,4 @@
 /* This is G-file @(#) array2.c Version 2.9 (10/12/88). copyright Xerox & Fuji Xerox  */
-static char *id = "@(#) array2.c	2.9 10/12/88";
 
 /************************************************************************/
 /*									*/

--- a/src/array3.c
+++ b/src/array3.c
@@ -1,5 +1,4 @@
 /* This is G-file @(#) array3.c Version 2.9 (10/12/88). copyright Xerox & Fuji Xerox  */
-static char *id = "@(#) array3.c	2.9 10/12/88";
 
 /************************************************************************/
 /*									*/

--- a/src/array4.c
+++ b/src/array4.c
@@ -1,5 +1,4 @@
 /* This is G-file @(#) array4.c Version 2.7 (10/12/88). copyright Xerox & Fuji Xerox  */
-static char *id = "@(#) array4.c	2.7 10/12/88";
 
 /************************************************************************/
 /*									*/

--- a/src/array5.c
+++ b/src/array5.c
@@ -1,5 +1,4 @@
 /* This is G-file @(#) array5.c Version 2.7 (10/12/88). copyright Xerox & Fuji Xerox  */
-static char *id = "@(#) array5.c	2.7 10/12/88";
 
 /************************************************************************/
 /*									*/

--- a/src/array6.c
+++ b/src/array6.c
@@ -1,5 +1,4 @@
 /* This is G-file @(#) array6.c Version 2.10 (4/21/92). copyright Xerox & Fuji Xerox  */
-static char *id = "@(#) array6.c	2.10 4/21/92";
 
 /************************************************************************/
 /*									*/

--- a/src/asmbbt.c
+++ b/src/asmbbt.c
@@ -1,6 +1,5 @@
 /* $Id: asmbbt.c,v 1.3 1999/05/31 23:35:23 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: asmbbt.c,v 1.3 1999/05/31 23:35:23 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/atom.c
+++ b/src/atom.c
@@ -1,5 +1,4 @@
 /* $Id: atom.c,v 1.3 1999/05/31 23:35:23 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: atom.c,v 1.3 1999/05/31 23:35:23 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -1,6 +1,5 @@
 /* $Id: bbtsub.c,v 1.3 2001/12/24 01:08:59 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: bbtsub.c,v 1.3 2001/12/24 01:08:59 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*                                                                      */

--- a/src/bin.c
+++ b/src/bin.c
@@ -1,5 +1,4 @@
 /* $Id: bin.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: bin.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/binds.c
+++ b/src/binds.c
@@ -1,5 +1,4 @@
 /* $Id: binds.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: binds.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -1,6 +1,5 @@
 /* $Id: bitblt.c,v 1.2 1999/01/03 02:06:47 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: bitblt.c,v 1.2 1999/01/03 02:06:47 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/blt.c
+++ b/src/blt.c
@@ -1,5 +1,4 @@
 /* $Id: blt.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: blt.c,v 1.3 1999/05/31 23:35:24 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/byteswap.c
+++ b/src/byteswap.c
@@ -1,6 +1,5 @@
 /* $Id: byteswap.c,v 1.5 2002/01/02 08:15:16 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: byteswap.c,v 1.5 2002/01/02 08:15:16 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/car-cdr.c
+++ b/src/car-cdr.c
@@ -1,6 +1,5 @@
 /* $Id: car-cdr.c,v 1.3 1999/05/31 23:35:25 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: car-cdr.c,v 1.3 1999/05/31 23:35:25 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/cdaudio.c
+++ b/src/cdaudio.c
@@ -1,6 +1,5 @@
 /* $Id: cdaudio.c,v 1.3 1999/05/31 23:35:25 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: cdaudio.c,v 1.3 1999/05/31 23:35:25 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -1,5 +1,4 @@
 /* $Id: cdrom.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: cdrom.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/chardev.c
+++ b/src/chardev.c
@@ -1,6 +1,5 @@
 /* $Id: chardev.c,v 1.2 1999/01/03 02:06:50 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: chardev.c,v 1.2 1999/01/03 02:06:50 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/chatter.c
+++ b/src/chatter.c
@@ -1,6 +1,5 @@
 /* $Id: chatter.c,v 1.2 1999/01/03 02:06:51 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: chatter.c,v 1.2 1999/01/03 02:06:51 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/codeconv.c
+++ b/src/codeconv.c
@@ -1,6 +1,5 @@
 /* $Id: codeconv.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: codeconv.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/codetbl.c
+++ b/src/codetbl.c
@@ -1,6 +1,5 @@
 /* $Id: codetbl.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: codetbl.c,v 1.3 1999/05/31 23:35:26 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/common.c
+++ b/src/common.c
@@ -1,6 +1,5 @@
 /* $Id: common.c,v 1.2 1999/01/03 02:06:52 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: common.c,v 1.2 1999/01/03 02:06:52 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/conspage.c
+++ b/src/conspage.c
@@ -1,6 +1,5 @@
 /* $Id: conspage.c,v 1.3 1999/05/31 23:35:27 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: conspage.c,v 1.3 1999/05/31 23:35:27 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/dbgtool.c
+++ b/src/dbgtool.c
@@ -1,6 +1,5 @@
 /* $Id: dbgtool.c,v 1.4 2001/12/24 01:09:00 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: dbgtool.c,v 1.4 2001/12/24 01:09:00 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/dir.c
+++ b/src/dir.c
@@ -1,5 +1,4 @@
 /* $Id: dir.c,v 1.4 2001/12/26 22:17:01 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: dir.c,v 1.4 2001/12/26 22:17:01 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/dlpi.c
+++ b/src/dlpi.c
@@ -1,5 +1,4 @@
 /* $Id: dlpi.c,v 1.3 2001/12/24 01:09:00 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: dlpi.c,v 1.3 2001/12/24 01:09:00 sybalsky Exp $ Copyright (C) Venue";
 #ifndef lint
 static char *RCSid =
     "$Header: /disk/disk3/cvsroot/medley/src/dlpi.c,v 1.3 2001/12/24 01:09:00 sybalsky Exp $";

--- a/src/doscomm.c
+++ b/src/doscomm.c
@@ -1,6 +1,5 @@
 /* $Id: doscomm.c,v 1.3 1999/05/31 23:35:27 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: doscomm.c,v 1.3 1999/05/31 23:35:27 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/doskbd.c
+++ b/src/doskbd.c
@@ -1,6 +1,5 @@
 /* $Id: doskbd.c,v 1.2 1999/01/03 02:06:55 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: doskbd.c,v 1.2 1999/01/03 02:06:55 sybalsky Exp $ Copyright (C) Venue";
 /************************************************************************/
 /*                                                                      */
 /*                D O S   K E Y B O A R D   H A N D L E R               */

--- a/src/dosmouse.c
+++ b/src/dosmouse.c
@@ -1,6 +1,5 @@
 /* $Id: dosmouse.c,v 1.2 1999/01/03 02:06:56 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: dosmouse.c,v 1.2 1999/01/03 02:06:56 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/draw.c
+++ b/src/draw.c
@@ -1,5 +1,4 @@
 /* $Id: draw.c,v 1.2 1999/01/03 02:06:56 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: draw.c,v 1.2 1999/01/03 02:06:56 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -1,5 +1,4 @@
 /* $Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: dsk.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/dspif.c
+++ b/src/dspif.c
@@ -1,5 +1,4 @@
 /* $Id: dspif.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: dspif.c,v 1.4 2001/12/24 01:09:01 sybalsky Exp $ Copyright (C) Venue";
 /* This is the display interface  */
 
 /************************************************************************/

--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -1,6 +1,5 @@
 /* $Id: dspsubrs.c,v 1.3 2001/12/26 22:17:02 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: dspsubrs.c,v 1.3 2001/12/26 22:17:02 sybalsky Exp $ Copyright (C) Venue";
 /*** ADOPTED NEW VERSION ***/
 
 /************************************************************************/

--- a/src/ejlisp.c
+++ b/src/ejlisp.c
@@ -1,6 +1,5 @@
 /* $Id: ejlisp.c,v 1.2 1999/01/03 02:06:58 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: ejlisp.c,v 1.2 1999/01/03 02:06:58 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -1,5 +1,4 @@
 /* $Id: eqf.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: eqf.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ether.c
+++ b/src/ether.c
@@ -1,5 +1,4 @@
 /* $Id: ether.c,v 1.4 2001/12/24 01:09:02 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: ether.c,v 1.4 2001/12/24 01:09:02 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/findkey.c
+++ b/src/findkey.c
@@ -1,6 +1,5 @@
 /* $Id: findkey.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: findkey.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -1,6 +1,5 @@
 /* $Id: foreign.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: foreign.c,v 1.3 1999/05/31 23:35:28 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/fp.c
+++ b/src/fp.c
@@ -1,5 +1,4 @@
 /* $Id: fp.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: fp.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/fvar.c
+++ b/src/fvar.c
@@ -1,5 +1,4 @@
 /* $Id: fvar.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: fvar.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gc.c
+++ b/src/gc.c
@@ -1,5 +1,4 @@
 /* $Id: gc.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: gc.c,v 1.3 1999/05/31 23:35:29 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gc2.c
+++ b/src/gc2.c
@@ -1,5 +1,4 @@
 /* $Id: gc2.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: gc2.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -1,6 +1,5 @@
 /* $Id: gcarray.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcarray.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gccode.c
+++ b/src/gccode.c
@@ -1,6 +1,5 @@
 /* $Id: gccode.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gccode.c,v 1.3 1999/05/31 23:35:30 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -1,6 +1,5 @@
 /* $Id: gcfinal.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcfinal.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gchtfind.c
+++ b/src/gchtfind.c
@@ -1,6 +1,5 @@
 /* $Id: gchtfind.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gchtfind.c,v 1.3 1999/05/31 23:35:31 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcmain3.c
+++ b/src/gcmain3.c
@@ -1,6 +1,5 @@
 /* $Id: gcmain3.c,v 1.4 1999/05/31 23:35:31 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcmain3.c,v 1.4 1999/05/31 23:35:31 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcoflow.c
+++ b/src/gcoflow.c
@@ -1,6 +1,5 @@
 /* $Id: gcoflow.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcoflow.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcr.c
+++ b/src/gcr.c
@@ -1,5 +1,4 @@
 /* $Id: gcr.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: gcr.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcrcell.c
+++ b/src/gcrcell.c
@@ -1,6 +1,5 @@
 /* $Id: gcrcell.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcrcell.c,v 1.3 1999/05/31 23:35:32 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gcscan.c
+++ b/src/gcscan.c
@@ -1,6 +1,5 @@
 /* $Id: gcscan.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: gcscan.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/gvar2.c
+++ b/src/gvar2.c
@@ -1,5 +1,4 @@
 /* $Id: gvar2.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: gvar2.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/hacks.c
+++ b/src/hacks.c
@@ -1,5 +1,4 @@
 /* $Id: hacks.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: hacks.c,v 1.3 1999/05/31 23:35:33 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/hardrtn.c
+++ b/src/hardrtn.c
@@ -1,6 +1,5 @@
 /* $Id: hardrtn.c,v 1.4 2001/12/24 01:09:02 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: hardrtn.c,v 1.4 2001/12/24 01:09:02 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/id
+++ b/src/id
@@ -1,1 +1,0 @@
-/* $Id$ (C) Copyright Venue, All Rights Reserved  */

--- a/src/id
+++ b/src/id
@@ -1,2 +1,1 @@
 /* $Id$ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id$ Copyright (C) Venue";

--- a/src/imagefile.c
+++ b/src/imagefile.c
@@ -1,6 +1,5 @@
 /* $Id: imagefile.c,v 1.2 1999/01/03 02:07:07 sybalsky Exp $ (C) Copyright Venue, All Rights
  * Reserved  */
-static char *id = "$Id: imagefile.c,v 1.2 1999/01/03 02:07:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/imagefile2.c
+++ b/src/imagefile2.c
@@ -1,6 +1,5 @@
 /* $Id: imagefile2.c,v 1.2 1999/01/03 02:07:07 sybalsky Exp $ (C) Copyright Venue, All Rights
  * Reserved  */
-static char *id = "$Id: imagefile2.c,v 1.2 1999/01/03 02:07:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/inet.c
+++ b/src/inet.c
@@ -1,5 +1,4 @@
 /* $Id: inet.c,v 1.3 2001/12/24 01:09:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: inet.c,v 1.3 2001/12/24 01:09:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -1,6 +1,5 @@
 /* $Id: initdsp.c,v 1.2 1999/01/03 02:07:08 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: initdsp.c,v 1.2 1999/01/03 02:07:08 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -1,6 +1,5 @@
 /* $Id: initkbd.c,v 1.2 1999/01/03 02:07:09 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: initkbd.c,v 1.2 1999/01/03 02:07:09 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -1,6 +1,5 @@
 /* $Id: initsout.c,v 1.3 1999/05/31 23:35:34 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: initsout.c,v 1.3 1999/05/31 23:35:34 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/intcall.c
+++ b/src/intcall.c
@@ -1,6 +1,5 @@
 /* $Id: intcall.c,v 1.3 1999/05/31 23:35:34 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: intcall.c,v 1.3 1999/05/31 23:35:34 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/kbdif.c
+++ b/src/kbdif.c
@@ -1,5 +1,4 @@
 /* $Id: kbdif.c,v 1.3 1999/05/31 23:35:35 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: kbdif.c,v 1.3 1999/05/31 23:35:35 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/kbdsubrs.c
+++ b/src/kbdsubrs.c
@@ -1,6 +1,5 @@
 /* $Id: kbdsubrs.c,v 1.2 1999/01/03 02:07:10 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: kbdsubrs.c,v 1.2 1999/01/03 02:07:10 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -1,6 +1,5 @@
 /* $Id: keyevent.c,v 1.3 2001/12/24 01:09:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: keyevent.c,v 1.3 2001/12/24 01:09:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/keylib.c
+++ b/src/keylib.c
@@ -1,6 +1,5 @@
 /* $Id: keylib.c,v 1.4 2001/12/24 01:09:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: keylib.c,v 1.4 2001/12/24 01:09:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/keytst.c
+++ b/src/keytst.c
@@ -1,6 +1,5 @@
 /* $Id: keytst.c,v 1.3 1999/05/31 23:35:36 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: keytst.c,v 1.3 1999/05/31 23:35:36 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/keytstno.c
+++ b/src/keytstno.c
@@ -1,6 +1,5 @@
 /* $Id: keytstno.c,v 1.3 1999/05/31 23:35:36 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: keytstno.c,v 1.3 1999/05/31 23:35:36 sybalsky Exp $ Copyright (C) Venue";
 
 /* Loaded instead of keytst.c, with unlocked definition of keytester */
 

--- a/src/kprint.c
+++ b/src/kprint.c
@@ -1,6 +1,5 @@
 /* $Id: kprint.c,v 1.2 1999/05/31 23:35:36 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: kprint.c,v 1.2 1999/05/31 23:35:36 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -1,6 +1,5 @@
 /* $Id: ldeboot.c,v 1.3 1999/01/03 02:07:13 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: ldeboot.c,v 1.3 1999/01/03 02:07:13 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -1,6 +1,5 @@
 /* $Id: ldeether.c,v 1.3 2001/12/24 01:09:04 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: ldeether.c,v 1.3 2001/12/24 01:09:04 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -1,6 +1,5 @@
 /* $Id: ldsout.c,v 1.4 2001/12/26 22:17:02 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: ldsout.c,v 1.4 2001/12/26 22:17:02 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lineblt8.c
+++ b/src/lineblt8.c
@@ -1,6 +1,5 @@
 /* $Id: lineblt8.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lineblt8.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lisp2c.c
+++ b/src/lisp2c.c
@@ -1,6 +1,5 @@
 /* $Id: lisp2c.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lisp2c.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ Copyright (C) Venue";
 /* File containing the conversion functions between lisp and C */
 /* -jarl */
 

--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -1,6 +1,5 @@
 /* $Id: llcolor.c,v 1.2 1999/01/03 02:07:15 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: llcolor.c,v 1.2 1999/01/03 02:07:15 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -1,5 +1,4 @@
 /* $Id: llstk.c,v 1.5 2001/12/26 22:17:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: llstk.c,v 1.5 2001/12/26 22:17:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/loader.c
+++ b/src/loader.c
@@ -1,6 +1,5 @@
 /* $Id: loader.c,v 1.2 1999/01/03 02:07:16 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: loader.c,v 1.2 1999/01/03 02:07:16 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -1,6 +1,5 @@
 /* $Id: loopsops.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: loopsops.c,v 1.3 1999/05/31 23:35:37 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lowlev1.c
+++ b/src/lowlev1.c
@@ -1,6 +1,5 @@
 /* $Id: lowlev1.c,v 1.3 1999/05/31 23:35:38 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lowlev1.c,v 1.3 1999/05/31 23:35:38 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lowlev2.c
+++ b/src/lowlev2.c
@@ -1,6 +1,5 @@
 /* $Id: lowlev2.c,v 1.3 1999/05/31 23:35:38 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lowlev2.c,v 1.3 1999/05/31 23:35:38 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lpdual.c
+++ b/src/lpdual.c
@@ -1,6 +1,5 @@
 /* $Id: lpdual.c,v 1.2 1999/01/03 02:07:17 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpdual.c,v 1.2 1999/01/03 02:07:17 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lpkit.c
+++ b/src/lpkit.c
@@ -1,5 +1,4 @@
 /* $Id: lpkit.c,v 1.2 1999/01/03 02:07:18 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: lpkit.c,v 1.2 1999/01/03 02:07:18 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lplexyy.c
+++ b/src/lplexyy.c
@@ -1,6 +1,5 @@
 /* $Id: lplexyy.c,v 1.2 1999/01/03 02:07:18 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lplexyy.c,v 1.2 1999/01/03 02:07:18 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lpmain.c
+++ b/src/lpmain.c
@@ -1,6 +1,5 @@
 /* $Id: lpmain.c,v 1.2 1999/01/03 02:07:19 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpmain.c,v 1.2 1999/01/03 02:07:19 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*                                                                      */

--- a/src/lpread.c
+++ b/src/lpread.c
@@ -1,6 +1,5 @@
 /* $Id: lpread.c,v 1.2 1999/01/03 02:07:19 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpread.c,v 1.2 1999/01/03 02:07:19 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*                                                                      */

--- a/src/lpsolve.c
+++ b/src/lpsolve.c
@@ -1,6 +1,5 @@
 /* $Id: lpsolve.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpsolve.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lptran.c
+++ b/src/lptran.c
@@ -1,6 +1,5 @@
 /* $Id: lptran.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lptran.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lpwrite.c
+++ b/src/lpwrite.c
@@ -1,6 +1,5 @@
 /* $Id: lpwrite.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpwrite.c,v 1.2 1999/01/03 02:07:20 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lpytab.c
+++ b/src/lpytab.c
@@ -1,6 +1,5 @@
 /* $Id: lpytab.c,v 1.2 1999/01/03 02:07:21 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lpytab.c,v 1.2 1999/01/03 02:07:21 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/lsthandl.c
+++ b/src/lsthandl.c
@@ -1,6 +1,5 @@
 /* $Id: lsthandl.c,v 1.4 1999/05/31 23:35:38 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: lsthandl.c,v 1.4 1999/05/31 23:35:38 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/main.c
+++ b/src/main.c
@@ -1,5 +1,4 @@
 /* $Id: main.c,v 1.4 2001/12/26 22:17:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: main.c,v 1.4 2001/12/26 22:17:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/misc7.c
+++ b/src/misc7.c
@@ -1,5 +1,4 @@
 /* $Id: misc7.c,v 1.2 1999/01/03 02:07:22 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: misc7.c,v 1.2 1999/01/03 02:07:22 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/miscn.c
+++ b/src/miscn.c
@@ -1,5 +1,4 @@
 /* $Id: miscn.c,v 1.3 1999/05/31 23:35:39 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: miscn.c,v 1.3 1999/05/31 23:35:39 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -1,6 +1,5 @@
 /* $Id: mkatom.c,v 1.4 2001/12/24 01:09:05 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mkatom.c,v 1.4 2001/12/24 01:09:05 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mkcell.c
+++ b/src/mkcell.c
@@ -1,6 +1,5 @@
 /* $Id: mkcell.c,v 1.3 1999/05/31 23:35:39 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mkcell.c,v 1.3 1999/05/31 23:35:39 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mkkey.c
+++ b/src/mkkey.c
@@ -1,5 +1,4 @@
 /* $Id: mkkey.c,v 1.2 1999/01/03 02:07:24 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: mkkey.c,v 1.2 1999/01/03 02:07:24 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mkvdate.c
+++ b/src/mkvdate.c
@@ -1,6 +1,5 @@
 /* $Id: mkvdate.c,v 1.5 2001/12/26 22:17:03 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mkvdate.c,v 1.5 2001/12/26 22:17:03 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mnwevent.c
+++ b/src/mnwevent.c
@@ -1,6 +1,5 @@
 /* $Id: mnwevent.c,v 1.2 1999/01/03 02:07:25 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mnwevent.c,v 1.2 1999/01/03 02:07:25 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mnxmeth.c
+++ b/src/mnxmeth.c
@@ -1,6 +1,5 @@
 /* $Id: mnxmeth.c,v 1.2 1999/01/03 02:07:25 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mnxmeth.c,v 1.2 1999/01/03 02:07:25 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mouseif.c
+++ b/src/mouseif.c
@@ -1,6 +1,5 @@
 /* $Id: mouseif.c,v 1.2 1999/01/03 02:07:26 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: mouseif.c,v 1.2 1999/01/03 02:07:26 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/mvs.c
+++ b/src/mvs.c
@@ -1,5 +1,4 @@
 /* $Id: mvs.c,v 1.3 1999/05/31 23:35:40 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: mvs.c,v 1.3 1999/05/31 23:35:40 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ocr.c
+++ b/src/ocr.c
@@ -1,5 +1,4 @@
 /* $Id: ocr.c,v 1.2 1999/01/03 02:07:27 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ocr.c,v 1.2 1999/01/03 02:07:27 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ocrproc.c
+++ b/src/ocrproc.c
@@ -1,6 +1,5 @@
 /* $Id: ocrproc.c,v 1.2 1999/01/03 02:07:27 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: ocrproc.c,v 1.2 1999/01/03 02:07:27 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/oether.c
+++ b/src/oether.c
@@ -1,6 +1,5 @@
 /* $Id: oether.c,v 1.2 1999/01/03 02:07:28 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: oether.c,v 1.2 1999/01/03 02:07:28 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/oldeether.c
+++ b/src/oldeether.c
@@ -1,6 +1,5 @@
 /* $Id: oldeether.c,v 1.2 1999/01/03 02:07:28 sybalsky Exp $ (C) Copyright Venue, All Rights
  * Reserved  */
-static char *id = "$Id: oldeether.c,v 1.2 1999/01/03 02:07:28 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/optck.c
+++ b/src/optck.c
@@ -1,5 +1,4 @@
 /* $Id: optck.c,v 1.3 1999/05/31 23:35:40 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: optck.c,v 1.3 1999/05/31 23:35:40 sybalsky Exp $ Copyright (C) Venue";
 /* optck.c
  *
  * This example is almost same as one shown in

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -1,5 +1,4 @@
 /* $Id: osmsg.c,v 1.2 1999/01/03 02:07:29 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: osmsg.c,v 1.2 1999/01/03 02:07:29 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/perrno.c
+++ b/src/perrno.c
@@ -1,6 +1,5 @@
 /* $Id: perrno.c,v 1.4 2001/12/26 22:17:04 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: perrno.c,v 1.4 2001/12/26 22:17:04 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/picture.c
+++ b/src/picture.c
@@ -1,6 +1,5 @@
 /* $Id: picture.c,v 1.2 1999/01/03 02:07:30 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: picture.c,v 1.2 1999/01/03 02:07:30 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/rawcolor.c
+++ b/src/rawcolor.c
@@ -1,6 +1,5 @@
 /* $Id: rawcolor.c,v 1.3 2001/12/26 22:17:04 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: rawcolor.c,v 1.3 2001/12/26 22:17:04 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/rawrs232c.c
+++ b/src/rawrs232c.c
@@ -1,6 +1,5 @@
 /* $Id: rawrs232c.c,v 1.2 1999/01/03 02:07:31 sybalsky Exp $ (C) Copyright Venue, All Rights
  * Reserved  */
-static char *id = "$Id: rawrs232c.c,v 1.2 1999/01/03 02:07:31 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/return.c
+++ b/src/return.c
@@ -1,6 +1,5 @@
 /* $Id: return.c,v 1.4 2001/12/24 01:09:05 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: return.c,v 1.4 2001/12/24 01:09:05 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -1,5 +1,4 @@
 /* $Id: rpc.c,v 1.3 2001/12/24 01:09:06 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: rpc.c,v 1.3 2001/12/24 01:09:06 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/rplcons.c
+++ b/src/rplcons.c
@@ -1,6 +1,5 @@
 /* $Id: rplcons.c,v 1.3 1999/05/31 23:35:41 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: rplcons.c,v 1.3 1999/05/31 23:35:41 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/rs232c.c
+++ b/src/rs232c.c
@@ -1,6 +1,5 @@
 /* $Id: rs232c.c,v 1.2 1999/01/03 02:07:32 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: rs232c.c,v 1.2 1999/01/03 02:07:32 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/setsout.c
+++ b/src/setsout.c
@@ -1,6 +1,5 @@
 /* $Id: setsout.c,v 1.3 1999/05/31 23:35:41 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: setsout.c,v 1.3 1999/05/31 23:35:41 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/shift.c
+++ b/src/shift.c
@@ -1,5 +1,4 @@
 /* $Id: shift.c,v 1.3 1999/05/31 23:35:42 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: shift.c,v 1.3 1999/05/31 23:35:42 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/socdvr.c
+++ b/src/socdvr.c
@@ -1,6 +1,5 @@
 /* $Id: socdvr.c,v 1.2 1999/01/03 02:07:33 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: socdvr.c,v 1.2 1999/01/03 02:07:33 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/socket.c
+++ b/src/socket.c
@@ -1,6 +1,5 @@
 /* $Id: socket.c,v 1.2 1999/01/03 02:07:34 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: socket.c,v 1.2 1999/01/03 02:07:34 sybalsky Exp $ Copyright (C) Venue";
 /* Copyright    Massachusetts Institute of Technology    1988	*/
 /*
  * THIS IS AN OS DEPENDENT FILE! It should work on 4.2BSD derived

--- a/src/subr.c
+++ b/src/subr.c
@@ -1,5 +1,4 @@
 /* $Id: subr.c,v 1.3 1999/05/31 23:35:42 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: subr.c,v 1.3 1999/05/31 23:35:42 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/subr0374.c
+++ b/src/subr0374.c
@@ -1,6 +1,5 @@
 /* $Id: subr0374.c,v 1.3 1999/05/31 23:35:43 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: subr0374.c,v 1.3 1999/05/31 23:35:43 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/sxhash.c
+++ b/src/sxhash.c
@@ -1,6 +1,5 @@
 /* $Id: sxhash.c,v 1.4 2001/12/24 01:09:06 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: sxhash.c,v 1.4 2001/12/24 01:09:06 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/sysatms.c
+++ b/src/sysatms.c
@@ -1,3 +1,2 @@
 /* $Id: sysatms.c,v 1.2 1999/01/03 02:07:36 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: sysatms.c,v 1.2 1999/01/03 02:07:36 sybalsky Exp $ Copyright (C) Venue";

--- a/src/testdsp.c
+++ b/src/testdsp.c
@@ -1,6 +1,5 @@
 /* $Id: testdsp.c,v 1.2 1999/01/03 02:07:36 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: testdsp.c,v 1.2 1999/01/03 02:07:36 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -1,6 +1,5 @@
 /* $Id: testtool.c,v 1.4 2001/12/24 01:09:07 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: testtool.c,v 1.4 2001/12/24 01:09:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/timer.c
+++ b/src/timer.c
@@ -1,5 +1,4 @@
 /* $Id: timer.c,v 1.5 2001/12/26 22:17:05 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: timer.c,v 1.5 2001/12/26 22:17:05 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/truecolor.c
+++ b/src/truecolor.c
@@ -1,6 +1,5 @@
 /* $Id: truecolor.c,v 1.2 1999/01/03 02:07:38 sybalsky Exp $ (C) Copyright Venue, All Rights
  * Reserved  */
-static char *id = "$Id: truecolor.c,v 1.2 1999/01/03 02:07:38 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/tstsout.c
+++ b/src/tstsout.c
@@ -1,6 +1,5 @@
 /* $Id: tstsout.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: tstsout.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyright (C) Venue";
 /*
  *	tstsout.c
  */

--- a/src/tty.c
+++ b/src/tty.c
@@ -1,5 +1,4 @@
 /* $Id: tty.c,v 1.2 1999/01/03 02:07:39 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: tty.c,v 1.2 1999/01/03 02:07:39 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/typeof.c
+++ b/src/typeof.c
@@ -1,6 +1,5 @@
 /* $Id: typeof.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: typeof.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ubf1.c
+++ b/src/ubf1.c
@@ -1,5 +1,4 @@
 /* $Id: ubf1.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ubf1.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/ubf2.c
+++ b/src/ubf2.c
@@ -1,5 +1,4 @@
 /* $Id: ubf2.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ubf2.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyright (C) Venue";
 /*	ubf2.c
  */
 

--- a/src/ubf3.c
+++ b/src/ubf3.c
@@ -1,5 +1,4 @@
 /* $Id: ubf3.c,v 1.3 1999/05/31 23:35:45 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ubf3.c,v 1.3 1999/05/31 23:35:45 sybalsky Exp $ Copyright (C) Venue";
 /*	ubf3.c
  */
 

--- a/src/ufn.c
+++ b/src/ufn.c
@@ -1,5 +1,4 @@
 /* $Id: ufn.c,v 1.2 1999/01/03 02:07:41 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ufn.c,v 1.2 1999/01/03 02:07:41 sybalsky Exp $ Copyright (C) Venue";
 /******************************************************************/
 /*
 

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -1,5 +1,4 @@
 /* $Id: ufs.c,v 1.2 1999/01/03 02:07:41 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: ufs.c,v 1.2 1999/01/03 02:07:41 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -1,5 +1,4 @@
 /* %Z% %M% Version %I% (%G%). copyright venue & Fuji Xerox  */
-static char *id = "%Z% %M%	%I% %G%	(venue & Fuji Xerox)";
 
 /*
 

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -1,6 +1,5 @@
 /* $Id: unixfork.c,v 1.6 2001/12/26 22:17:05 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: unixfork.c,v 1.6 2001/12/26 22:17:05 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -1,6 +1,5 @@
 /* $Id: unwind.c,v 1.3 1999/05/31 23:35:46 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: unwind.c,v 1.3 1999/05/31 23:35:46 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -1,5 +1,4 @@
 /* @(#) uraid.c Version 1.52 (4/23/92). copyright Venue & Fuji Xerox  */
-static char *id = "@(#) uraid.c 1.52 4/23/92            (Venue & Fuji Xerox)";
 
 /************************************************************************/
 /*                                                                      */

--- a/src/usrsubr.c
+++ b/src/usrsubr.c
@@ -1,6 +1,5 @@
 /* $Id: usrsubr.c,v 1.3 1999/05/31 23:35:46 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: usrsubr.c,v 1.3 1999/05/31 23:35:46 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -1,6 +1,5 @@
 /* $Id: uutils.c,v 1.3 1999/05/31 23:35:47 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: uutils.c,v 1.3 1999/05/31 23:35:47 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/vars3.c
+++ b/src/vars3.c
@@ -1,5 +1,4 @@
 /* $Id: vars3.c,v 1.4 2001/12/24 01:09:07 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: vars3.c,v 1.4 2001/12/24 01:09:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/vesainit.c
+++ b/src/vesainit.c
@@ -1,6 +1,5 @@
 /* $Id: vesainit.c,v 1.2 1999/01/03 02:07:44 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: vesainit.c,v 1.2 1999/01/03 02:07:44 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/vgainit.c
+++ b/src/vgainit.c
@@ -1,6 +1,5 @@
 /* $Id: vgainit.c,v 1.2 1999/01/03 02:07:45 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: vgainit.c,v 1.2 1999/01/03 02:07:45 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -1,6 +1,5 @@
 /* $Id: vmemsave.c,v 1.2 1999/01/03 02:07:45 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: vmemsave.c,v 1.2 1999/01/03 02:07:45 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xbbt.c
+++ b/src/xbbt.c
@@ -1,5 +1,4 @@
 /* $Id: xbbt.c,v 1.2 1999/01/03 02:07:46 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: xbbt.c,v 1.2 1999/01/03 02:07:46 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xc.c
+++ b/src/xc.c
@@ -1,5 +1,4 @@
 /* $Id: xc.c,v 1.4 2001/12/26 22:17:06 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: xc.c,v 1.4 2001/12/26 22:17:06 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -1,6 +1,5 @@
 /* $Id: xcursor.c,v 1.4 2001/12/26 22:17:06 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xcursor.c,v 1.4 2001/12/26 22:17:06 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -1,5 +1,4 @@
 /* $Id: xinit.c,v 1.5 2001/12/26 22:17:06 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved */
-static char *id = "$Id: xinit.c,v 1.5 2001/12/26 22:17:06 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -1,6 +1,5 @@
 /* $Id: xlspwin.c,v 1.4 2001/12/26 22:17:07 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xlspwin.c,v 1.4 2001/12/26 22:17:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xmkicon.c
+++ b/src/xmkicon.c
@@ -1,6 +1,5 @@
 /* $Id: xmkicon.c,v 1.3 2001/12/24 01:09:09 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xmkicon.c,v 1.3 2001/12/24 01:09:09 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -1,6 +1,5 @@
 /* $Id: xrdopt.c,v 1.6 2001/12/26 22:17:07 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xrdopt.c,v 1.6 2001/12/26 22:17:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xscroll.c
+++ b/src/xscroll.c
@@ -1,6 +1,5 @@
 /* $Id: xscroll.c,v 1.2 1999/01/03 02:07:48 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xscroll.c,v 1.2 1999/01/03 02:07:48 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/xwinman.c
+++ b/src/xwinman.c
@@ -1,6 +1,5 @@
 /* $Id: xwinman.c,v 1.3 2001/12/26 22:17:07 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved
  */
-static char *id = "$Id: xwinman.c,v 1.3 2001/12/26 22:17:07 sybalsky Exp $ Copyright (C) Venue";
 
 /************************************************************************/
 /*									*/

--- a/src/z2.c
+++ b/src/z2.c
@@ -1,5 +1,4 @@
 /* $Id: z2.c,v 1.3 1999/05/31 23:35:47 sybalsky Exp $ (C) Copyright Venue, All Rights Reserved  */
-static char *id = "$Id: z2.c,v 1.3 1999/05/31 23:35:47 sybalsky Exp $ Copyright (C) Venue";
 /*
  *	Author :  don charnley
  */


### PR DESCRIPTION
The (old) version and copyright information is in a comment in each file, and this removes an unused variable warning.