### PR TITLE
Pass correct sockaddr size to bind.

### DIFF
--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -789,7 +789,7 @@ LispPTR Unix_handlecomm(LispPTR *args) {
 
       sock.sun_family = AF_UNIX;
       strcpy(sock.sun_path, shcom);
-      if (bind(sockFD, (struct sockaddr *)&sock, strlen(shcom) + sizeof(sock.sun_family)) < 0) {
+      if (bind(sockFD, (struct sockaddr *)&sock, sizeof(struct sockaddr_un)) < 0) {
         close(sockFD);
         free(UJ[sockFD].pathname);
         UJ[sockFD].type = UJUNUSED;


### PR DESCRIPTION
We should be passing the size of the `struct sockaddr_un`, not
the length of the path + the size of the path field.

There is another `bind` call in this file that had it right.