### PR TITLE
Simplify including sun/fbio.h.

### DIFF
--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -25,11 +25,7 @@
 #endif
 
 #ifdef USESUNSCREEN
-#ifdef OS5
 #include <sys/fbio.h>
-#else
-#include <sun/fbio.h>
-#endif /* OS5 */
 #endif /* USESUNSCREEN */
 
 #include "unixfork.h"


### PR DESCRIPTION
Both sides of this #ifdef were the same, so just collapse it.

This code isn't actually relevant any longer, but this removes
an OS-specific #ifdef, making inspection of platform specific
code a bit easier.