### PR TITLE
Remove XWINDOWS define from FreeBSD, Linux, and macOS builds.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -247,7 +247,6 @@ typedef signed char s_char;
 #ifdef LINUX
 		/* LINUX, the free POSIX-compliant Unix */
 #define NOETHER 1
-#define XWINDOWS 1
 /* JDS trial 12/22/01 #define USETIMEFN 1 */
 
 #undef REGISTER
@@ -267,7 +266,6 @@ typedef signed char s_char;
 #if defined(MACOSX) || defined(FREEBSD)
 /* MacOS X, FreeBSD - mostly POSIX-compliant Unix */
 #define NOETHER 1
-#define XWINDOWS 1
 
 #undef REGISTER
 #define REGISTER


### PR DESCRIPTION
The right define is `XWINDOW` which is already defined via the
build system.