### PR TITLE
ForkUnixShell: Replace strlen with strnlen

### DIFF
--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -229,7 +229,7 @@ int fork_Unix() {
   pid_t pid;
 
   char IOBuf[4];
-  unsigned short tmp;
+  unsigned short tmp = 0;
   char *cmdstring;
 
   /* Pipes between LISP subr and process */

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -317,7 +317,7 @@ int fork_Unix() {
       case 'S':
       case 'P':          /* Fork PTY shell */
         if (slot >= 0) { /* Found a free slot */
-          char termtype[32];
+          char termtype[64];
 #ifdef FULLSLAVENAME
           char slavepty[32]; /* For slave pty name */
 

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -146,7 +146,7 @@ int ForkUnixShell(int slot, char ltr, char numb, char *termtype, char *shellarg)
        configure the shell appropriately, though this may not be so important any more */
     setenv("LDESHELL", "YES", 1);
 
-    if ((termtype[0] != 0) && (strlen(termtype) < 59)) { /* set the TERM environment var */
+    if (termtype[0] != 0) { /* set the TERM environment var */
       setenv("TERM", termtype, 1);
     }
     /* Start up csh */
@@ -327,7 +327,9 @@ int fork_Unix() {
 
           if (IOBuf[0] == 'P') { /* The new style, which takes term type & command to csh */
             if (SAFEREAD(LispPipeIn, (char *)&tmp, 2) < 0) perror("Slave reading cmd length");
+            if (tmp > 63) perror("Slave termtype length too long");
             if (SAFEREAD(LispPipeIn, termtype, tmp) < 0) perror("Slave reading termtype");
+            termtype[tmp] = '\0';
             if (SAFEREAD(LispPipeIn, (char *)&tmp, 2) < 0) perror("Slave reading cmd length");
             if (tmp > 510)
               cmdstring = (char *)malloc(tmp + 5);


### PR DESCRIPTION
We also reduce the upper bound length to 32 as termtype is defined as
char termtype[32]. strlen may result in reading past the memory
allocated for termtype if no null byte is found in the first 32 bytes,
Use strnlen to avoid that.

This is a follow up to what was mentioned on https://github.com/Interlisp/maiko/pull/99#issuecomment-748418032 Let me know if I missed something and we should be keep 59 bytes as the upper limit.