### PR TITLE
Rename NOFORN to MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -207,11 +207,6 @@ error Must specify RELEASE to build Medley.
 
 	/* Set up defaults */
 #define NOETHER 1
-/* Foreign function call support relies upon DLD which
- * weren't supported in modern OSes and the GNU DLD
- * library hasn't been supported or maintained since
- * at least 2006. */
-#define NOFORN
 #define UNALIGNED_FETCH_OK
 #define HAS_GETHOSTID
 #define UNSIGNED unsigned long

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -10,7 +10,11 @@
 
 #include "version.h"
 
-#ifndef NOFORN
+/* Foreign function call support relies upon DLD which
+ * weren't supported in modern OSes and the GNU DLD
+ * library hasn't been supported or maintained since
+ * at least 2006. */
+#ifdef MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE
 #include <stdio.h>
 #include <sys/param.h>
 
@@ -928,4 +932,4 @@ int get_c_basebyte(LispPTR *args) {
       break;
   }
 }
-#endif /* NOFORN */
+#endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */

--- a/src/main.c
+++ b/src/main.c
@@ -321,13 +321,13 @@ int main(int argc, char *argv[])
   extern int TIMER_INTERVAL;
   char keytyped[255];
   extern fd_set LispReadFds;
-#ifndef NOFORN
+#ifdef MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE
   if (dld_find_executable(argv[0]) == 0) {
     perror("Name of executable not found.");
   } else if (dld_init(dld_find_executable(argv[0])) != 0) {
     dld_perror("Can't init DLD.");
   };
-#endif /* NOFORN */
+#endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */
 
 #ifdef XWINDOW
   read_Xoption(&argc, argv);
@@ -751,9 +751,11 @@ void print_info_lines() {
 #ifdef NOVERSION
   printf("Does not enforce SYSOUT version matching.\n");
 #endif /* NOVERSION */
-#ifdef NOFORN
+#ifdef MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE
+  printf("Has foreign-function-call interface.\n");
+#else
   printf("Has no foreign-function-call interface.\n");
-#endif /* NOFORN */
+#endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */
 #ifdef NOEUROKBD
   printf("No support for European keyboards.\n");
 #else

--- a/src/subr.c
+++ b/src/subr.c
@@ -697,7 +697,7 @@ void OP_subrcall(int subr_no, int argnum) {
         break;
       }
 
-#ifndef NOFORN
+#ifdef MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE
     /*****************************************/
     /*  foreign-function-call support subrs  */
     /*****************************************/
@@ -766,7 +766,7 @@ void OP_subrcall(int subr_no, int argnum) {
       TopOfStack = smashing_c_fn(args);
       break;
     }
-#endif /* NOFORN */
+#endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */
 
 #ifdef MNW
     case sb_FILL_IN: {


### PR DESCRIPTION
This lets us get rid of double-negatives, which are confusing,
and starts a naming scheme that is easier to see when something
is a Maiko flag versus something else.