### PR TITLE
Cygwin doesn't have O_ASYNC, so fix compilation.

### DIFF
--- a/src/inet.c
+++ b/src/inet.c
@@ -28,8 +28,8 @@
 #include <unistd.h>
 #endif /* DOS */
 
-#ifdef OS5
-/* Solaris doesn't define O_ASYNC, yet still defines FASYNC. */
+#if (defined(OS5) || defined(__CYGWIN__)) && !defined(O_ASYNC)
+/* Cygwin and Solaris don't define O_ASYNC, yet still define FASYNC. */
 #define O_ASYNC FASYNC
 #endif
 


### PR DESCRIPTION
It looks like Cygwin doesn't actually support signal-based I/O,
so while this compiles, it won't be correct and will need
addressing in another way.