### PR TITLE
Fix typo #ifdef RESWAPPEDDCODESTREAM -- should be RESWAPPEDCODESTREAM

### DIFF
--- a/inc/byteswapdefs.h
+++ b/inc/byteswapdefs.h
@@ -5,7 +5,7 @@ unsigned short byte_swap_word(unsigned short word);
 void byte_swap_page(unsigned short *page, int wordcount);
 void word_swap_page(unsigned short *page, int longwordcount);
 void bit_reverse_region(unsigned short *top, int width, int height, int rasterwidth);
-#ifdef RESWAPPEDDCODESTREAM
+#ifdef RESWAPPEDCODESTREAM
 unsigned int byte_swap_code_block(unsigned int *base);
 #endif
 #endif

--- a/src/byteswap.c
+++ b/src/byteswap.c
@@ -166,7 +166,7 @@ void bit_reverse_region(unsigned short *top, int width, int height, int rasterwi
 /*									*/
 /************************************************************************/
 
-#ifdef RESWAPPEDDCODESTREAM
+#ifdef RESWAPPEDCODESTREAM
 unsigned int byte_swap_code_block(unsigned int *base) {
   UNSIGNED startpc, len;
 


### PR DESCRIPTION
All uses of the defined symbol, which are intended to be the same symbol, must be spelled in the same way.