### PR TITLE
`killpg` is POSIX, so we can rely on it now.

### DIFF
--- a/src/timer.c
+++ b/src/timer.c
@@ -912,13 +912,8 @@ and do a 'v' before trying anything else.";
     case SIGHUP:
       sprintf(errormsg, "HANGUP signalled (code %d) at address %p.\n%s", code, addr, stdmsg);
 /* Assume that a user tried to exit UNIX shell */
-#ifdef SYSVONLY
-      kill(0, SIGKILL);
-      exit(0);
-#else
       killpg(getpgrp(), SIGKILL);
       exit(0);
-#endif /* SYSVONLY */
       break;
 #endif /* SIGHUP */
     case SIGFPE:

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -803,18 +803,8 @@ LispPTR Unix_handlecomm(LispPTR *args) {
         /* Change window size, then
            notify process group of the change */
         if ((ioctl(pty, TIOCSWINSZ, &w) >= 0) &&
-#ifdef ISC
-            (tcgetpgrp(pty) >= 0) &&
-#else
-            (ioctl(pty, TIOCGPGRP, &pgrp) >= 0) &&
-#endif /* ISC */
-
-#ifdef SYSVONLY
-            (kill(-pgrp, SIGWINCH) >= 0))
-#else
+            ((pgrp = tcgetpgrp(pty)) >= 0) &&
             (killpg(pgrp, SIGWINCH) >= 0))
-#endif /* SYSVONLY */
-
           return (ATOM_T);
         return (GetSmallp(errno));
       }

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -344,11 +344,7 @@ LispPTR suspend_lisp(LispPTR *args) {
 /* Send a terminal-stop signal to the whole process-group, not
    just this process, so that if we are running as part of a
    C-shell file the shell will be suspended too. */
-#ifdef SYSVONLY
-  kill(0, SIGTSTP);
-#else
   killpg(getpgrp(), SIGTSTP);
-#endif /* SYSVONLY */
 
   OSMESSAGE_PRINT(printf("resuming\n"));
   device_after_raid();


### PR DESCRIPTION
This removes some usages of the SYSVONLY flag and lets us assume
the existence of `killpg`. It also updates a bit of code to accurately
populate the `pgrp` variable using `tcgetpgrp` rather than an ioctl.