### PR TITLE
integer multiply overflow wasn't catching all cases

### DIFF
--- a/src/arith4.c
+++ b/src/arith4.c
@@ -61,7 +61,7 @@ dummy:
 #else
 
   result = arg1 * arg2;
-  if ((arg2 != 0) && ((result / arg2) != arg1)) goto doufn2;
+  if ((arg2 != 0) && (((result % arg2) != 0) || ((result / arg2) != arg1))) goto doufn2;
   N_ARITH_SWITCH(result);
 
 #endif
@@ -91,7 +91,7 @@ dummy:
 
   /* UB: signed integer overflow: 1073741824 * 32768 cannot be represented in type 'int' */
   result = arg1 * arg2;
-  if ((arg2 != 0) && ((result / arg2) != arg1)) { goto doufn; }
+  if ((arg2 != 0) && (((result % arg2) != 0) || ((result / arg2) != arg1))) { goto doufn; }
   N_ARITH_SWITCH(result);
 
 #endif


### PR DESCRIPTION
I thought this had to do with 64-bit, but I don't know C well enough to say.
This fixes the bug that (cl:* 300000 300000) returned a negative number.