### PR TITLE
Replace calls to putenv with setenv

### DIFF
--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -269,22 +269,18 @@ int fork_Unix() {
        and put their numbers in the environment so parent can find them */
     /* JDS - NB that sprintf doesn't always return a string! */
 
-    char *tempstring;
+    char tempstring[30];
 
-    tempstring = (char *)malloc(30);
-    snprintf(tempstring, 30, "%d", UnixToLisp[0]);
+    snprintf(tempstring, sizeof(tempstring), "%d", UnixToLisp[0]);
     setenv("LDEPIPEINE", tempstring, 1);
 
-    tempstring = (char *)malloc(30);
-    snprintf(tempstring, 30, "%d", LispToUnix[1]);
+    snprintf(tempstring, sizeof(tempstring), "%d", LispToUnix[1]);
     setenv("LDEPIPEOUT", tempstring, 1);
 
-    tempstring = (char *)malloc(30);
-    snprintf(tempstring, 30, "%ld", StartTime);
+    snprintf(tempstring, sizeof(tempstring), "%ld", StartTime);
     setenv("LDESTARTTIME", tempstring, 1);
 
-    tempstring = (char *)malloc(30);
-    snprintf(tempstring, 30, "%d", UnixPID);
+    snprintf(tempstring, sizeof(tempstring), "%d", UnixPID);
     setenv("LDEUNIXPID", tempstring, 1);
 
     close(LispToUnix[0]);

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -272,19 +272,19 @@ int fork_Unix() {
     char *tempstring;
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "%d", UnixToLisp[0]);
+    snprintf(tempstring, 30, "%d", UnixToLisp[0]);
     setenv("LDEPIPEINE", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "%d", LispToUnix[1]);
+    snprintf(tempstring, 30, "%d", LispToUnix[1]);
     setenv("LDEPIPEOUT", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "%ld", StartTime);
+    snprintf(tempstring, 30, "%ld", StartTime);
     setenv("LDESTARTTIME", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "%d", UnixPID);
+    snprintf(tempstring, 30, "%d", UnixPID);
     setenv("LDEUNIXPID", tempstring, 1);
 
     close(LispToUnix[0]);

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -145,11 +145,10 @@ int ForkUnixShell(int slot, char ltr, char numb, char *termtype, char *shellarg)
 
     /* set the LDESHELL variable so the underlying .cshrc can see it and
        configure the shell appropriately, though this may not be so important any more */
-    putenv("LDESHELL=YES");
+    setenv("LDESHELL", "YES", 1);
 
     if ((termtype[0] != 0) && (strlen(termtype) < 59)) { /* set the TERM environment var */
-      sprintf(envstring, "TERM=%s", termtype);
-      putenv(envstring);
+      setenv("TERM", termtype, 1);
     }
     /* Start up csh */
     argvec[0] = "csh";
@@ -273,20 +272,20 @@ int fork_Unix() {
     char *tempstring;
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "LDEPIPEIN=%d", UnixToLisp[0]);
-    putenv(tempstring);
+    sprintf(tempstring, "%d", UnixToLisp[0]);
+    setenv("LDEPIPEINE", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "LDEPIPEOUT=%d", LispToUnix[1]);
-    putenv(tempstring);
+    sprintf(tempstring, "%d", LispToUnix[1]);
+    setenv("LDEPIPEOUT", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "LDESTARTTIME=%ld", StartTime);
-    putenv(tempstring);
+    sprintf(tempstring, "%ld", StartTime);
+    setenv("LDESTARTTIME", tempstring, 1);
 
     tempstring = (char *)malloc(30);
-    sprintf(tempstring, "LDEUNIXPID=%d", UnixPID);
-    putenv(tempstring);
+    sprintf(tempstring, "%d", UnixPID);
+    setenv("LDEUNIXPID", tempstring, 1);
 
     close(LispToUnix[0]);
     close(UnixToLisp[1]);


### PR DESCRIPTION
I've verified that that the code builds and the medley image starts, but I'm not sure how to exercise the code paths call fork. Also I went ahead and removed the calls to malloc, instead reusing the same tempstring across calls to setenv.

Closes https://github.com/Interlisp/medley/issues/83