### PR TITLE
Remove USETIMEFN define.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -252,7 +252,6 @@ typedef signed char s_char;
 #ifdef LINUX
 		/* LINUX, the free POSIX-compliant Unix */
 #define NOETHER 1
-/* JDS trial 12/22/01 #define USETIMEFN 1 */
 
 #undef REGISTER
 #define REGISTER


### PR DESCRIPTION
In the past, we didn't use `gettimeofday()` on all non-DOS platforms
because it wasn't available, so we had to fall back to `time()`.
Those days are long gone and we have `gettimeofday()` on all non-DOS
platforms.

This also removes some code that used `times()` when it used `time()`.
This leaves us using `getrusage()` on all non-DOS platforms. This,
much like `gettimeofday()`, is now available everywhere. Not all of
the fields used here are guaranteed by POSIX, but the ones used
here shouldn't be an issue for now.