### PR TITLE
Fix makefile fragment for linux on arm

### DIFF
--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,4 +1,4 @@
-# Options for Linux, Intel 386/486 and X-Window
+# Options for Linux, ARMv7 and X-Window
 
 #CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
 CC = clang -m32 $(CLANG_CFLAGS)

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,7 +1,8 @@
 # Options for Linux, ARMv7 and X-Window
 
-#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
+#CC = gcc $(GCC_CFLAGS)
 CC = clang -m32 $(CLANG_CFLAGS)
+
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \
 	$(OBJECTDIR)dspif.o \
@@ -11,7 +12,6 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xlspwin.o \
 	$(OBJECTDIR)xrdopt.o \
 	$(OBJECTDIR)xwinman.o
-
 
 XFLAGS = -DXWINDOW -DNOPIXRECT
 

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,7 +1,7 @@
 # Options for Linux, ARMv7 and X-Window
 
 #CC = gcc $(GCC_CFLAGS)
-CC = clang -m32 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -1,7 +1,7 @@
 # Options for Linux, ARMv7 and X-Window
 
-#CC = gcc $(GCC_CFLAGS)
-CC = clang $(CLANG_CFLAGS)
+CC = gcc $(GCC_CFLAGS)
+#CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \


### PR DESCRIPTION
Clean up compiler flags and switch from clang to gcc as the default compiler.
Neither clang nor gcc on arm appear to recognize the -m32 flag.