### PR TITLE
REGISTER is for floats.

### DIFF
--- a/src/lsthandl.c
+++ b/src/lsthandl.c
@@ -91,7 +91,7 @@ LispPTR fmemb(register LispPTR item, register LispPTR list) {
   }
 
 LispPTR N_OP_listget(register LispPTR plist, register LispPTR tos) {
-  REGISTER struct cadr_cell cadrobj;
+  struct cadr_cell cadrobj;
 
   while (plist != NIL_PTR) {
     S_N_CHECKANDCADR2(plist, cadrobj, tos, plist);

--- a/src/vars3.c
+++ b/src/vars3.c
@@ -143,7 +143,7 @@ N_OP_assoc
 *******************************************/
 
 LispPTR N_OP_assoc(register LispPTR key, register LispPTR list) {
-  REGISTER struct cadr_cell cadr1;
+  struct cadr_cell cadr1;
   register LispPTR cdr; /* address of (cdr A-list); Lisp address */
 
   if (list == NIL_PTR) { return (NIL_PTR); }

--- a/src/z2.c
+++ b/src/z2.c
@@ -45,7 +45,7 @@
 
 /*   N_OP_classoc()  OP 33Q  */
 LispPTR N_OP_classoc(LispPTR key, LispPTR list) {
-  REGISTER struct cadr_cell cadr1;
+  struct cadr_cell cadr1;
   register LispPTR cdrcell; /* address of (cdr A-list); Lisp address */
 
   switch (key & SEGMASK) {


### PR DESCRIPTION
According to `inc/version.h`, `REGISTER` is for floats which may
or may not be able to be in registers due to the `FPTEST` macro
implementation. We shouldn't be using it here for non-float
data.