### PR TITLE
Replace int_timer_on|off with int_(un)block.

### DIFF
--- a/inc/timerdefs.h
+++ b/inc/timerdefs.h
@@ -11,7 +11,5 @@ void int_io_open(int fd);
 void int_io_close(int fd);
 void int_block(void);
 void int_unblock(void);
-void int_timer_off(void);
-void int_timer_on(void);
 void int_init(void);
 #endif

--- a/src/loader.c
+++ b/src/loader.c
@@ -102,9 +102,9 @@ int do_system_call(LispPTR arg)
 #ifdef DEBUG
   printf(":: %s \n", cmd_str);
 #endif
-  int_timer_off();
+  int_block();
   result = system(cmd_str);
-  int_timer_on();
+  int_unblock();
   ARITH_SWITCH(result, lisp_result);
   return (lisp_result);
 }
@@ -159,9 +159,9 @@ int exec_command(char *cmd_str)
   char ws[21][80];
   int i, ii, cmd_length;
 
-  int_timer_off();
+  int_block();
   i = system(cmd_str);
-  int_timer_on();
+  int_unblock();
   return (i);
 
 } /*exec_command */

--- a/src/timer.c
+++ b/src/timer.c
@@ -631,9 +631,6 @@ void int_unblock() {
 #endif /* DOS */
 }
 
-void int_timer_on() { int_unblock(); }
-void int_timer_off() { int_block(); }
-
 #ifdef FLTINT
 /************************************************************************/
 /*									*/

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -878,7 +878,7 @@ int device_before_raid() {
   sigset_t signals;
 #endif
 
-  int_timer_off();
+  int_block();
 
 #ifdef XWINDOW
   /* So X events still get recognized. */
@@ -1127,7 +1127,7 @@ int device_after_raid() {
   flush_display_buffer();
 #endif /* XWINDOW | DOS */
 
-  int_timer_on();
+  int_unblock();
   *EmKbdAd068K = *EmRealUtilin68K = *EmKbdAd168K = *EmKbdAd268K = *EmKbdAd368K = *EmKbdAd468K =
       *EmKbdAd568K = KB_ALLUP;
   return (0);


### PR DESCRIPTION
Both were used, but one just called the other, so simplify
the API.