### PR TITLE
Update how we configure gcc / clang command lines.

### DIFF
--- a/bin/makefile-darwin.386-x
+++ b/bin/makefile-darwin.386-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -m32 -std=gnu89 -funsigned-char -fno-strict-aliasing
+CC = clang -m32 $(CLANG_CFLAGS)
 OEXT=.o
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -std=gnu89 -funsigned-char -fno-strict-aliasing
+CC = clang $(CLANG_CFLAGS)
 OEXT=.o
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -m64 -std=gnu89 -funsigned-char -fno-strict-aliasing
+CC = clang -m64 $(CLANG_CFLAGS)
 OEXT=.o
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-header
+++ b/bin/makefile-header
@@ -13,6 +13,10 @@ RANLIB = ranlib
 AR = ar rcv
 ANSICC = $(CC)
 
+# Compiler flags
+CLANG_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing
+GCC_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing
+
 # for the files that need to be included in byte-swapped implementations:
 BYTESWAPFILES =
 SXHASHFILE = 

--- a/bin/makefile-header
+++ b/bin/makefile-header
@@ -14,8 +14,8 @@ AR = ar rcv
 ANSICC = $(CC)
 
 # Compiler flags
-CLANG_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing
-GCC_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing
+CLANG_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing -fwrapv
+GCC_CFLAGS = -std=gnu89 -funsigned-char -fno-strict-aliasing -fwrapv
 
 # for the files that need to be included in byte-swapped implementations:
 BYTESWAPFILES =

--- a/bin/makefile-init.386
+++ b/bin/makefile-init.386
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows, for INIT processing
 
-CC = clang -m32 -std=gnu89 -Wimplicit-function-declaration
+CC = clang -m32 $(CLANG_CFLAGS)
 OEXT=.o
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
 CC = clang -m32 $(CLANG_CFLAGS)
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -1,7 +1,7 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 -std=gnu89 -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations -fno-strict-aliasing
-CC = clang -m32 -std=gnu89 -funsigned-char -fno-strict-aliasing
+#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+CC = clang -m32 $(CLANG_CFLAGS)
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \
 	$(OBJECTDIR)dspif.o \

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
 CC = clang -m32 $(CLANG_CFLAGS)
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,7 +1,7 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 -std=gnu89 -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations -fno-strict-aliasing
-CC = clang -m32 -std=gnu89 -funsigned-char -fno-strict-aliasing
+#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+CC = clang -m32 $(CLANG_CFLAGS)
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \
 	$(OBJECTDIR)dspif.o \

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+#CC = gcc -m64 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
 CC = clang -m64 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -1,7 +1,7 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 -std=gnu89 -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations -fno-strict-aliasing
-CC = clang -m64 -std=gnu89 -funsigned-char -fno-strict-aliasing
+#CC = gcc -m64 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fwrapv -fno-aggressive-loop-optimizations
+CC = clang -m64 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-sunos5.386-x
+++ b/bin/makefile-sunos5.386-x
@@ -10,7 +10,7 @@
 #*									*/
 #************************************************************************/
 
-CC = clang -m32 -std=gnu89 -funsigned-char -fno-strict-aliasing
+CC = clang -m32 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-sunos5.sparc-x
+++ b/bin/makefile-sunos5.sparc-x
@@ -13,7 +13,7 @@
 #************************************************************************/
 
 # Setup for using gcc
-#  CC = gcc -std=gnu89 -funsigned-char
+#  CC = gcc $(GCC_CFLAGS)
 # Setup for using Solaris Developer Studio 12.6 cc
 #  CC = cc -m32 -funsigned-char
 

--- a/bin/makefile-sunos5.x86_64-x
+++ b/bin/makefile-sunos5.x86_64-x
@@ -10,7 +10,7 @@
 #*									*/
 #************************************************************************/
 
-CC = clang -std=gnu89 -funsigned-char -fno-strict-aliasing
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \


### PR DESCRIPTION
This PR centralizes the configuration of clang and gcc command lines, and then in a subsequent commit, adds `-fwrapv` to deal with the problems discussed in interlisp/medley#90.