### PR TITLE
Revert "integer multiply overflow wasn't catching all cases"

### DIFF
--- a/src/arith4.c
+++ b/src/arith4.c
@@ -61,7 +61,7 @@ dummy:
 #else
 
   result = arg1 * arg2;
-  if ((arg2 != 0) && (((result % arg2) != 0) || ((result / arg2) != arg1))) goto doufn2;
+  if ((arg2 != 0) && ((result / arg2) != arg1)) goto doufn2;
   N_ARITH_SWITCH(result);
 
 #endif
@@ -91,7 +91,7 @@ dummy:
 
   /* UB: signed integer overflow: 1073741824 * 32768 cannot be represented in type 'int' */
   result = arg1 * arg2;
-  if ((arg2 != 0) && (((result % arg2) != 0) || ((result / arg2) != arg1))) { goto doufn; }
+  if ((arg2 != 0) && ((result / arg2) != arg1)) { goto doufn; }
   N_ARITH_SWITCH(result);
 
 #endif


### PR DESCRIPTION
Reverts Interlisp/maiko#100

This is not the correct fix for the problem.  See discussion at Interlisp/medley#90