### PR TITLE
init_Xcursor takes Window, not int for window.

### DIFF
--- a/inc/xcursordefs.h
+++ b/inc/xcursordefs.h
@@ -4,6 +4,6 @@
 #include "devif.h"
 void Init_XCursor(void);
 void Set_XCursor(int x, int y);
-void init_Xcursor(Display *display, int window);
+void init_Xcursor(Display *display, Window window);
 void set_Xcursor(DspInterface dsp, unsigned char *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp);
 #endif

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -149,7 +149,7 @@ void Set_XCursor(int x, int y)
 /*									*/
 /************************************************************************/
 
-void init_Xcursor(Display *display, int window)
+void init_Xcursor(Display *display, Window window)
 {
   TPRINT(("TRACE: init_Xcursor()\n"));
 


### PR DESCRIPTION
`Window` is an X11 typedef for `unsigned long` (via `XID`). We should
pass it as that, not an `int`, to avoid 64 bit conversion issues.