### PR TITLE
Remove SunOS 4 version of aref_switch.

### DIFF
--- a/inc/my.h
+++ b/inc/my.h
@@ -92,43 +92,6 @@
 		}							\
 	}
 
-#ifdef OS4
-#define aref_switch(type, tos, baseL, index)				\
-{									\
-  LispPTR result;							\
-  DLword *wordp;							\
-									\
-    switch (type) {							\
-      case 38: /* pointer : 32 bits */					\
-         return(*(((int *)Addr68k_from_LADDR(baseL)) + index));		\
-      case 20: /* signed : 16 bits */					\
-         result = (GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF;										\
-         if (result & 0x8000) return(result | S_NEGATIVE);		\
-         else return(result | S_POSITIVE);				\
-      case 67: /* Character :  8 bits */				\
-         return(S_CHARACTER | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));								\
-      case 22: /* signed : 32 bits */					\
-         result = *(((int *)Addr68k_from_LADDR(baseL)) + index);	\
-         N_ARITH_SWITCH(result);					\
-      case 0: /* unsigned : 1 bit per element */			\
-         return(S_POSITIVE | (((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + (index >> 3))) >> (7 - (index & 7))) & 1));					\
-      case 3: /* unsigned : 8 bits per element */			\
-         return(S_POSITIVE | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));								\
-      case 4: /* unsigned : 16 bits per element */			\
-         return(S_POSITIVE | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));								\
-      case 54: /* Float : 32 bits */					\
-         wordp = createcell68k(TYPE_FLOATP);				\
-         *((int *)wordp) = *(((int *)Addr68k_from_LADDR(baseL)) + index);										\
-         return(LADDR_from_68k(wordp));					\
-      case 68: /* Character :  16 bits */				\
-         return(S_CHARACTER | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));								\
-      case 86: /* XPointer : 32 bits */					\
-         return(*(((int *)Addr68k_from_LADDR(baseL)) + index));		\
-      default: /* Illegal or Unimplemented */				\
-         ERROR_EXIT(tos);						\
-    }/* end switch typenumber */					\
-}
-#else
 __inline__ static LispPTR
 aref_switch(int type, LispPTR tos, LispPTR baseL, int index)
 {								  
@@ -166,7 +129,6 @@ aref_switch(int type, LispPTR tos, LispPTR baseL, int index)
       ERROR_EXIT(tos);						
     }/* end switch typenumber */					
 }
-#endif /* NEVER */
 
 #define aset_switch(type, tos)						\
 {									\

--- a/src/array.c
+++ b/src/array.c
@@ -52,11 +52,6 @@ LispPTR N_OP_misc3(LispPTR baseL, LispPTR typenumber, LispPTR inx, int alpha) {
   /*  test and setup typenumber  */
   N_GetPos(typenumber, type, inx);
 
-/*  disp on type  */
-#ifdef OS4
-  aref_switch(type, inx, baseL, index);
-#else
+  /*  disp on type  */
   return (aref_switch(type, inx, baseL, index));
-#endif
-
 } /*  end N_OP_misc3()  */

--- a/src/array3.c
+++ b/src/array3.c
@@ -51,11 +51,6 @@ LispPTR N_OP_aref1(register LispPTR arrayarg, register LispPTR inx) {
   /*  setup base  */
   baseL = arrayblk->base;
 
-/*  disp on type  */
-#ifdef OS4
-  aref_switch(type, inx, baseL, index);
-#else
+  /*  disp on type  */
   return (aref_switch(type, inx, baseL, index));
-#endif
-
 } /*  end N_OP_aref1()  */

--- a/src/array5.c
+++ b/src/array5.c
@@ -62,11 +62,6 @@ LispPTR N_OP_aref2(LispPTR arrayarg, LispPTR inx0, LispPTR inx1) {
   /*  setup typenumber  */
   type = 0xFF & arrayblk->typenumber;
 
-/*  disp on type  */
-#ifdef OS4
-  aref_switch(type, inx1, baseL, arindex);
-#else
+  /*  disp on type  */
   return (aref_switch(type, inx1, baseL, arindex));
-#endif
-
 } /*  end N_OP_aref2()  */


### PR DESCRIPTION
When compiling for SunOS4, we would have a macro-ized version
of this function which required a slightly different call-site.

This removes all of that as it isn't used or needed.