### PR TITLE
fcntl(..., F_SETFL, ...) return value only signals error.

### DIFF
--- a/src/Cldeetr.c
+++ b/src/Cldeetr.c
@@ -142,7 +142,7 @@ int main(int argc, char *argv[])
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
       flags = fcntl(ether_fd, F_GETFL, 0);
-      flags = fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
 
 #ifdef DEBUG
       printf("init_ether: **** Ethernet starts ****\n");

--- a/src/chardev.c
+++ b/src/chardev.c
@@ -78,7 +78,6 @@ LispPTR CHAR_openfile(LispPTR *args)
 #ifndef DOS
   register int fd;    /* return value  of open system call. */
   register int flags; /* open system call's argument */
-  register int rval;
   struct stat statbuf;
   char pathname[MAXPATHLEN];
 
@@ -104,9 +103,7 @@ LispPTR CHAR_openfile(LispPTR *args)
   }
   /* Prevent I/O requests from blocking -- make them error */
   /* if no char is available, or there's no room in pipe.  */
-  rval = fcntl(fd, F_GETFL, 0);
-  rval |= FNDELAY;
-  rval = fcntl(fd, F_SETFL, rval);
+  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | FNDELAY);
 
   return (GetSmallp(fd));
 #endif /* DOS */

--- a/src/ether.c
+++ b/src/ether.c
@@ -823,7 +823,7 @@ void init_ether() {
         }
 
         flags = fcntl(ether_fd, F_GETFL, 0);
-        flags = fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
+        fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
 
       } else {
       I_Give_Up:

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -130,7 +130,7 @@ int main(int argc, char *argv[]) {
       }
 
       flags = fcntl(ether_fd, F_GETFL, 0);
-      flags = fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
+      fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
 
 #else
 /*    N O T   D L P I   C O D E   */
@@ -211,7 +211,7 @@ int main(int argc, char *argv[]) {
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
       flags = fcntl(ether_fd, F_GETFL, 0);
-      flags = fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
 
 #endif /* USE_DLPI  */
 #ifdef DEBUG

--- a/src/oldeether.c
+++ b/src/oldeether.c
@@ -140,7 +140,7 @@ int main(int argc, char *argv[])
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
       flags = fcntl(ether_fd, F_GETFL, 0);
-      flags = fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
 
 #ifdef DEBUG
       printf("init_ether: **** Ethernet starts ****\n");

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -149,7 +149,7 @@ gotpty:
 #ifdef LOGINT
   LogFileFd = cons_pty; /* was kept as an fd_set, but doesn't need to be */
   flags = fcntl(cons_pty, F_GETFL, 0);
-  flags = fcntl(cons_pty, F_SETFL, (flags | FASYNC | FNDELAY));
+  fcntl(cons_pty, F_SETFL, (flags | FASYNC | FNDELAY));
   if (fcntl(cons_pty, F_SETOWN, getpid()) == -1) {
 #ifdef DEBUG
     perror("fcntl F_SETOWN of log PTY");

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -225,7 +225,7 @@ of the packet received except:
 int fork_Unix() {
   int LispToUnix[2], /* Incoming pipe from LISP */
       UnixToLisp[2], /* Outgoing pipe to LISP */
-      UnixPID, LispPipeIn, LispPipeOut, res, slot;
+      UnixPID, LispPipeIn, LispPipeOut, flags, slot;
   pid_t pid;
 
   char IOBuf[4];
@@ -292,9 +292,9 @@ int fork_Unix() {
   close(LispToUnix[1]);
   close(UnixToLisp[0]);
 
-  res = fcntl(LispPipeIn, F_GETFL, 0);
-  res &= (65535 - FNDELAY);
-  res = fcntl(LispPipeIn, F_SETFL, res);
+  flags = fcntl(LispPipeIn, F_GETFL, 0);
+  flags &= (65535 - FNDELAY);
+  fcntl(LispPipeIn, F_SETFL, flags);
 
   while (1) {
     ssize_t len;


### PR DESCRIPTION
The return value of `fcntl` when passed `F_SETFL` isn't guaranteed
to return the flags passed in as its return value. It will be `-1`
in the event of an error, but no other value is to be relied upon.

Fortunately, we weren't relying upon the value apart from
occasionally checking for an error.

This is as it is specified in https://pubs.opengroup.org/onlinepubs/7908799/xsh/fcntl.html

Closes interlisp/medley#87.