### PR TITLE
ptsname() needs _GNU_SOURCE on glibc.

### DIFF
--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -9,6 +9,10 @@ Unix Interface Communications
 /* Don't compile this at all under DOS. */
 #ifndef DOS
 
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* Needed for ptsname on glibc systems. */
+#endif
+
 /************************************************************************/
 /*									*/
 /*	(C) Copyright 1989-1995 by Venue. All Rights Reserved.		*/


### PR DESCRIPTION
glibc needs `_XOPEN_SOURCE` to have a declaration for
`ptsname()`. An easy way to get that without having to
know about particular `_XOPEN_SOURCE` values is to define
`_GNU_SOURCE`.

Closes interlisp/medley#137.