### PR TITLE
Remove bzero macro def and usages.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -289,8 +289,6 @@ typedef unsigned char u_char;
 typedef unsigned long u_int;
 typedef signed char s_char;
 typedef unsigned short u_short;
-	/* DOS doesn't have the BSD bzero &c functions */
-#define bzero(place,len) memset(place, 0, len)
 #undef UNALIGNED_FETCH_OK
 #undef HAS_GETHOSTID
 #undef REGISTER

--- a/src/Cldeetr.c
+++ b/src/Cldeetr.c
@@ -17,6 +17,7 @@
 #include "version.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -99,7 +100,7 @@ int main(int argc, char *argv[])
         perror("Couldn't GIFCONF socket; Net is off");
 #else  /* OS4 */
 
-      bzero(ifbuf, sizeof(ifbuf));
+      memset(ifbuf, 0, sizeof(ifbuf));
       {
         /* we have to get the interface name from another socket, since
         /dev/nit doesn't know anything until it gets bound, and we

--- a/src/ether.c
+++ b/src/ether.c
@@ -18,6 +18,7 @@
 #endif
 
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include <ctype.h>
 #ifndef DOS
@@ -850,7 +851,7 @@ void init_ether() {
         if_data.ifc_len = sizeof(ifbuf);
         if_data.ifc_req = ifbuf;
         /* 4.0 - before the SIOCGIFCONF, do:
-                bzero(ifbuf, sizeof(ifbuf))
+                memset(ifbuf, 0, sizeof(ifbuf))
         */
         if (ioctl(ether_fd, SIOCGIFCONF, &if_data) < 0) {
           perror("Couldn't GIFCONF socket; Net is off");
@@ -877,7 +878,7 @@ void init_ether() {
         }
         if_data.ifc_len = sizeof(ifbuf);
         if_data.ifc_req = ifbuf;
-        bzero(ifbuf, sizeof(ifbuf));
+        memset(ifbuf, 0, sizeof(ifbuf));
         {
           /* we have to get the interface name from another socket, since
                   /dev/nit doesn't know anything until it gets bound, and we
@@ -978,7 +979,7 @@ void init_ether() {
 
 #ifndef PKTFILTER
     /* establish the operating modes */
-    bzero(&nioc, sizeof(nioc));
+    memset(&nioc, 0, sizeof(nioc));
     nioc.nioc_bufspace = 20000;
     nioc.nioc_chunksize = 50; /* small chunks so each packet read */
     nioc.nioc_typetomatch = NT_ALLTYPES;

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -18,6 +18,7 @@ int main(int argc, char *argv[]) { return (0); }
 /* THERE -IS- AN ETHERNET */
 
 #include <stdio.h>
+#include <string.h>
 
 #ifdef USE_DLPI
 #include <sys/stream.h>
@@ -168,7 +169,7 @@ int main(int argc, char *argv[]) {
         perror("Couldn't GIFCONF socket; Net is off");
 #else  /* OS4 */
 
-      bzero(ifbuf, sizeof(ifbuf));
+      memset(ifbuf, 0, sizeof(ifbuf));
       {
         /* we have to get the interface name from another socket, since
         /dev/nit doesn't know anything until it gets bound, and we

--- a/src/oether.c
+++ b/src/oether.c
@@ -11,6 +11,7 @@
 #include "version.h"
 
 #include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #ifndef DOS
 #include <sys/file.h>
@@ -659,7 +660,7 @@ void init_ether() {
         if_data.ifc_len = sizeof(ifbuf);
         if_data.ifc_req = ifbuf;
         /* 4.0 - before the SIOCGIFCONF, do:
-                bzero(ifbuf, sizeof(ifbuf))
+                memset(ifbuf, 0, sizeof(ifbuf))
         */
         if (ioctl(ether_fd, SIOCGIFCONF, &if_data) < 0) {
           perror("Couldn't GIFCONF socket; Net is off");
@@ -686,7 +687,7 @@ void init_ether() {
         }
         if_data.ifc_len = sizeof(ifbuf);
         if_data.ifc_req = ifbuf;
-        bzero(ifbuf, sizeof(ifbuf));
+        memset(ifbuf, 0, sizeof(ifbuf));
         {
           /* we have to get the interface name from another socket, since
                   /dev/nit doesn't know anything until it gets bound, and we
@@ -783,7 +784,7 @@ if (ether_fd >= 0) {
 
 #ifndef OS4
   /* establish the operating modes */
-  bzero(&nioc, sizeof(nioc));
+  memset(&nioc, 0, sizeof(nioc));
   nioc.nioc_bufspace = 20000;
   nioc.nioc_chunksize = 50; /* small chunks so each packet read */
   nioc.nioc_typetomatch = NT_ALLTYPES;

--- a/src/oldeether.c
+++ b/src/oldeether.c
@@ -16,6 +16,7 @@ int main(int argc, char *argv[])
 #else
 
 #include <stdio.h>
+#include <string.h>
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/time.h>
@@ -97,7 +98,7 @@ int main(int argc, char *argv[])
         perror("Couldn't GIFCONF socket; Net is off");
 #else  /* OS4 */
 
-      bzero(ifbuf, sizeof(ifbuf));
+      memset(ifbuf, 0, sizeof(ifbuf));
       {
         /* we have to get the interface name from another socket, since
         /dev/nit doesn't know anything until it gets bound, and we


### PR DESCRIPTION
We can just use memset for bzero and we weren't using bcmp at all.