### PR TITLE
Rename NOETHER to MAIKO_ENABLE_ETHERNET.

### DIFF
--- a/inc/version.h
+++ b/inc/version.h
@@ -206,7 +206,6 @@ error Must specify RELEASE to build Medley.
 
 
 	/* Set up defaults */
-#define NOETHER 1
 #define UNALIGNED_FETCH_OK
 #define UNSIGNED unsigned long
 #define INT long
@@ -229,7 +228,7 @@ error Must specify RELEASE to build Medley.
 	/********************************************************/
 #ifdef OS5
 		/* Solaris, sort of SYSV-ish, but not really */
-#undef NOETHER
+#define MAIKO_ENABLE_ETHERNET
 #define LOCK_X_UPDATES 1
 #endif /* OS5 */
 

--- a/src/ether.c
+++ b/src/ether.c
@@ -28,7 +28,7 @@
 #include <sys/types.h>
 #include <sys/time.h>
 #include <sys/select.h>
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #include <sys/socket.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -60,7 +60,7 @@
 #endif
 #include <nlist.h>
 #endif /* DOS */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 #include "commondefs.h"
 #include "lispemul.h"
@@ -96,7 +96,7 @@ int ETHEREventCount = 0;
 #define PacketTypePUP 0x0200
 #define PacketType3TO10 0x0201
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifdef PKTFILTER
 /* the receiving packetfilter structure */
 /* if this is changed, be sure to get the references to it in init_ether
@@ -215,7 +215,7 @@ int ether_out = 0; /* number of packets sent */
 static struct nit_ioc nioc;
 #endif /* PKTFILTER */
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 /************************************************************************/
 /*									*/
@@ -228,7 +228,7 @@ static struct nit_ioc nioc;
 
 LispPTR ether_suspend(LispPTR args[])
 {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifdef PKTFILTER
   static struct packetfilt pf = {0, 1, {ENF_PUSHZERO}};
   struct strioctl si;
@@ -264,7 +264,7 @@ LispPTR ether_suspend(LispPTR args[])
   }
 #endif /* USE_DLPI */
 #endif /* PKTFILTER */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (ATOM_T);
 } /* ether_suspend */
@@ -279,7 +279,7 @@ LispPTR ether_suspend(LispPTR args[])
 
 LispPTR ether_resume(LispPTR args[])
 {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
   struct strioctl si;
   if (ether_fd == -1) return (NIL);
 #ifndef PKTFILTER
@@ -311,7 +311,7 @@ LispPTR ether_resume(LispPTR args[])
 #endif /* USE_DLPI */
 #endif /* PKTFILTER */
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (ATOM_T);
 } /* ether_resume */
@@ -364,7 +364,7 @@ LispPTR ether_reset(LispPTR args[])
 LispPTR ether_get(LispPTR args[])
 {
   LispPTR result = NIL;
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
   LispPTR MaxByteCount;
   sigset_t signals;
 
@@ -388,7 +388,7 @@ LispPTR ether_get(LispPTR args[])
   /* enable interrupts */
   sigprocmask(SIG_UNBLOCK, &signals, NULL);
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (result);
 } /* ether_get */
@@ -401,7 +401,7 @@ LispPTR ether_get(LispPTR args[])
 
 LispPTR ether_send(LispPTR args[])
 {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
   /*
    *	Send a packet.
    */
@@ -454,7 +454,7 @@ LispPTR ether_send(LispPTR args[])
     }
 #endif /* PKTFILTER */
   }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (ATOM_T);
 } /* ether_send */
@@ -475,26 +475,26 @@ LispPTR ether_setfilter(LispPTR args[])
 int estat[3];
 
 int *ether_debug() {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
   estat[0] = 0;
   if (ether_fd < 0) return (NIL);
   printf("fd %d bsize %d buf %X icb %X in %d out %d\n ", ether_fd, ether_bsize, (int)ether_buf,
          IOPage->dlethernet[3], ether_in, ether_out);
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (estat);
 } /* end ether_debug */
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 static struct timeval EtherTimeout = {0, 0};
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 /**********************************************************************
  *	check_ether()
  *	checks an incoming packet
  **********************************************************************/
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifndef PKTFILTER
 static int nitpos = 0, nitlen = 0; /* for NIT read buffer in OS3 */
 #endif
@@ -507,7 +507,7 @@ LispPTR check_ether() {
  *	and signal the icb and return T.
  */
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifndef PKTFILTER
   fd_set rfds;
   int result, fromlen;
@@ -601,7 +601,7 @@ LispPTR check_ether() {
   }
 #endif /* PKTFILTER */
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (NIL);
 } /* end check_ether */
@@ -616,7 +616,7 @@ LispPTR check_ether() {
 /************************************************************************/
 
 LispPTR get_packet() {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifndef PKTFILTER
   fd_set rfds;
   int result, fromlen;
@@ -692,12 +692,12 @@ LispPTR get_packet() {
     perror("Check_ether read error:\n");
 #endif /* PKTFILTER */
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
   return (NIL);
 } /* end get_packet */
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 /**********************************************************************
  *	ether_addr_equal(add1, add2)
  *	checks ethernet addresses equality
@@ -744,7 +744,7 @@ static void init_uid() {
   rid = getuid();
   seteuid(rid);
 }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 /************************************************************************/
 /*		i n i t _ i f p a g e _ e t h e r			*/
@@ -760,13 +760,13 @@ void init_ifpage_ether() {
   InterfacePage->nshost2 = (DLword)((ether_host[4] << 8) + ether_host[5]);
 }
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 /* this needs to be a global so the name can be set by main() in Ctest */
-/* But NOETHER doesn't support NIT, so dyke it out for NOETHER */
+/* But MAIKO_ENABLE_ETHERNET doesn't support NIT, so dyke it out for MAIKO_ENABLE_ETHERNET */
 #ifndef USE_DLPI
 struct sockaddr_nit snit;
 #endif /* USE_DLPI */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 /************************************************************************/
 /*			    i n i t _ e t h e r				*/
@@ -775,7 +775,7 @@ struct sockaddr_nit snit;
 /*      								*/
 /************************************************************************/
 void init_ether() {
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 
   /* JRB - This code will have to be a bit different for SUN 4.0; the			probable
      differences are in commented-out code below
@@ -1082,7 +1082,7 @@ void init_ether() {
 
     DBPRINT(("init_ether: **** Ethernet starts ****\n"));
   }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 }
 
 #define MASKWORD1 0xffff

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -114,10 +114,9 @@ void init_ifpage(int sysout_size) {
     Initialize IFPAGE
    */
   InterfacePage->machinetype = KATANA; /* 3 is katana */
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
   init_ifpage_ether(); /* store ethernet ID in IF page */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
   /*InterfacePage->dl24bitaddressable = (sysout_size == 32? 0xffff : 0);*/
   InterfacePage->dl24bitaddressable = (sysout_size == 8 ? 0 : 0xffff);
   new_lastvmem = (sysout_size * PAGES_IN_MBYTE) - 1;

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -125,10 +125,9 @@ int XNeedSignal = 0; /* T if an X interrupt happened while XLOCK asserted */
 
 extern int LogFileFd;
 
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
 extern int ether_fd;
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 extern DLword *DisplayRegion68k;
 
@@ -337,13 +336,12 @@ getmore:
 
 #endif /* XWINDOW */
 
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
     if (ether_fd >= 0 && FD_ISSET(ether_fd, &rfds)) { /* Raw ethernet (NIT) I/O happened, so handle it. */
       DBPRINT(("Handling enet interrupt.\n\n"));
       check_ether();
     }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 #ifdef RS232
     if (RS232C_Fd >= 0 && (FD_ISSET(RS232C_Fd, &rfds) || (RS232C_remain_data && rs232c_lisp_is_ready())))

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -10,7 +10,7 @@
 
 #include "version.h"
 
-#ifdef NOETHER
+#ifndef MAIKO_ENABLE_ETHERNET
 /* No ethernet, so have a dummy here. */
 unsigned char ether_host[6] = {0, 0, 0, 0, 0, 0}; /* 48 bit address */
 int main(int argc, char *argv[]) { return (0); }
@@ -247,4 +247,4 @@ int main(int argc, char *argv[]) {
   return (1);
 }
 
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */

--- a/src/main.c
+++ b/src/main.c
@@ -35,11 +35,11 @@
 #define R_OK 04
 #endif /* DOS */
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifndef USE_DLPI
 #include <net/nit.h> /* needed for Ethernet stuff below */
 #endif               /* USE_DLPI */
-#endif               /* NOETHER */
+#endif               /* MAIKO_ENABLE_ETHERNET */
 
 #include "emlglob.h"
 #include "address.h"
@@ -219,10 +219,10 @@ LispPTR *LastStackAddr_word;
 LispPTR *NeedHardreturnCleanup_word;
 
 /*** Ethernet stuff (JRB) **/
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 extern int ether_fd;
 extern u_char ether_host[6];
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 extern struct sockaddr_nit snit;
 
@@ -443,8 +443,7 @@ int main(int argc, char *argv[])
 
     /* Can only do this under SUNOs, for now */
     else if (!strcmp(argv[i], "-E")) { /**** ethernet info	****/
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
       int b0, b1, b2, b3, b4, b5;
 #ifdef USE_DLPI
       if (argc > ++i &&
@@ -453,7 +452,7 @@ int main(int argc, char *argv[])
       if (argc > ++i &&
           sscanf(argv[i], "%d:%x:%x:%x:%x:%x:%x:%s", &ether_fd, &b0, &b1, &b2, &b3, &b4, &b5,
                  snit.snit_ifname) == 8)
-#endif /* USE_FDLPI */
+#endif /* USE_DLPI */
       {
         ether_host[0] = b0;
         ether_host[1] = b1;
@@ -466,7 +465,7 @@ int main(int argc, char *argv[])
         ether_fd = -1;
         exit(1);
       }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
     }
     /* diagnostic flag for big vmem write() calls */
@@ -494,9 +493,9 @@ int main(int argc, char *argv[])
 
   FD_ZERO(&LispReadFds);
 
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
   init_ether(); /* modified by kiuchi Nov. 4 */
-#endif          /* NOETHER */
+#endif          /* MAIKO_ENABLE_ETHERNET */
 
 #ifdef FORKCOMM
   /* Fork Unix was called in kickstarter; if we forked, look up the */

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -894,13 +894,12 @@ int device_before_raid() {
 #endif
 #endif /* SUNDISPLAY */
 
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifdef ETHERINT
   if (ether_fd > 0) /* check ether is used or not */
     int_io_close(ether_fd);
 #endif
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 #ifdef RS232INT
   int_io_close(RS232C_Fd);
@@ -1084,8 +1083,7 @@ int device_after_raid() {
   truecolor_after_raid();
 #endif /* TRUECOLOR */
 
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
   init_ether();
 #ifdef USE_DLPI
   if (ether_fd > 0)
@@ -1096,7 +1094,7 @@ int device_after_raid() {
       return (-1);
     }
 #endif /* USE_DLPI */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 #ifdef XWINDOW
 #ifdef I_SETSIG
@@ -1111,10 +1109,9 @@ int device_after_raid() {
   FD_SET(LispWindowFd, &LispReadFds);
 #endif /* SUNDISPLAY */
 
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
   FD_SET(ether_fd, &LispReadFds);
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 #ifdef XWINDOW
   (currentdsp->device.after_raid)(currentdsp);

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -17,11 +17,11 @@
 #include <sys/file.h>
 #include <sys/time.h>
 #include <unistd.h>
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 #ifndef USE_DLPI
 #include <net/nit.h> /* needed for Ethernet stuff below */
 #endif               /* USE_DLPI */
-#endif               /* NOETHER */
+#endif               /* MAIKO_ENABLE_ETHERNET */
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/Xresource.h>
@@ -97,13 +97,13 @@ extern char keystring[];
 int Lisp_Border = 2;
 
 /*** Ethernet stuff (JRB) **/
-#ifndef NOETHER
+#ifdef MAIKO_ENABLE_ETHERNET
 extern int ether_fd;
 extern u_char ether_host[6];
 #ifndef USE_DLPI
 extern struct sockaddr_nit snit;
 #endif /* USE_DLPI */
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 
 /************************************************************************/
 /*									*/
@@ -326,8 +326,7 @@ void read_Xoption(int *argc, char *argv[])
     (void)strncpy(keystring, value.addr, (int)value.size);
   }
   if (XrmGetResource(rDB, "ldex.xsync", "Ldex.xsync", str_type, &value) == True) { xsync = True; }
-#ifdef NOETHER
-#else
+#ifdef MAIKO_ENABLE_ETHERNET
   if (XrmGetResource(rDB, "ldex.EtherNet", "Ldex.EtherNet", str_type, &value) == True) {
     int b0, b1, b2, b3, b4, b5;
     (void)strncpy(tmp, value.addr, (int)value.size);
@@ -350,5 +349,5 @@ void read_Xoption(int *argc, char *argv[])
       exit(1);
     }
   }
-#endif /* NOETHER */
+#endif /* MAIKO_ENABLE_ETHERNET */
 } /* end readXoption */


### PR DESCRIPTION
Like the renaming of NOFORN, this gets rid of some double
negatives. It also removes some patterns where we had:

```
    #ifdef NOETHER
    #else
    ...
    #endif
```

and replaces them with:

```
    #ifdef MAIKO_ENABLE_ETHERNET
    ...
    #endif
```