### PR TITLE
Remove XV11R4 and related defines.

### DIFF
--- a/bin/makefile-darwin.386-x
+++ b/bin/makefile-darwin.386-x
@@ -14,8 +14,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -14,8 +14,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O1 -g

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -14,8 +14,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O1 -g

--- a/bin/makefile-freebsd.386-x
+++ b/bin/makefile-freebsd.386-x
@@ -13,8 +13,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -I/usr/local/include -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -I/usr/local/include -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-init.386
+++ b/bin/makefile-init.386
@@ -14,8 +14,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2, for INIT we want unoptimized in case we need to debug it
 OPTFLAGS =  -O0 -g

--- a/bin/makefile-init.sparc
+++ b/bin/makefile-init.sparc
@@ -32,8 +32,7 @@ XFILES = $(OBJECTDIR)xlspwin.o \
 	$(OBJECTDIR)xinit.o
 
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DXV11R4 -I/usr/openwin/include
+XFLAGS = -DXWINDOW -I/usr/openwin/include
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -13,8 +13,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -13,8 +13,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -14,8 +14,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xwinman.o
 
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos3.mc68020-x
+++ b/bin/makefile-sunos3.mc68020-x
@@ -25,8 +25,7 @@ XFILES = $(OBJECTDIR)XClose.o \
 	$(OBJECTDIR)VideoColor.o \
 	$(OBJECTDIR)XWindowMgr.o  
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos4.1.mc68020-x
+++ b/bin/makefile-sunos4.1.mc68020-x
@@ -25,8 +25,7 @@ XFILES = $(OBJECTDIR)XClose.o \
 	$(OBJECTDIR)VideoColor.o \
 	$(OBJECTDIR)XWindowMgr.o  
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos4.1.sparc-x
+++ b/bin/makefile-sunos4.1.sparc-x
@@ -25,8 +25,7 @@ XFILES = $(OBJECTDIR)XClose.o \
 	$(OBJECTDIR)Xcolor.o \
 	$(OBJECTDIR)Xwinman.o
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos4.mc68020-x
+++ b/bin/makefile-sunos4.mc68020-x
@@ -25,8 +25,7 @@ XFILES = $(OBJECTDIR)XClose.o \
 	$(OBJECTDIR)VideoColor.o \
 	$(OBJECTDIR)XWindowMgr.o  
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos4.sparc-x
+++ b/bin/makefile-sunos4.sparc-x
@@ -12,8 +12,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 
 CC = gcc
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos4.sparc-x-3
+++ b/bin/makefile-sunos4.sparc-x-3
@@ -25,8 +25,7 @@ XFILES = $(OBJECTDIR)XClose.o \
 	$(OBJECTDIR)VideoColor.o \
 	$(OBJECTDIR)XWindowMgr.o  
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos5.386-x
+++ b/bin/makefile-sunos5.386-x
@@ -22,8 +22,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xrdopt.o \
 	$(OBJECTDIR)xwinman.o
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos5.i386-x
+++ b/bin/makefile-sunos5.i386-x
@@ -22,8 +22,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xrdopt.o \
 	$(OBJECTDIR)xwinman.o
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos5.sparc-x
+++ b/bin/makefile-sunos5.sparc-x
@@ -29,8 +29,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xrdopt.o \
 	$(OBJECTDIR)xwinman.o
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -D$(XVERSION)
+XFLAGS = -DXWINDOW
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/bin/makefile-sunos5.x86_64-x
+++ b/bin/makefile-sunos5.x86_64-x
@@ -22,8 +22,7 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xrdopt.o \
 	$(OBJECTDIR)xwinman.o
 
-XVERSION = XV11R4
-XFLAGS = -DXWINDOW -DNOPIXRECT -D$(XVERSION)
+XFLAGS = -DXWINDOW -DNOPIXRECT
 
 # This is to make the %$#@! Apollo cc happy
 OEXT = .o

--- a/inc/xdefs.h
+++ b/inc/xdefs.h
@@ -50,36 +50,4 @@ extern int XNeedSignal;
 #define XUNLOCK
 #endif	/* LOCK_X_UPDATES */
 
-#ifdef XWINDOW
-#ifdef XV11R4
-#undef XV11R1
-#undef XV11R2
-#undef XV11R3
-#endif /* XV11R4 */
-
-#ifdef XV11R3
-#undef XV11R1
-#undef XV11R2
-#undef XV11R4
-#endif /* XV11R3 */
-
-#ifdef XV11R2
-#undef XV11R1
-#undef XV11R3
-#undef XV11R4
-#endif /* XV11R2 */
-
-#ifdef XV11R1
-#undef XV11R2
-#undef XV11R3
-#undef XV11R4
-#endif /* XV11R1 */
-
-#if ( !(defined( XV11R1 ))  \
-   && !(defined( XV11R2 ))  \
-   && !(defined( XV11R3 ))  \
-   && !(defined( XV11R4 )) )
-#define XV11R4			/* newest version */
-#endif
-#endif /* XWINDOW */
 #endif /* XDEFS_H */


### PR DESCRIPTION
We no longer have anything predicated upon the version of X11 that
we're using (and these versions are all ancient anyway).