### PR TITLE
Clean up some mixed sign issues

### DIFF
--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -493,7 +493,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 #define	MAXVERSION		999999999
 
-#define	LASTVERSIONARRAY	0xFFFFFFFF
+#define	LASTVERSIONARRAY	-1
 #define	VERSIONARRAYLENGTH	200
 
 #define NoFileP(varray)						\

--- a/src/dir.c
+++ b/src/dir.c
@@ -285,7 +285,7 @@ FINFO *FreeFinfoList;
 DFINFO *FinfoArray;
 #define INITFINFOARRAY 32
 
-unsigned MAXFINFO;
+int MAXFINFO;
 
 #define FINFOARRAYRSIZE 16
 


### PR DESCRIPTION
LASTVERSIONARRAY, the marker value indicating the last entry, can be an int value as it is only compared to the int version_no field in a struct filename_entry.

MAXFINFO is the number of elements in the file info array -- doesn't need to be unsigned, and is used in signed contexts (it could be ssize_t, but we're not generally using that yet).