### PR TITLE
Remove I386-only, undefined macro usages: I386Round, I386Reset.

### DIFF
--- a/inc/my.h
+++ b/inc/my.h
@@ -56,8 +56,8 @@
 	}								\
 }
 #else
-#define	N_MakeFloat(arg, dest, tos){		I386Reset;		\
-	switch (SEGMASK & (int)arg) {				\
+#define	N_MakeFloat(arg, dest, tos){					\
+	switch (SEGMASK & (int)arg) {					\
 	case S_POSITIVE:						\
 		dest = (float)(0xFFFF & (int)arg);			\
 		break;							\
@@ -66,7 +66,7 @@
 		break;							\
 	default:							\
 		switch (GetTypeNumber(arg)) {				\
-		  case TYPE_FLOATP: 	I386Reset;				\
+		  case TYPE_FLOATP: 					\
 		    dest = *((float *)Addr68k_from_LADDR(arg));		\
 		    break; 						\
 		  case TYPE_FIXP: 					\

--- a/src/fp.c
+++ b/src/fp.c
@@ -56,9 +56,6 @@ LispPTR N_OP_fplus2(LispPTR parg1, LispPTR parg2) {
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
   FPCLEAR;
-#ifdef I386
-  I386Round;
-#endif
   result = arg1 + arg2;
   if (FPTEST(result)) ERROR_EXIT(parg2);
   wordp = createcell68k(TYPE_FLOATP);
@@ -82,9 +79,6 @@ LispPTR N_OP_fdifference(LispPTR parg1, LispPTR parg2) {
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
   FPCLEAR;
-#ifdef I386
-  I386Round;
-#endif
   result = arg1 - arg2;
   if (FPTEST(result)) ERROR_EXIT(parg2);
   wordp = createcell68k(TYPE_FLOATP);
@@ -108,9 +102,6 @@ LispPTR N_OP_ftimes2(LispPTR parg1, LispPTR parg2) {
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
   FPCLEAR;
-#ifdef I386
-  I386Round;
-#endif
   result = arg1 * arg2;
   if (FPTEST(result)) ERROR_EXIT(parg2);
   wordp = createcell68k(TYPE_FLOATP);
@@ -134,9 +125,6 @@ LispPTR N_OP_fquotient(LispPTR parg1, LispPTR parg2) {
   N_MakeFloat(parg1, arg1, parg2);
   N_MakeFloat(parg2, arg2, parg2);
   FPCLEAR;
-#ifdef I386
-  I386Round;
-#endif
   result = arg1 / arg2;
 
   if (FPTEST(result)) ERROR_EXIT(parg2);

--- a/src/ubf1.c
+++ b/src/ubf1.c
@@ -56,14 +56,7 @@ LispPTR N_OP_ubfloat1(int arg, int alpha) {
       int val;
       temp = *(float *)&arg;
       if ((temp > ((float)0x7fffffff)) || (temp < ((float)0x80000000))) ERROR_EXIT(arg);
-#ifdef I386
-      I386Reset;
-#endif /* I386 */
-
       val = (int)temp;
-#ifdef I386
-      I386Round;
-#endif
       N_ARITH_SWITCH(val);
     }
     default: ERROR_EXIT(arg);


### PR DESCRIPTION
These macros aren't actually defined anywhere in our code and
aren't used outside of the old support for the Sun I386 hardware.