### PR TITLE
Don't use dirent's d_reclen as if it were d_namlen.

### DIFF
--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2648,7 +2648,7 @@ static int locate_file(char *dir, char *name)
   for (S_TOUT(dp = readdir(dirp)); dp != NULL || errno == EINTR;
        errno = 0, S_TOUT(dp = readdir(dirp)))
     if (dp) {
-      if (dp->d_reclen == len) {
+      if (strlen(dp->d_name) == len) {
         strcpy(nb2, dp->d_name);
         UPCASE(nb2);
         if (strcmp(nb1, nb2) == 0) {


### PR DESCRIPTION
This code was treating the `d_reclen` incorrectly from some of the
original old porting work. It is not the same as `d_namlen` and
`d_namlen` is not widely supported or standard. It should be using
`strlen(d_name)`.

This addresses an issue mentioned in interlisp/medley#103.