### PR TITLE
Change lisp_string_to_c_string length parameter to be size_t

### DIFF
--- a/inc/uutilsdefs.h
+++ b/inc/uutilsdefs.h
@@ -1,6 +1,6 @@
 #ifndef UUTILSDEFS_H
 #define UUTILSDEFS_H 1
-int lisp_string_to_c_string(LispPTR Lisp, char *C, int length);
+int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length);
 int c_string_to_lisp_string(char *C, LispPTR Lisp);
 LispPTR check_unix_password(LispPTR *args);
 LispPTR unix_username(LispPTR *args);

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -50,7 +50,7 @@
 /*									*/
 /************************************************************************/
 
-int lisp_string_to_c_string(LispPTR Lisp, char *C, int length) {
+int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length) {
   register OneDArray *arrayp;
   register char *base;
 
@@ -95,7 +95,7 @@ int lisp_string_to_c_string(LispPTR Lisp, char *C, int length) {
 int c_string_to_lisp_string(char *C, LispPTR Lisp) {
   register OneDArray *arrayp;
   char *base;
-  register int length;
+  register size_t length;
 
   length = strlen(C);
   if (GetTypeNumber(Lisp) != TYPE_ONED_ARRAY) { return (-1); }
@@ -111,7 +111,7 @@ int c_string_to_lisp_string(char *C, LispPTR Lisp) {
       strcpy(base, C);
 #else
       {
-        register int i;
+        register size_t i;
         register char *dp;
         for (i = 0, dp = C; i < length + 1; i++) {
           int ch = *dp++;


### PR DESCRIPTION
The argument passed to the length parameter of lisp_string_to_c_string is
always the sizeof an array, and since it is compared to the Lisp unsigned
length of the Lisp string is more appropriately a size_t than an int.
Likewise for the index into a string.