### PR TITLE
Remove extra flags for gcc on some platforms.

### DIFF
--- a/bin/makefile-cygwin.x86_64-x
+++ b/bin/makefile-cygwin.x86_64-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
+#CC = gcc -m64 $(GCC_CFLAGS)
 CC = clang -m64 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
+#CC = gcc -m32 $(GCC_CFLAGS)
 CC = clang -m32 $(CLANG_CFLAGS)
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -1,6 +1,6 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 $(GCC_CFLAGS) -fno-omit-frame-pointer -Wall -Wextra -fno-aggressive-loop-optimizations
+#CC = gcc -m64 $(GCC_CFLAGS)
 CC = clang -m64 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \


### PR DESCRIPTION
On Linux x86 and x86_64 as well as Cygwin, we were adding some
flags to the (commented out) usage of gcc. These shouldn't be
here.