### PR TITLE
Remove ToMem macro.

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -48,12 +48,6 @@
 #include "inlnPS2.h"
 #endif
 
-#ifdef OS5
-#define ToMem memmove
-#else
-#define ToMem memcpy
-#endif /* !OS5 */
-
 #define TCPhostlookup 0
 #define TCPservicelookup 1
 #define TCPsocket 2
@@ -126,7 +120,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
       LispStringToCString(nameConn, namestring, 100);
       host = gethostbyname(namestring);
       if (!host) return (NIL);
-      ToMem((char *)&farend.sin_addr, (char *)host->h_addr, host->h_length);
+      memcpy((char *)&farend.sin_addr, (char *)host->h_addr, host->h_length);
     host_ok:
       sock = LispNumToCInt(proto);
       result = socket(AF_INET, SOCK_STREAM, 0);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -46,12 +46,6 @@
 #define MAX_HOSTNAME_LENGTH 100
 #define UDP_DATA_BLOCK_SIZE 1000
 
-#ifdef OS5
-#define ToMem memmove
-#else
-#define ToMem memcpy
-#endif /* OS5 */
-
 LispPTR rpc(LispPTR *args)
 {
 #ifndef DOS
@@ -130,7 +124,7 @@ LispPTR rpc(LispPTR *args)
   /* Resolve the host address. */
   if (hp) {
     sin1.sin_family = hp->h_addrtype;
-    ToMem((caddr_t)&sin1.sin_addr, hp->h_addr, hp->h_length);
+    memcpy((caddr_t)&sin1.sin_addr, hp->h_addr, hp->h_length);
   } else
     goto handle_error;
 


### PR DESCRIPTION
We can always use `memcpy` to copy from a `hostent` struct to a
`sockaddr_in` struct as they will not be overlapping.