### PR TITLE
Include termios as <termios.h>, not <sys/...>.

### DIFF
--- a/src/chatter.c
+++ b/src/chatter.c
@@ -11,9 +11,9 @@
 #include "version.h"
 
 #include <sys/fcntlcom.h>
-#include <sys/termios.h>
 #include <sys/ttydev.h>
 #include <stdio.h>
+#include <termios.h>
 
 #include "lispemul.h"
 #include "address.h"

--- a/src/rawrs232c.c
+++ b/src/rawrs232c.c
@@ -12,13 +12,13 @@
 
 #include <sys/select.h>
 #include <sys/types.h>
-#include <sys/termios.h>
 #include <sys/ttold.h>
 #include <sys/time.h>
 #include <stropts.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
+#include <termios.h>
 
 #include "lispemul.h"
 #include "address.h"

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -41,13 +41,7 @@ Unix Interface Communications
 #include <unistd.h>
 
 
-#ifdef OS4
-#include <sys/termios.h>
-#elif OS5
-#include <sys/termio.h>
-#else
 #include <termios.h>
-#endif /* OS4 */
 
 #ifdef sun
 /* to get S_IFIFO defn for creating fifos */


### PR DESCRIPTION
termios is available via `<termios.h>` on all supported platforms,
so variants of `<sys/termio.h>` and `<sys/termios.h>` are no
longer needed.