### PR TITLE
Remove HAS_GETHOSTID.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -213,7 +213,6 @@ error Must specify RELEASE to build Medley.
  * at least 2006. */
 #define NOFORN
 #define UNALIGNED_FETCH_OK
-#define HAS_GETHOSTID
 #define UNSIGNED unsigned long
 #define INT long
 
@@ -269,7 +268,6 @@ typedef unsigned char u_char;
 typedef unsigned long u_int;
 typedef unsigned short u_short;
 #undef UNALIGNED_FETCH_OK
-#undef HAS_GETHOSTID
 #define USHORT unsigned
 #else
 #define USHORT unsigned short

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -139,10 +139,10 @@ void init_ifpage(int sysout_size) {
     *LASTVMEMFILEPAGE_word = InterfacePage->dllastvmempage;
 #endif /* BIGVM */
 
-/* unfortunately, Lisp only looks at a 16 bit serial number */
-#ifdef HAS_GETHOSTID
+  /* unfortunately, Lisp only looks at a 16 bit serial number */
+#ifndef DOS
   InterfacePage->serialnumber = 0xffff & gethostid();
-#endif /* HAS_GETHOSTID */
+#endif /* DOS */
 
 /* get user name and stuff into vmem; this is the VMEM buffer;
 This is a BCPL string -- it starts with a length count. C strings


### PR DESCRIPTION
This is only true on DOS now. It was previously true on older
unsupported platforms, but they are gone now.