### PR TITLE
Remove REGISTER define.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -167,7 +167,6 @@ error Must specify RELEASE to build Medley.
 	/*								*/
 	/*  Defaults:	Unaligned fetches OK	UNALIGNED_FETCH_OK	*/
 	/*		fp values used with				*/
-	/*		FPTEST can be in regs.	REGISTER		*/
 	/*		Use asm inline arith	USE_INLINE_ARITH	*/
 	/*		pointer-wide unsigned	UNSIGNED		*/
 	/*		pointer-wide int	INT	 		*/
@@ -206,7 +205,6 @@ error Must specify RELEASE to build Medley.
 	/* Set up defaults */
 #define NOETHER 1
 #define UNALIGNED_FETCH_OK
-#define REGISTER register
 #define HAS_GETHOSTID
 #define UNSIGNED unsigned long
 #define INT long
@@ -253,9 +251,6 @@ typedef signed char s_char;
 	/********************************************************/
 #ifdef LINUX
 		/* LINUX, the free POSIX-compliant Unix */
-#undef REGISTER
-#define REGISTER
-
 typedef signed char s_char;
 
 #undef UNALIGNED_FETCH_OK
@@ -269,9 +264,6 @@ typedef signed char s_char;
 /********************************************************/
 #if defined(MACOSX) || defined(FREEBSD)
 /* MacOS X, FreeBSD - mostly POSIX-compliant Unix */
-#undef REGISTER
-#define REGISTER
-
 typedef signed char s_char;
 #endif /* MACOSX || FREEBSD */
 
@@ -294,8 +286,6 @@ typedef signed char s_char;
 typedef unsigned short u_short;
 #undef UNALIGNED_FETCH_OK
 #undef HAS_GETHOSTID
-#undef REGISTER
-#define REGISTER
 #define SYSVSIGNALS 1
 #define USHORT unsigned
 #else

--- a/src/fp.c
+++ b/src/fp.c
@@ -48,10 +48,10 @@
 /************************************************************************/
 
 LispPTR N_OP_fplus2(LispPTR parg1, LispPTR parg2) {
-  REGISTER float arg1;
-  REGISTER float arg2;
-  REGISTER float result;
-  register DLword *wordp;
+  float arg1;
+  float arg2;
+  float result;
+  DLword *wordp;
 
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
@@ -75,9 +75,9 @@ LispPTR N_OP_fplus2(LispPTR parg1, LispPTR parg2) {
 /************************************************************************/
 
 LispPTR N_OP_fdifference(LispPTR parg1, LispPTR parg2) {
-  REGISTER float arg1, arg2;
-  REGISTER float result;
-  register DLword *wordp;
+  float arg1, arg2;
+  float result;
+  DLword *wordp;
 
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
@@ -101,9 +101,9 @@ LispPTR N_OP_fdifference(LispPTR parg1, LispPTR parg2) {
 /************************************************************************/
 
 LispPTR N_OP_ftimes2(LispPTR parg1, LispPTR parg2) {
-  REGISTER float arg1, arg2;
-  REGISTER float result;
-  register DLword *wordp;
+  float arg1, arg2;
+  float result;
+  DLword *wordp;
 
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
@@ -127,9 +127,9 @@ LispPTR N_OP_ftimes2(LispPTR parg1, LispPTR parg2) {
 /************************************************************************/
 
 LispPTR N_OP_fquotient(LispPTR parg1, LispPTR parg2) {
-  REGISTER float arg1, arg2;
-  REGISTER float result;
-  register DLword *wordp;
+  float arg1, arg2;
+  float result;
+  DLword *wordp;
 
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
@@ -154,7 +154,7 @@ LispPTR N_OP_fquotient(LispPTR parg1, LispPTR parg2) {
 /************************************************************************/
 
 LispPTR N_OP_fgreaterp(LispPTR parg1, LispPTR parg2) {
-  REGISTER float arg1, arg2;
+  float arg1, arg2;
 
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);

--- a/src/ubf2.c
+++ b/src/ubf2.c
@@ -32,7 +32,7 @@
 354/9	AREF
 ***********************************************************/
 LispPTR N_OP_ubfloat2(int a2, int a1, int alpha) {
-  REGISTER float arg1, arg2;
+  float arg1, arg2;
   float ans;
   int ret;
 

--- a/src/ubf3.c
+++ b/src/ubf3.c
@@ -26,10 +26,10 @@
 ***********************************************************/
 
 LispPTR N_OP_ubfloat3(int arg3, LispPTR arg2, LispPTR arg1, int alpha) {
-  REGISTER float val;
-  REGISTER float ans;
-  REGISTER float *fptr;
-  register int degree;
+  float val;
+  float ans;
+  float *fptr;
+  int degree;
   int ret;
   float flot;
 


### PR DESCRIPTION
This was used to indicate that the value was allowed to live
in a register. Compilers are much better now and can handle
this themselves.

This helps get rid of more platform-specific ifdef-ery.