### PR TITLE
Remove call to ieee_handler().

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -793,13 +793,9 @@ void int_fp_service(int sig, int code, struct sigcontext *scp)
 }
 
 void int_fp_init() { /* first set up the signal handler */
-#ifdef OS5
   if (sigset(SIGFPE, int_fp_service))
-#else
-  if (ieee_handler("set", "all", int_fp_service))
-#endif /* OS5 */
 
-  perror("Sigvec for FPE failed");
+  perror("Sigset for FPE failed");
   DBPRINT(("FP interrupts enabled\n"));
 }
 


### PR DESCRIPTION
When `FLTINT` is defined (which is currently only on SunOS), if
`OS5` was not defined, then it tried to use `ieee_handler` which
doesn't exist on Linux and friends. If we were to enable `FLTINT`
on more platforms, then we'd want to always be using more modern
signal handling and not `ieee_handler`.