### PR TITLE
Switch to using POSIX pseudoterminals.

### DIFF
--- a/inc/unixfork.h
+++ b/inc/unixfork.h
@@ -1,7 +1,2 @@
 int fork_Unix(void);
-#ifdef FULLSLAVENAME
 int ForkUnixShell(int slot, char *PtySlave, char *termtype, char *shellarg);
-#else
-int ForkUnixShell(int slot, char ltr, char numb, char *termtype, char *shellarg);
-#endif
-


### PR DESCRIPTION
Previously, we were using SysV pseudo-terminals on Solaris and BSD
pseudo-terminals on other Unix platforms. BSD pseudo-terminals have
been deprecated on Linux and are no longer available in some kernel
configurations.

The POSIX API is basically the same as the SysV API, apart from using
`posix_openpt` instead of `open` with `/dev/ptmx`.

Closes interlisp/medley#121.