### PR TITLE
Use sig_atomic_t for FP_error when using FP exceptions.

### DIFF
--- a/inc/medleyfp.h
+++ b/inc/medleyfp.h
@@ -27,7 +27,8 @@
     --------------------------------------------------  */
 
 #ifdef FLTINT
-volatile extern int  FP_error;
+#include <signal.h>
+extern volatile sig_atomic_t FP_error;
 
 /*  Note that a compiler may very likely move code around the arithmetic
     operation, causing this test (set by an interrupt handler) to be

--- a/src/timer.c
+++ b/src/timer.c
@@ -644,7 +644,7 @@ void int_unblock() {
 /************************************************************************/
 
 /* The global used to signal floating-point errors */
-volatile int FP_error = 0;
+volatile sig_atomic_t FP_error = 0;
 
 void int_fp_service(int sig, siginfo_t *info, void *context)
 {


### PR DESCRIPTION
`sig_atomic_t` is usually `int`, but is the typedef that one
should use for flags written to from a signal handler.