### PR TITLE
Use the real gethostid on Solaris.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -231,7 +231,6 @@ typedef signed char s_char;
 	/********************************************************/
 #ifdef OS5
 		/* Solaris, sort of SYSV-ish, but not really */
-#undef HAS_GETHOSTID
 #define SYSVSIGNALS 1
 #define NOFORN
 #define LOCK_X_UPDATES 1

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -24,9 +24,7 @@
 
 #ifndef DOS
 #include <pwd.h>
-#else
-#undef HAS_GETHOSTID
-#endif /* DOS */
+#endif
 
 #include "hdw_conf.h"
 #include "lispemul.h"

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -40,10 +40,6 @@
 #include "osmsgdefs.h"
 #include "uraiddefs.h"
 
-#ifdef OS5
-#define gethostid() 0
-#endif /* OS5 */
-
 /************************************************************************/
 /*									*/
 /*		l i s p _ s t r i n g _ t o _ c _ s t r i n g		*/


### PR DESCRIPTION
Solaris has this, so we might as well use it like we do on other
platforms. This value is used in response to queries from it from
Lisp.