### PR TITLE
Remove mention of TRASE.

### DIFF
--- a/bin/compile-flags
+++ b/bin/compile-flags
@@ -54,7 +54,6 @@ DEBUG		Used when debugging, to enclose trace and dump code.
 		dbprint.h for the definition.
 TRACE
 TRACE2
-TRASE
 OPTRACE		If true, the dispatch loop prints the PC & opcode each time thru
 FNTRACE		If true, you see the name of each function called.
 STACKCHECK	If true, you see unusual cases of stack manipulation

--- a/src/tty.c
+++ b/src/tty.c
@@ -185,7 +185,7 @@ void tty_setbaudrate() {
 int tty_baudtosymbol(short aBaud)
 {
 #ifdef TRACE
-  printf("TRASE: tty_baudtosymbol(%x)\n", aBaud);
+  printf("TRACE: tty_baudtosymbol(%x)\n", aBaud);
 #endif
 
   if (aBaud == 0) return (B50);


### PR DESCRIPTION
This macro no longer exists and one message had it as a typo.