### PR TITLE
Use `SEEK_SET` for third arg to `*seek()` functions.

### DIFF
--- a/src/imagefile2.c
+++ b/src/imagefile2.c
@@ -11,6 +11,7 @@
 #include "version.h"
 
 #include <stdio.h>
+#include <unistd.h>
 #include <pixrect/pixrect_hs.h>
 
 #define FALSE 0
@@ -132,7 +133,7 @@ int position_rasterfile(RASTERFILE_INFO *fileinfo, int n)
 
   if (n > 0) {
     position = sizeof(struct rasterfile) + (n - 1) * fileinfo->rh.ras_length;
-    if ((status = fseek(fileinfo->file, position, (int)0)) == 0) {
+    if ((status = fseek(fileinfo->file, position, SEEK_SET)) == 0) {
       /* normal return */
       return (TRUE);
     } /* end if( status ) */

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -110,7 +110,7 @@ int sysout_loader(char * sysout_file_name, int sys_size)
   }
 
   /* seek to IFPAGE */
-  if (lseek(sysout, IFPAGE_ADDRESS, 0) == -1) {
+  if (lseek(sysout, IFPAGE_ADDRESS, SEEK_SET) == -1) {
     perror("sysout_loader: can't seek to IFPAGE");
     exit(-1);
   }
@@ -249,7 +249,7 @@ int sysout_loader(char * sysout_file_name, int sys_size)
 #else
   fptovp_offset = (fptovp_offset - 1) * BYTESPER_PAGE + 2;
 #endif
-  if (lseek(sysout, fptovp_offset, 0) == -1) {
+  if (lseek(sysout, fptovp_offset, SEEK_SET) == -1) {
     perror("sysout_loader: can't seek to FPTOVP");
     exit(-1);
   }
@@ -311,7 +311,7 @@ int sysout_loader(char * sysout_file_name, int sys_size)
     }
 #endif /* DOS */
     if (GETPAGEOK(fptovp, i) != 0177777) {
-      if (lseek(sysout, i * BYTESPER_PAGE, 0) == -1) {
+      if (lseek(sysout, i * BYTESPER_PAGE, SEEK_SET) == -1) {
         perror("sysout_loader: can't seek sysout file");
         exit(-1);
       };

--- a/src/setsout.c
+++ b/src/setsout.c
@@ -60,7 +60,7 @@ void set_sysout(int version, char *sysout_file_name) {
     exit(-1);
   }
   /* seek to IFPAGE */
-  if (lseek(sysout, IFPAGE_ADDRESS, 0) == -1) {
+  if (lseek(sysout, IFPAGE_ADDRESS, SEEK_SET) == -1) {
     perror("sysout_loader: can't seek to IFPAGE");
     exit(-1);
   }
@@ -78,7 +78,7 @@ void set_sysout(int version, char *sysout_file_name) {
   ifpage.minbversion = version;
 
   /* seek to IFPAGE */
-  if (lseek(sysout, IFPAGE_ADDRESS, 0) == -1) {
+  if (lseek(sysout, IFPAGE_ADDRESS, SEEK_SET) == -1) {
     perror("sysout_loader: can't seek to IFPAGE");
     exit(-1);
   }

--- a/src/tstsout.c
+++ b/src/tstsout.c
@@ -55,7 +55,7 @@ void check_sysout(char *sysout_file_name, int verbose) {
     exit(-1);
   }
   /* seek to IFPAGE */
-  if (lseek(sysout, IFPAGE_ADDRESS, 0) == -1) {
+  if (lseek(sysout, IFPAGE_ADDRESS, SEEK_SET) == -1) {
     perror("sysout_loader: can't seek to IFPAGE");
     exit(-1);
   }

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -421,7 +421,7 @@ LispPTR vmem_save(char *sysout_file_name)
       int contig_pages = 0;
       register char *base_addr;
 
-      TIMEOUT(rval = lseek(sysout, i * BYTESPER_PAGE, 0));
+      TIMEOUT(rval = lseek(sysout, i * BYTESPER_PAGE, SEEK_SET));
       if (rval == -1) {
         err_mess("lseek", errno);
         return (FILECANNOTSEEK);
@@ -472,7 +472,7 @@ LispPTR vmem_save(char *sysout_file_name)
   }
 
   /* seek to IFPAGE */
-  TIMEOUT(rval = lseek(sysout, (long)FP_IFPAGE, 0));
+  TIMEOUT(rval = lseek(sysout, (long)FP_IFPAGE, SEEK_SET));
   if (rval == -1) {
     err_mess("lseek", errno);
     return (FILECANNOTSEEK);


### PR DESCRIPTION
Instead of sometimes passing `0` to `lseek` and friends, we should
use the standard symbolic constant `SEEK_SET`.