### PR TITLE
Update fcntl F_SETFL usage.

### DIFF
--- a/src/Cldeetr.c
+++ b/src/Cldeetr.c
@@ -50,7 +50,6 @@ int main(int argc, char *argv[])
 {
   char Earg[30], Ename[30], **newargv;
   int i;
-  int flags;
   /* Kickstart program for the Lisp Development Environment (LDE).
           Run this as setuid root to open the LDE ether socket.
           Passes all arguments through to LDE plus -E <ether-info>
@@ -141,8 +140,7 @@ int main(int argc, char *argv[])
       bcopy(if_data.ifc_req[0].ifr_addr.sa_data, ether_host, 6);
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
-      flags = fcntl(ether_fd, F_GETFL, 0);
-      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
 
 #ifdef DEBUG
       printf("init_ether: **** Ethernet starts ****\n");

--- a/src/chardev.c
+++ b/src/chardev.c
@@ -84,7 +84,7 @@ LispPTR CHAR_openfile(LispPTR *args)
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[2]));
 
   LispStringToCString(args[0], pathname, MAXPATHLEN);
-  flags = O_NDELAY;
+  flags = O_NONBLOCK;
   ERRSETJMP(NIL);
   /*    TIMEOUT( rval=stat(pathname, &statbuf) );
       if(rval == 0){      } */
@@ -103,7 +103,7 @@ LispPTR CHAR_openfile(LispPTR *args)
   }
   /* Prevent I/O requests from blocking -- make them error */
   /* if no char is available, or there's no room in pipe.  */
-  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | FNDELAY);
+  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_NONBLOCK);
 
   return (GetSmallp(fd));
 #endif /* DOS */

--- a/src/ether.c
+++ b/src/ether.c
@@ -779,7 +779,6 @@ void init_ether() {
      differences are in commented-out code below
       (not ifdefed because they're untested...)
   */
-  int flags;
   struct strioctl si;
   unsigned long snaplen = 0;
 
@@ -822,8 +821,7 @@ void init_ether() {
           return;
         }
 
-        flags = fcntl(ether_fd, F_GETFL, 0);
-        fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
+        fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_NONBLOCK);
 
       } else {
       I_Give_Up:
@@ -858,7 +856,7 @@ void init_ether() {
 #else  /* OS4 */
 
     if (getuid() != geteuid()) {
-      if ((ether_fd = open("/dev/nit", O_RDWR | FASYNC)) >= 0) {
+      if ((ether_fd = open("/dev/nit", O_RDWR | O_ASYNC)) >= 0) {
         /* it's open, now query it and find out its name and address */
         /* JRB - must document that LDE uses the first net board as
            found by SIOCGIFCONF (see if(4)).  Maybe we need an option
@@ -1020,7 +1018,7 @@ void init_ether() {
 #endif /* USE_DLPI */
 #endif /* PKTFILTER -- jds 23 sep 96 unmatched if fix */
 #ifndef PKTFILTER
-    if (fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | FASYNC | FNDELAY) < 0)
+    if (fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_ASYNC | O_NONBLOCK) < 0)
       perror("Ether setup SETFLAGS fcntl");
     if (fcntl(ether_fd, F_SETOWN, getpid()) < 0) perror("Ether setup SETOWN");
 #else /* PKTFILTER */

--- a/src/inet.c
+++ b/src/inet.c
@@ -28,6 +28,11 @@
 #include <unistd.h>
 #endif /* DOS */
 
+#ifdef OS5
+/* Solaris doesn't define O_ASYNC, yet still defines FASYNC. */
+#define O_ASYNC FASYNC
+#endif
+
 #include "lispemul.h"
 #include "lispmap.h"
 #include "lsptypes.h"
@@ -106,7 +111,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
       addr_class = LispNumToCInt(nameConn);
       protocol = LispNumToCInt(proto);
       result = socket(addr_class, protocol, 0);
-      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | FNDELAY | FASYNC);
+      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
       fcntl(result, F_SETOWN, getpid());
 
       return (GetSmallp(result));
@@ -130,7 +135,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
         perror("TCP connect");
         return (NIL);
       }
-      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | FNDELAY);
+      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | O_NONBLOCK);
       fcntl(result, F_SETOWN, getpid());
 
       return (GetSmallp(result));
@@ -203,7 +208,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
         int oldmask = sigblock(sigmask(SIGIO));
 #endif /* SYSVSIGNALS */
 
-        fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | FNDELAY | FASYNC);
+        fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
         fcntl(result, F_SETOWN, getpid());
 
         if (listen(result, 5) == -1) {
@@ -236,7 +241,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
         if (errno != EWOULDBLOCK) perror("TCP Accept");
         return (NIL);
       }
-      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | FNDELAY);
+      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | O_NONBLOCK);
       fcntl(result, F_SETOWN, getpid());
 
       return (GetSmallp(result));
@@ -274,7 +279,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
         close(result);
         return (NIL);
       }
-      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | FNDELAY | FASYNC);
+      fcntl(result, F_SETFL, fcntl(result, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
       fcntl(result, F_SETOWN, getpid());
 
       FD_SET(result, &LispIOFds);  /* so we get interrupts */

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -335,7 +335,7 @@ void init_display2(DLword *display_addr, int display_max)
 /* int_io_open(LispWindowFd);  JDS 4/27/94 move to initkbd, to try preventing the
  * move-mouse-never-get-kbd bug */
 #endif
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | FNDELAY);
+    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
   }
 #endif /* SUNDISPLAY */
 

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -76,7 +76,6 @@ char filetorun[30] = "lde";
 int main(int argc, char *argv[]) {
   char Earg[30], Ename[30], **newargv;
   int i;
-  int flags;
 #ifdef USE_DLPI
   static struct packetfilt pf = {0, 1, {ENF_PUSHZERO}};
   struct strioctl si;
@@ -129,8 +128,7 @@ int main(int argc, char *argv[]) {
         return (-1);
       }
 
-      flags = fcntl(ether_fd, F_GETFL, 0);
-      fcntl(ether_fd, F_SETFL, flags | O_NDELAY);
+      fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_NONBLOCK);
 
 #else
 /*    N O T   D L P I   C O D E   */
@@ -210,8 +208,7 @@ int main(int argc, char *argv[]) {
       bcopy(if_data.ifc_req[0].ifr_addr.sa_data, ether_host, 6);
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
-      flags = fcntl(ether_fd, F_GETFL, 0);
-      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
 
 #endif /* USE_DLPI  */
 #ifdef DEBUG

--- a/src/ocr.c
+++ b/src/ocr.c
@@ -408,9 +408,9 @@ int doblock;
   if (flags < 0) return 0;
 
   if (doblock) {
-    flags &= ~FNDELAY;
+    flags &= ~O_NONBLOCK;
   } else {
-    flags |= FNDELAY;
+    flags |= O_NONBLOCK;
   }
 
   if (fcntl(fd, F_SETFL, flags) < 0) return 0;

--- a/src/ocrproc.c
+++ b/src/ocrproc.c
@@ -317,7 +317,7 @@ static int ocr_init_sv() {
     perror("ocr_init_sv: fcntl");
     return 0;
   }
-  flags &= ~FNDELAY;
+  flags &= ~O_NONBLOCK;
   if (fcntl(OCR_sv, F_SETFL, flags) < 0) {
     perror("ocr_init_sv: fcntl 2");
     return 0;

--- a/src/oether.c
+++ b/src/oether.c
@@ -667,7 +667,7 @@ void init_ether() {
 #else  /* OS4 */
 
     if (getuid() != geteuid()) {
-      if ((ether_fd = open("/dev/nit", O_RDWR | FASYNC)) >= 0) {
+      if ((ether_fd = open("/dev/nit", O_RDWR | O_ASYNC)) >= 0) {
         /* it's open, now query it and find out its name and address */
         /* JRB - must document that LDE uses the first net board as
            found by SIOCGIFCONF (see if(4)).  Maybe we need an option
@@ -808,7 +808,7 @@ if (ether_fd >= 0) {
   }
 #ifndef OS4
   EtherReadFds |= (1 << ether_fd);
-  if (fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | FASYNC | FNDELAY) < 0)
+  if (fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_ASYNC | O_NONBLOCK) < 0)
     perror("Ether setup SETFLAGS fcntl");
   if (fcntl(ether_fd, F_SETOWN, getpid()) < 0) perror("Ether setup SETOWN");
 #else  /* OS4 */

--- a/src/oldeether.c
+++ b/src/oldeether.c
@@ -48,7 +48,6 @@ int main(int argc, char *argv[])
 {
   char Earg[30], Ename[30], **newargv;
   int i;
-  int flags;
   /* Kickstart program for the Lisp Development Environment (LDE).
           Run this as setuid root to open the LDE ether socket.
           Passes all arguments through to LDE plus -E <ether-info>
@@ -139,8 +138,7 @@ int main(int argc, char *argv[])
       bcopy(if_data.ifc_req[0].ifr_addr.sa_data, ether_host, 6);
       strcpy(Ename, if_data.ifc_req[0].ifr_name);
 
-      flags = fcntl(ether_fd, F_GETFL, 0);
-      fcntl(ether_fd, F_SETFL, flags | FASYNC | FNDELAY);
+      fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
 
 #ifdef DEBUG
       printf("init_ether: **** Ethernet starts ****\n");

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -85,7 +85,7 @@ void mess_init() {
   int ttyfd;
   int ptyfd, ptynum;
   char *ptyname, *ttyname;
-  int temp, flags;
+  int temp;
   int on = 1;
 
   ptyname = "/dev/ptypx";
@@ -148,8 +148,7 @@ gotpty:
   if ((log_id = open(logfile, (O_RDWR | O_CREAT), 0666)) < 0) return;
 #ifdef LOGINT
   LogFileFd = cons_pty; /* was kept as an fd_set, but doesn't need to be */
-  flags = fcntl(cons_pty, F_GETFL, 0);
-  fcntl(cons_pty, F_SETFL, (flags | FASYNC | FNDELAY));
+  fcntl(cons_pty, F_SETFL, fcntl(cons_pty, F_GETFL, 0) | O_ASYNC | O_NONBLOCK);
   if (fcntl(cons_pty, F_SETOWN, getpid()) == -1) {
 #ifdef DEBUG
     perror("fcntl F_SETOWN of log PTY");

--- a/src/testdsp.c
+++ b/src/testdsp.c
@@ -89,7 +89,7 @@ void init_display2(int display_addr, int display_max)
 #ifdef KBINT
     int_io_open(LispWindowFd);
 #endif
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | FNDELAY);
+    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
   }
 
   DisplayRegion68k = (short *)display_addr;

--- a/src/timer.c
+++ b/src/timer.c
@@ -546,7 +546,7 @@ void int_io_open(int fd)
     perror("fcntl F_SETOWN ERROR");
 #endif
   };
-  if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | FASYNC) == -1) perror("fcntl F_SETFL error");
+  if (fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) | O_ASYNC) == -1) perror("fcntl F_SETFL error");
 #endif
 }
 
@@ -555,7 +555,7 @@ void int_io_close(int fd)
 #ifdef DOS
 /* Turn off signaller here */
 #elif KBINT
-  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~FASYNC);
+  fcntl(fd, F_SETFL, fcntl(fd, F_GETFL, 0) & ~O_ASYNC);
 #endif
 }
 

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -225,7 +225,7 @@ of the packet received except:
 int fork_Unix() {
   int LispToUnix[2], /* Incoming pipe from LISP */
       UnixToLisp[2], /* Outgoing pipe to LISP */
-      UnixPID, LispPipeIn, LispPipeOut, flags, slot;
+      UnixPID, LispPipeIn, LispPipeOut, slot;
   pid_t pid;
 
   char IOBuf[4];
@@ -292,9 +292,7 @@ int fork_Unix() {
   close(LispToUnix[1]);
   close(UnixToLisp[0]);
 
-  flags = fcntl(LispPipeIn, F_GETFL, 0);
-  flags &= (65535 - FNDELAY);
-  fcntl(LispPipeIn, F_SETFL, flags);
+  fcntl(LispPipeIn, F_SETFL, fcntl(LispPipeIn, F_GETFL, 0) & ~O_NONBLOCK);
 
   while (1) {
     ssize_t len;

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -1185,7 +1185,7 @@ static int re_init_display(int lisp_display_addr, int display_max)
   } else {
 #ifdef KBINT
     int_io_open(LispWindowFd);
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | FNDELAY);
+    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
 
 #ifdef FX_AR_124
     /* For AR 124. Type4 driver bug?? by m.matsuda */
@@ -1297,7 +1297,7 @@ static int re_init_display(int lisp_display_addr, int display_max)
   } else {
 #ifdef KBINT
     int_io_open(LispWindowFd);
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | FNDELAY);
+    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
 #endif
   }
 


### PR DESCRIPTION
This changes from `FASYNC` to `O_ASYNC`, `FNDELAY` to `O_NONBLOCK`,
and `O_NDELAY` to `O_NONBLOCK`. These are the modern names.

`O_NONBLOCK` is part of the POSIX standard. However, `O_ASYNC` is
specific to Linux and BSD. It is not available on Solaris, where
the `I_SETSIG` `ioctl` should be used instead, or things should
be done some other way, with `poll()` or the like. Also, the
behavior of having I/O trigger a `SIGIO` signal is not in POSIX,
since the `SIGIO` signal is not in POSIX. Instead, it is only
the behavior of having `SIGURG` being signalled for out of band
data that is specified.

We also takes this opportunity to collapse some multi-line calls
to get the flags, store it into a temp, and then set them, to
just doing it in one line, skipping the stored temporary value.

We also change one instance of `65535 - FNDELAY` to `~O_NONBLOCK`.

Closes interlisp/medley#85.