### PR TITLE
Clean up `extern int errno` and errno.h inclusions.

### DIFF
--- a/src/chatter.c
+++ b/src/chatter.c
@@ -15,7 +15,6 @@ static char *id = "$Id: chatter.c,v 1.2 1999/01/03 02:06:51 sybalsky Exp $ Copyr
 #include <sys/termios.h>
 #include <sys/ttydev.h>
 #include <stdio.h>
-#include <errno.h>
 
 #include "lispemul.h"
 #include "address.h"

--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -87,8 +87,6 @@ LispPTR DSP_VideoColor(LispPTR *args) /* args[0] :	black flag	*/
 extern struct cursor CurrentCursor;
 extern int LispWindowFd;
 
-extern int errno;
-
 /****************************************************
  *
  *	DSP_Cursor() entry of SUBRCALL 64 2

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -129,7 +129,6 @@ struct winlock DisplayLockArea;
 #endif /* SUNDISPLAY */
 
 extern DLword *EmCursorBitMap68K;
-extern int errno;
 extern IFPAGE *InterfacePage;
 
 int DebugDSP = T;

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -11,6 +11,7 @@ static char *id = "$Id: initkbd.c,v 1.2 1999/01/03 02:07:09 sybalsky Exp $ Copyr
 
 #include "version.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
@@ -124,7 +125,6 @@ extern struct screen LispScreen;
 
 extern int LispWindowFd;
 int LispKbdFd = -1;
-extern int errno;
 
 /*   for debug    */
 int DebugKBD = NIL;

--- a/src/kbdsubrs.c
+++ b/src/kbdsubrs.c
@@ -11,6 +11,7 @@ static char *id = "$Id: kbdsubrs.c,v 1.2 1999/01/03 02:07:10 sybalsky Exp $ Copy
 
 #include "version.h"
 
+#include <errno.h>
 #include <stdio.h>
 #ifdef DOS
 #include <time.h>
@@ -69,8 +70,6 @@ extern struct screen LispScreen;
 
 extern int LispWindowFd;
 extern fd_set LispReadFds;
-
-extern int errno;
 
 void KB_enable(LispPTR *args) /* args[0] :	ON/OFF flag
                                      *		T -- ON

--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -13,7 +13,6 @@ static char *id = "$Id: ldeboot.c,v 1.3 1999/01/03 02:07:13 sybalsky Exp $ Copyr
 
 #include <ctype.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -63,7 +63,6 @@ char *devices[] = {"le0",   "le1",   "le2",   "le3",   "le4",   "ie0", "ie1", "i
 
 #include <nlist.h>
 #include <fcntl.h>
-#include <errno.h>
 #include <malloc.h>
 
 #endif /* NOETHER */

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -12,7 +12,6 @@ static char *id = "$Id: ldsout.c,v 1.4 2001/12/26 22:17:02 sybalsky Exp $ Copyri
 
 #include "version.h"
 
-#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,7 +40,6 @@ static char *id = "$Id: ldsout.c,v 1.4 2001/12/26 22:17:02 sybalsky Exp $ Copyri
 #define DEFAULT_PRIME_SYSOUTSIZE 8
 #define MAX_EXPLICIT_SYSOUTSIZE 256 /* Max possible sysout size is 64Mb */
 #define MBYTE 0x100000              /* 1 Mbyte */
-extern int errno;
 
 /* Flag for indication whether process space
   is going to expand or not */

--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -27,8 +27,6 @@ static char *id = "$Id: llcolor.c,v 1.2 1999/01/03 02:07:15 sybalsky Exp $ Copyr
 #include <sys/types.h>
 #include <sys/file.h>
 
-#include <errno.h>
-
 #include "lispemul.h"
 #include "lispmap.h"
 #include "lsptypes.h"

--- a/src/oldeether.c
+++ b/src/oldeether.c
@@ -39,7 +39,6 @@ int main(int argc, char *argv[])
 
 #include <nlist.h>
 #include <fcntl.h>
-#include <errno.h>
 
 int ether_fd = -1;                                /* file descriptor for ether socket */
 unsigned char ether_host[6] = {0, 0, 0, 0, 0, 0}; /* 48 bit address */

--- a/src/setsout.c
+++ b/src/setsout.c
@@ -41,7 +41,6 @@ static char *id = "$Id: setsout.c,v 1.3 1999/05/31 23:35:41 sybalsky Exp $ Copyr
 
 #define IFPAGE_ADDRESS 512
 #define MBYTE 0x100000 /* 1 Mbyte */
-extern int errno;
 
 void set_sysout(int version, char *sysout_file_name);
 

--- a/src/socket.c
+++ b/src/socket.c
@@ -13,6 +13,7 @@ static char *id = "$Id: socket.c,v 1.2 1999/01/03 02:07:34 sybalsky Exp $ Copyri
 
 #include "version.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <X11/Xos.h>
 #include <X11/Xproto.h>
@@ -22,9 +23,6 @@ static char *id = "$Id: socket.c,v 1.2 1999/01/03 02:07:34 sybalsky Exp $ Copyri
 #include <netdb.h>
 #include <sys/socket.h>
 #include <netinet/tcp.h>
-
-extern int errno; /* Certain (broken) OS's don't have this */
-                  /* decl in errno.h */
 
 #ifdef UNIXCONN
 #include <sys/un.h>

--- a/src/testdsp.c
+++ b/src/testdsp.c
@@ -55,8 +55,6 @@ short *DisplayRegion68k; /* 68k addr of #{}22,0 */
 struct cursor CurrentCursor, InvisibleCursor;
 struct winlock DisplayLockArea;
 
-extern int errno;
-
 /**************************************
 extern DLword *EmCursorBitMap68K;
 extern IFPAGE *InterfacePage;

--- a/src/tstsout.c
+++ b/src/tstsout.c
@@ -20,7 +20,6 @@ static char *id = "$Id: tstsout.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyr
 #include <sys/file.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <errno.h>
 #include <fcntl.h>
 
 #include "adr68k.h"
@@ -34,7 +33,6 @@ static char *id = "$Id: tstsout.c,v 1.3 1999/05/31 23:35:44 sybalsky Exp $ Copyr
 
 #define IFPAGE_ADDRESS 512
 #define MBYTE 0x100000 /* 1 Mbyte */
-extern int errno;
 
 void check_sysout(char *sysout_file_name, int verbose);
 void usage(char *prog);


### PR DESCRIPTION
Closes interlisp/medley#86.