### PR TITLE
Remove prototypes for getenv. Use stdlib.h.

### DIFF
--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -12,6 +12,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #ifndef DOS
@@ -382,8 +383,6 @@ void seteventmask(struct inputmask *eventmask)
   win_setinputmask(LispWindowFd, eventmask, eventmask, WIN_NULLLINK);
 }
 #endif /* SUNDISPLAY */
-
-char *getenv(); /*  ---- external entry points --------*/
 
 #define MIN_KEYTYPE 3
 #define KB_AS3000J (7 + MIN_KEYTYPE)

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -63,6 +63,7 @@ char *devices[] = {"le0",   "le1",   "le2",   "le3",   "le4",   "ie0", "ie1", "i
 #include <nlist.h>
 #include <fcntl.h>
 #include <malloc.h>
+#include <stdlib.h>
 
 #endif /* NOETHER */
 
@@ -103,7 +104,7 @@ int main(int argc, char *argv[]) {
     /* Use DLPI to connect to the ethernet.  This code is stolen
        from NFSWATCH4.3
     */
-    char *etherdev = (char *)getenv("LDEETHERDEV");
+    char *etherdev = getenv("LDEETHERDEV");
     ether_fd = setup_dlpi_dev(etherdev);
     if (ether_fd >= 0) { /* Open an ether interface */
       ether_intf_type = dlpi_devtype(ether_fd);

--- a/src/main.c
+++ b/src/main.c
@@ -20,6 +20,7 @@
 #include <errno.h>
 #include <setjmp.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
 #include <time.h>
@@ -248,7 +249,6 @@ char keystring[128] = {""};
 #define FALSE 0
 #define TRUE !FALSE
 
-char *getenv();
 int Lisp_Xinitialized = FALSE;
 char sysout_name[MAXPATHLEN]; /* Set by read_Xoption, in the X version. */
 int sysout_size = 0;    /* ditto */

--- a/src/timer.c
+++ b/src/timer.c
@@ -44,6 +44,7 @@ unsigned long tick_count = 0; /* approx 18 ticks per sec            */
 #endif /* DOS */
 #include <sys/types.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <signal.h>
 #include <unistd.h>
 #include <fcntl.h>
@@ -102,7 +103,6 @@ extern DspInterface currentdsp;
  */
 
 int TIMEOUT_TIME; /* For file system timeout */
-char *getenv();
 
 #ifdef XWINDOW
 #define FALSE 0

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -31,6 +31,7 @@ Unix Interface Communications
 #include <setjmp.h> /* JRB - timeout.h needs setjmp.h */
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/file.h>
 #include <sys/ioctl.h>
@@ -258,7 +259,7 @@ void close_unix_descriptors(void) /* Get ready to shut Maiko down */
 /************************************************************************/
 
 int FindUnixPipes(void) {
-  char *envtmp, *getenv(const char *);
+  char *envtmp;
   register int i;
   struct unixjob cleareduj;
 

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -20,6 +20,7 @@
 
 #include <signal.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
@@ -220,8 +221,6 @@ LispPTR unix_username(LispPTR *args) {
  * The only usage seems to be checking "ARCH" == "dos" and for the existance
  * of *any* result from the call, which indicates it's an emulated system.
  */
-char *getenv(const char *);
-
 LispPTR unix_getparm(LispPTR *args) {
   char envname[20], result[128], *envvalue;
   if (lisp_string_to_c_string(args[0], envname, sizeof envname)) return NIL;

--- a/src/xmkicon.c
+++ b/src/xmkicon.c
@@ -43,7 +43,6 @@ Pixmap make_Xicon(DspInterface dsp)
 {
   unsigned int width, height;
   int value, x_hot, y_hot;
-  char *getenv();
 
 #ifdef TRACE
   printf("In make_Xicon().\n");

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -205,12 +205,12 @@ void read_Xoption(int *argc, char *argv[])
   if (*argc == 2) /* There was probably a sysoutarg */
   {
     (void)strcpy(sysout_name, argv[1]);
-  } else if ((envname = (char *)getenv("LDESRCESYSOUT")) != NULL) {
+  } else if ((envname = getenv("LDESRCESYSOUT")) != NULL) {
     strcpy(sysout_name, envname);
-  } else if ((envname = (char *)getenv("LDESOURCESYSOUT")) != NULL)
+  } else if ((envname = getenv("LDESOURCESYSOUT")) != NULL)
     strcpy(sysout_name, envname);
   else {
-    envname = (char *)getenv("HOME");
+    envname = getenv("HOME");
     (void)strcat(sysout_name, envname);
     (void)strcat(sysout_name, "/lisp.virtualmem");
 
@@ -231,7 +231,7 @@ void read_Xoption(int *argc, char *argv[])
     fprintf(stderr, "or provide a -display argument.\n");
     print_Xusage(argv[0]);
   } else {
-    envname = (char *)getenv("DISPLAY");
+    envname = getenv("DISPLAY");
     (void)strcpy(Display_Name, envname);
   }
   if ((xdisplay = XOpenDisplay(Display_Name)) != NULL) {
@@ -252,7 +252,7 @@ void read_Xoption(int *argc, char *argv[])
     exit(-1);
   }
 
-  envname = (char *)getenv("HOME");
+  envname = getenv("HOME");
   (void)strcat(tmp, envname);
   (void)strcat(tmp, "/.Xdefaults");
   if (access(tmp, R_OK) != 0) {


### PR DESCRIPTION
This also removes some casts to `char *` that were present but
not needed, since `getenv()` is defined to return `char *`.