### PR TITLE
Update FreeBSD makefile to use clang and new style for configuring options

### DIFF
--- a/bin/makefile-freebsd.386-x
+++ b/bin/makefile-freebsd.386-x
@@ -1,6 +1,6 @@
-# Options for Linux, Intel 386/486 and X-Window
+# Options for FreeBSD, Intel 386/486 and X Windows
 
-CC = gcc -m32 -std=c89 -Wall
+CC = clang -m32 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \


### PR DESCRIPTION
Followup to PR #103. FreeBSD has installed clang by default since 10.0-CURRENT and 9.0-STABLE and gcc is no longer installed by default.  Update the makefile fragment to use clang and the default CLANG_CFLAGS as per other platforms.