### PR TITLE
Fix lispcmp bytecmp

### DIFF
--- a/inc/mkatomdefs.h
+++ b/inc/mkatomdefs.h
@@ -5,7 +5,7 @@ DLword compute_lisp_hash(const char *char_base, DLword offset, DLword length, DL
 LispPTR compare_chars(register const char *char1, register const char *char2, register DLword length);
 int bytecmp(const char *char1, const char *char2, int len);
 LispPTR compare_lisp_chars(register const char *char1, register const char *char2, register DLword length, DLword fat1, DLword fat2);
-int lispcmp(const DLword *char1, const unsigned char *char2, int len);
+int lispcmp(const DLword *char1, const char *char2, int len);
 LispPTR make_atom(const char *char_base, DLword offset, DLword length, short int non_numericp);
 LispPTR parse_number(const char *char_base, short int length);
 #endif

--- a/inc/mkatomdefs.h
+++ b/inc/mkatomdefs.h
@@ -3,9 +3,7 @@
 DLword compute_hash(const char *char_base, DLword offset, DLword length);
 DLword compute_lisp_hash(const char *char_base, DLword offset, DLword length, DLword fatp);
 LispPTR compare_chars(register const char *char1, register const char *char2, register DLword length);
-int bytecmp(const char *char1, const char *char2, int len);
 LispPTR compare_lisp_chars(register const char *char1, register const char *char2, register DLword length, DLword fat1, DLword fat2);
-int lispcmp(const DLword *char1, const char *char2, int len);
 LispPTR make_atom(const char *char_base, DLword offset, DLword length, short int non_numericp);
 LispPTR parse_number(const char *char_base, short int length);
 #endif

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -165,7 +165,7 @@ int bytecmp(const char *char1, const char *char2, int len)
 {
   int index;
   for (index = 0; index < len; index++) {
-    if (GETBYTE(char1++) != *(char2++)) return (0);
+      if (GETBYTE(char1++) != *(unsigned char *)(char2++)) return (0);
   }
   return (1);
 }

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -31,6 +31,9 @@
 */
 /**********************************************************************/
 
+#ifndef BYTESWAP
+#include <string.h>
+#endif
 #include "lispemul.h"
 #include "adr68k.h"
 #include "lsptypes.h"

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -34,6 +34,7 @@
 #ifndef BYTESWAP
 #include <string.h>
 #endif
+#include <stdint.h>
 #include "lispemul.h"
 #include "adr68k.h"
 #include "lsptypes.h"
@@ -136,7 +137,7 @@ int bytecmp(const char *char1, const char *char2, int len)
 {
   int index;
   for (index = 0; index < len; index++) {
-      if (GETBYTE(char1++) != *(unsigned char *)(char2++)) return (0);
+      if (GETBYTE(char1++) != *(uint8_t *)(char2++)) return (0);
   }
   return (1);
 }

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -128,6 +128,17 @@ DLword compute_lisp_hash(const char *char_base, DLword offset, DLword length, DL
 
 } /* end compute_lisp_hash */
 
+#ifdef BYTESWAP
+int bytecmp(const char *char1, const char *char2, int len)
+{
+  int index;
+  for (index = 0; index < len; index++) {
+      if (GETBYTE(char1++) != *(unsigned char *)(char2++)) return (0);
+  }
+  return (1);
+}
+#endif /* BYTESWAP */
+
 /**********************************************************************/
 /*
         Func name :	compare_chars
@@ -160,16 +171,14 @@ LispPTR compare_chars(register const char *char1, register const char *char2, re
   }
 
 } /* end compare_chars */
-#ifdef BYTESWAP
-int bytecmp(const char *char1, const char *char2, int len)
-{
+
+int lispcmp(const DLword *char1, const char *char2, int len) {
   int index;
   for (index = 0; index < len; index++) {
-      if (GETBYTE(char1++) != *(unsigned char *)(char2++)) return (0);
+      if (GETWORD(char1++) != GETBYTE(char2++)) return (0);
   }
   return (1);
 }
-#endif /* BYTESWAP */
 
 /**********************************************************************/
 /*
@@ -230,14 +239,6 @@ LispPTR compare_lisp_chars(register const char *char1, register const char *char
   }
 
 } /* end compare_lisp_chars */
-
-int lispcmp(const DLword *char1, const char *char2, int len) {
-  int index;
-  for (index = 0; index < len; index++) {
-      if (GETWORD(char1++) != GETBYTE(char2++)) return (0);
-  }
-  return (1);
-}
 
 /**********************************************************************/
 /*

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -231,10 +231,10 @@ LispPTR compare_lisp_chars(register const char *char1, register const char *char
 
 } /* end compare_lisp_chars */
 
-int lispcmp(const DLword *char1, const unsigned char *char2, int len) {
+int lispcmp(const DLword *char1, const char *char2, int len) {
   int index;
   for (index = 0; index < len; index++) {
-      if (GETWORD(char1++) != (unsigned char)GETBYTE(char2++)) return (0);
+      if (GETWORD(char1++) != GETBYTE(char2++)) return (0);
   }
   return (1);
 }


### PR DESCRIPTION
Cleans up some type mismatches and makes local helper functions static and remove them from the header file.