### PR TITLE
Fix various spelling, grammatical, and punctuation errors

### DIFF
--- a/inc/XKeymap.h
+++ b/inc/XKeymap.h
@@ -230,7 +230,7 @@ int generic_X_keymap[] = {
     0, 132, XK_Right,
     0, 87, XK_Right,
 
-    0, 93, XK_Multi_key,   /* Expand, suyn type-4 */
+    0, 93, XK_Multi_key,   /* Expand, Sun type-4 */
     0, 93, XK_Alt_R,       /* Expand, RH Alt key  */
     0, 93, XK_Mode_switch, /* Expand, RH Alt key on PC kbd */
     /* No key defs may come here! */

--- a/inc/display.h
+++ b/inc/display.h
@@ -59,9 +59,9 @@ extern DLword *DISP_MAX_Address;
 /************************************************************************/
 /* Osamu '90/02/08
  * This definition is moved from initdsp.c
- * Change into macro for efficiency.
- * And also DISP_MAX_Address is changed as variable
- * to avoid same calicuration every time it uses.
+ * Changed into a macro for efficiency.
+ * Also DISP_MAX_Address is changed to a variable
+ * to avoid doing the same calculation every time it is used.
  *********************************************************************/
 extern DLword *DisplayRegion68k;
 

--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -129,7 +129,7 @@
 	/********************************************************/
 #ifdef BIGVM  
 struct   hashentry
-  { /* GC hastable entry */
+  { /* GC hashtable entry */
     unsigned short count        :15;
     unsigned short stackref     :1;
     unsigned short segnum       :15;
@@ -160,7 +160,7 @@ struct  htoverflow
   };
 #else
 struct   hashentry
-  { /* GC hastable entry */
+  { /* GC hashtable entry */
     USHORT count        :6;
     USHORT stackref     :1;
     USHORT segnum       :8;

--- a/inc/lispmap.h
+++ b/inc/lispmap.h
@@ -66,7 +66,7 @@
 #define STK_SIZE	0x10000
 
 /* for PLISTSPACE */
-#define PLIS_HI			2 /* place holder, really -- keep the olde value, even though it's inconsistent with the OFFSET, because it's known by LISP, and is used as a dispatch constant. */
+#define PLIS_HI			2 /* place holder, really -- keep the old value, even though it's inconsistent with the OFFSET, because it's known by LISP, and is used as a dispatch constant. */
 #define PLIS_OFFSET 0x30000
 #define PLIS_SIZE 0x10
 
@@ -210,7 +210,7 @@
 #define PLIS_OFFSET	0x20000
 #define PLIS_SIZE	0x20000
 #else
-#define PLIS_HI			2 /* place holder, really -- keep the olde value, even though it's inconsistent with the OFFSET, because it's known by LISP, and is used as a dispatch constant. */
+#define PLIS_HI			2 /* place holder, really -- keep the old value, even though it's inconsistent with the OFFSET, because it's known by LISP, and is used as a dispatch constant. */
 #define PLIS_OFFSET 0x30000
 #define PLIS_SIZE 0x10
 #endif

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -318,7 +318,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 /* DOS version of LispVersionToUnixVersion */
 /* * * * * This is done this way because DOS can't handle the non-DOS version -- */
-/* * * * * it gived "Too many characters in a character constant" errors!        */
+/* * * * * it gave "Too many characters in a character constant" errors!        */
 #include "lispver1.h"
 #else /* DOS */
 /* NON-DOS version of the macro LispVersionToUnixVersion */

--- a/inc/lpkit.h
+++ b/inc/lpkit.h
@@ -275,7 +275,7 @@ typedef struct _lprec
   int       eta_size;           /* The number of Eta columns */
   int       num_inv;            /* The number of real pivots */
   int       max_num_inv;        /* ## The number of real pivots between 
-				   reinvertions */
+				   reinversions */
   REAL      *eta_value;         /* eta_alloc :The Structure containing the
 				   values of Eta */
   int       *eta_row_nr;         /*  "     "  :The Structure containing the Row
@@ -326,7 +326,7 @@ typedef struct _lprec
   short     *lag_con_type;      /* NumLagrange :TRUE if constraint type EQ */
   REAL      lag_bound;		/* the lagrangian lower bound */
 
-  short     valid;		/* Has this lp pased the 'test' */
+  short     valid;		/* Has this lp passed the 'test' */
   REAL      infinite;           /* ## numerical stuff */
   REAL      epsilon;            /* ## */
   REAL      epsb;               /* ## */

--- a/inc/lspglob.h
+++ b/inc/lspglob.h
@@ -116,13 +116,13 @@ extern LispPTR *System_Buffer_List_word;
 
 /*** The end of the addition of cache values for reclaimer by Tomtom ***/
 
-/*** cashe valuses for top level reclaimer Tomtom 15-Oct-1987 ***/
+/*** cache values for top level reclaimer Tomtom 15-Oct-1987 ***/
 extern LispPTR *GcMess_word;
 extern LispPTR *ReclaimMin_word;
 extern LispPTR *GcTime1_word;
 extern LispPTR *GcTime2_word;
 extern LispPTR *MaxTypeNumber_word;
-/*** The end of the addition of cashe values for the top level reclaimer ***/
+/*** The end of the addition of cache values for the top level reclaimer ***/
 
 /*** The addition cache for closure-caching ***/
 

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -1919,7 +1919,7 @@ void ccfuncall(register unsigned int atom_index, register int argnum, register i
   register struct definition_cell *defcell68k; /* Definition Cell PTR */
   register short pv_num;                       /* scratch for pv */
   register struct fnhead *tmp_fn;
-  int rest; /* use for arignments */
+  int rest; /* use for alignments */
 
   /* Get Next Block offset from argnum */
   CURRENTFX->nextblock = (LADDR_from_68k(CurrentStackPTR) & 0x0ffff) - (argnum << 1) + 4 /* +3  */;

--- a/src/cdrom.c
+++ b/src/cdrom.c
@@ -179,7 +179,7 @@ static int cdrom_mikanat(LispPTR *args)
         args[1] pointer to a search key
         args[2] pointer to buffer
         args[3] size of searched data
-        args[4] nuber of items matched to the search key
+        args[4] number of items matched to the search key
 */
 {
   char key[65];

--- a/src/codeconv.c
+++ b/src/codeconv.c
@@ -52,12 +52,12 @@ int FatcharNStoEUC(unsigned char *ns_ptr, int ns_len, unsigned char *euc_ptr) {
     ns += *ns_ptr++;
     euc = ns_euc(ns);
     if (euc / TABLESIZE) {
-      /* 16 bit charactor */
+      /* 16 bit character */
       *euc_ptr++ = euc / TABLESIZE;
       *euc_ptr++ = euc % TABLESIZE;
       euc_len += 2;
     } else {
-      /* ASCII charactor */
+      /* ASCII character */
       *euc_ptr++ = euc % TABLESIZE;
       ++euc_len;
     }
@@ -95,12 +95,12 @@ int ThincharNStoEUC(unsigned char *ns_ptr, int ns_len, unsigned char *euc_ptr) {
     ns = *ns_ptr++;
     euc = ns_euc(ns);
     if (euc / TABLESIZE) {
-      /* 16 bit charactor */
+      /* 16 bit character */
       *euc_ptr++ = euc / TABLESIZE;
       *euc_ptr++ = euc % TABLESIZE;
       euc_len += 2;
     } else {
-      /* ASCII charactor */
+      /* ASCII character */
       *euc_ptr++ = euc % TABLESIZE;
       ++euc_len;
     }
@@ -133,7 +133,7 @@ int EUCtoFatcharNS(unsigned char *euc_ptr, unsigned char *ns_ptr) {
   i = 0;
   while (euc = *euc_ptr++) {
     if (euc & EUCMASK) {
-      /* 16 bit charactor */
+      /* 16 bit character */
       euc *= TABLESIZE;
       euc += *euc_ptr++;
     }
@@ -168,12 +168,12 @@ int EUCstrlen(char *euc_ptr) {
 
   while (*euc_ptr)
     if (*euc_ptr & EUCMASK) {
-      /* 16 bit charactor */
+      /* 16 bit character */
       len += 2;
       *euc_ptr++;
       *euc_ptr++;
     } else {
-      /* ASCII charactor */
+      /* ASCII character */
       len++;
       *euc_ptr++;
     }

--- a/src/codetbl.c
+++ b/src/codetbl.c
@@ -11,7 +11,7 @@
 #include "version.h"
 
 /***************************************************/
-/* NS <-> EUC character code converstion program   */
+/* NS <-> EUC character code conversion program    */
 /* file name : nstables.c                          */
 /* function  : ns_euc --- NS to EUC conversion     */
 /*           : euc_ns --- EUC to NS                */

--- a/src/conspage.c
+++ b/src/conspage.c
@@ -158,7 +158,7 @@ struct conspage *next_conspage(void) {
       page2 = (struct conspage *)((DLword *)page1 + DLWORDSPER_PAGE);
 
       /* XXX: why is the link for page2's next here?
-       * when it was previously commented as "Doesn't exst next page"
+       * when it was previously commented as "Doesn't exist next page"
        */
       init_conspage(page2, ListpDTD->dtd_nextpage);
       init_conspage(page1, LPAGE_from_68k(page2));

--- a/src/dbgtool.c
+++ b/src/dbgtool.c
@@ -97,7 +97,7 @@ jmp_buf BT_jumpbuf;
         Desc :		returns atom index of ivar on the given
                         FX.
                         If ivar is localvars then set *localivar
-                        1 otherwize 0.
+                        1 otherwise 0.
 
         Changed		25 Aug 1987	NMitani
 

--- a/src/doskbd.c
+++ b/src/doskbd.c
@@ -307,7 +307,7 @@ void EnterDosKbd(KbdInterface kbd)
     /* Don't hook in our handler if the user flagged he wants to run */
     /* without a kbd. */
     if (!nokbdflag) {
-      kbd->prev_handler = _dos_getvect(0x09); /* get addr of currnt 09 hndlr */
+      kbd->prev_handler = _dos_getvect(0x09); /* get addr of current 09 hndlr */
       _dos_setvect(0x09, kbd->device_event);  /* hook our int handler to interrupt  */
     }
   }

--- a/src/dosmouse.c
+++ b/src/dosmouse.c
@@ -206,7 +206,7 @@ void DosMouseBeforeRaid(MouseInterface mouse, DspInterface dsp)
 /*            d o s _ c u r s o r _ i n v i s s i b l e        */
 /* Since we only blit the cursor to the VESA/VGA displaybuffer */
 /* and not to the emulator displaybuffer we can make the cursor*/
-/* invisible just by updateing the area under the cursor!     */
+/* invisible just by updating the area under the cursor!       */
 /***************************************************************/
 void dos_cursor_invisible(DspInterface dsp, IOPAGE *iop)
 
@@ -459,10 +459,10 @@ void ButtonTimer() {
 
 /***************************************************************/
 /*                 T w o B u t t o n H a n d l e r             */
-/* This function is ther interrupt handler for the mouse.      */
+/* This function is the interrupt handler for the mouse.       */
 /* This function sets the state of the mouse structure and     */
-/* signals the dispatch loop to care of the matter. This       */
-/* akward solution is due to the severe braindamage in DOS.    */
+/* signals the dispatch loop to take care of the matter. This  */
+/* awkward solution is due to the severe braindamage in DOS.   */
 /***************************************************************/
 void TwoButtonHandler(void) {
   _XSTACK *stk_ptr;
@@ -584,10 +584,10 @@ void TwoButtonHandler(void) {
 
 /***************************************************************/
 /*              T h r e e B u t t o n H a n d l e r            */
-/* This function is ther interrupt handler for the mouse.      */
+/* This function is the interrupt handler for the mouse.       */
 /* This function sets the state of the mouse structure and     */
-/* signals the dispatch loop to care of the matter. This       */
-/* akward solution is due to the severe braindamage in DOS.    */
+/* signals the dispatch loop to take care of the matter. This  */
+/* awkward solution is due to the severe braindamage in DOS.   */
 /***************************************************************/
 void ThreeButtonHandler()
 

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2802,7 +2802,7 @@ static int make_directory(register char *dir)
  *
  * Value:	N/A
  *
- * Side Effect:	mentry and max_no will be replaced with the highset versioned entry
+ * Side Effect:	mentry and max_no will be replaced with the highest versioned entry
  *		and highest version number respectively.
  *
  * Description:

--- a/src/dspif.c
+++ b/src/dspif.c
@@ -69,7 +69,7 @@ void make_dsp_instance(DspInterface dsp, char *lispbitmap, int width_hint, int h
     exit(-1);
   }
 #endif /* DOS | XWINDOW */
-} /* Now we know the Maxi-MooM capabillities of the hardware. */
+} /* Now we know the maximum capabilities of the hardware. */
 
 #ifdef DOS
 VESA_p() {

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -39,9 +39,9 @@ op 0377  N_OP_eqq	CL:=
 ***********************************************************/
 /* differences between these operations:
 
-EQ is a strict pointer comparision, equivalent to C's ==
+EQ is a strict pointer comparison, equivalent to C's ==
 
-EQL (common lisp) does no conversions before comparision, but will
+EQL (common lisp) does no conversions before comparison, but will
         compare equal FIXPs or equal FLOATPs.
 
 CL:=  will do a numeric comparison
@@ -51,7 +51,7 @@ CL:=  will do a numeric comparison
 IL:EQUAL  is a recursive comparison which will compare 1 = 1.0
           it work like code with CL:= for the most part
 
-CL:EQUAL is a recursive comparision which uses EQL at the leaves
+CL:EQUAL is a recursive comparison which uses EQL at the leaves
 
 Interlisp operations IEQP, FEQP have no opcodes, although there
 is an unboxed FEQP.

--- a/src/ether.c
+++ b/src/ether.c
@@ -573,7 +573,7 @@ LispPTR check_ether() {
 
   if (ether_fd >= 0 && ether_bsize > 0
       /*   && select(32, &rfds, NULL, NULL, &EtherTimeout) >= 0
-       *     -- [on '90/02/14: getsignsldata() chech this] */
+       *     -- [on '90/02/14: getsignsldata() check this] */
       && (FD_ISSET(ether_fd, &rfds))) {
     data.maxlen = sizeof(nit_buf);
     data.len = 0;

--- a/src/fvar.c
+++ b/src/fvar.c
@@ -281,7 +281,7 @@ void nfvlookup(struct frameex1 *apframe1, register DLword *achain,
 /* pointer to current frame extension */
 /* pointer to 1st word of the searching
    FVAR slot in CurrentFrameExtension */
-/* pointer to current function heaer */
+/* pointer to current function header */
 {
   register DLword *pfh;  /* pointer to current function header */
   register int paoffset; /* 2word offset in PVAR AREA */

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -278,7 +278,7 @@ void init_keyboard(int flg) /* if 0 init else re-init */
 #ifdef SUNDISPLAY
   keytrans = TR_UNTRANS_EVENT; /* keyboard does not encode key */
   if (ioctl(LispKbdFd, KIOCTRANS, &keytrans) == -1) {
-    fprintf(stderr, "Error at ioctl errnoo =%d\n", errno);
+    fprintf(stderr, "Error at ioctl errno =%d\n", errno);
     exit(-1);
   }
   close(LispKbdFd);
@@ -324,7 +324,7 @@ void device_before_exit() {
 
   keytrans = TR_EVENT; /* keyboard encodes key */
   if (ioctl(LispKbdFd, KIOCTRANS, &keytrans) == -1) {
-    fprintf(stderr, "Error at ioctl errnoo =%d\n", errno);
+    fprintf(stderr, "Error at ioctl errno =%d\n", errno);
     exit(-1);
   }
   close(LispKbdFd);
@@ -446,7 +446,7 @@ static int find_unused_key(KeySym *map, int minkey, int codecount, int symsperco
 
 static u_char *make_X_keymap() {
   u_char *table = (u_char *)malloc(256); /* the final result table */
-  int lisp_codes_used[256];              /* Keep track of the Lisk key #s we've used */
+  int lisp_codes_used[256];              /* Keep track of the Lisp key #s we've used */
   int last_KEYSYM = -1;
   int sym_used = 0;
   int *key_sym_pairs = generic_X_keymap;

--- a/src/intcall.c
+++ b/src/intcall.c
@@ -34,7 +34,7 @@ void cause_interruptcall(register unsigned int atom_index)
   register struct definition_cell *defcell68k; /* Definition Cell PTR */
   register short pv_num;                       /* scratch for pv */
   register struct fnhead *tmp_fn;
-  int rest; /* use for arignments */
+  int rest; /* use for alignments */
 
   CURRENTFX->nopush = T;
   CURRENTFX->nextblock = StkOffset_from_68K(CurrentStackPTR) + 4;

--- a/src/keylib.c
+++ b/src/keylib.c
@@ -32,7 +32,7 @@
 #define FAILURE2 -2
 
 /* ===========================================================================
-        IMOD64BIT computs (IMOD X Y).
+        IMOD64BIT computes (IMOD X Y).
         X is a 64-bit integer; x1 is the higher 32-bit while x0 is the lower 32-bit.
         Y is  less than 65535.
         (((ULONG_MAX % y) + 1 ) % y) is equivalent to (expt 2 32) % y
@@ -56,7 +56,7 @@ unsigned long make_verification(long unsigned int x, long unsigned int y) {
 }
 
 /* ============================================================
-        DATE_INTEGER16 takes a date string  and return an intger
+        DATE_INTEGER16 takes a date string  and return an integer
    =============================================================*/
 
 unsigned long date_integer16(const char *date) {

--- a/src/keytst.c
+++ b/src/keytst.c
@@ -57,7 +57,7 @@ int keytester(char *keystring) {
   unsigned long hashedword;
   int rc; /* return code */
 
-  /* check the keys and convert them from hexdecimal strings to numbers  */
+  /* check the keys and convert them from hexadecimal strings to numbers  */
   if (keystring == NULL) return FAILURE3;
   if (read_hex(keystring, keyarray) == FAILURE3) return FAILURE3;
 

--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -81,7 +81,7 @@ int main(int argc, char *argv[])
 
 #ifdef XWINDOW
   /* If X-Server exists on the host specified in -display option
-     or environment variable DISPLAY, ldex is started. Othewise
+     or environment variable DISPLAY, ldex is started. Otherwise
      ldesingle or ldemulti.
      */
   {

--- a/src/lineblt8.c
+++ b/src/lineblt8.c
@@ -51,9 +51,9 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
 **************************************************************/
 /* srcw points DLword which contains the nibble processed now */
 /* offset indicates MSB in the nibble */
-/* width:before copy,make sure the nibble is inside source bitmap */
-/* width:after copy,decremented by BITSPERNIBBLE.
-       therefore,width indictes the rest bits in source bitmap */
+/* width: before copy, make sure the nibble is inside source bitmap */
+/* width: after copy, decremented by BITSPERNIBBLE.
+       therefore, width indicates the rest bits in source bitmap */
 
 #define LineBLT8(srcWptr, offset, width, dstLptr, op1, op2)                                \
   {                                                                                        \

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -113,7 +113,7 @@ tryfsb:
     } else if (StkOffset_from_68K(new68k) == InterfacePage->endofstack) {
       if ((StkOffset_from_68K(new68k) > LOLOC(*GuardStackAddr_word)) &&
           ((*STACKOVERFLOW_word) == NIL))
-        at_eos = T; /* search FSB in earler STACK area by freestackblock */
+        at_eos = T; /* search FSB in earlier STACK area by freestackblock */
       else if (extendstack() != NIL) {
         new68k = (DLword *)oldfx68k;
         goto out;
@@ -230,8 +230,8 @@ int do_stackoverflow(int incallp) {
 #endif
 
   /* Don't care PC,FuncObj, */
-  /*if incall flag ON ,Don't care IVar
-       ,became resudual and it is pointed by copied FX's BLINK*/
+  /* if incall flag ON, don't care that IVar
+       became residual, and it is pointed to by copied FX's BLINK */
   oldPVar = PVar;
 
   if (*NeedHardreturnCleanup_word) { warn("HardreturnCleanup in do_stackoverflow"); }

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -349,7 +349,7 @@ LispPTR lcfuncall(register unsigned int atom_index, register int argnum, registe
   register struct definition_cell *defcell68k; /* Definition Cell PTR */
   register short pv_num;                       /* scratch for pv */
   register struct fnhead *tmp_fn;
-  int rest; /* use for arignments */
+  int rest; /* use for alignments */
 
   if (atom_index == 0xffffffff) error("Loops punt to nonexistent fn");
 

--- a/src/lpread.c
+++ b/src/lpread.c
@@ -31,7 +31,7 @@
   of all columns in the constraints and in the objectfunction
   Hash_tab : contains all columnnames on the first level of the structure
   the row information is kept under each column structure
-  in a linked list (also the objext funtion is in this structure)
+  in a linked list (also the objext function is in this structure)
   Bound information is also stored under under the column name
   First_rside : points to a linked list containing all relational operators
   and the righthandside values of the constraints

--- a/src/main.c
+++ b/src/main.c
@@ -630,9 +630,9 @@ void start_lisp() {
 
   FastRetCALL;
 
-  /* JRB - The interrupt intitialization must be done right before */
+  /* JRB - The interrupt initialization must be done right before  */
   /*       entering the bytecode dispatch loop; interrupts get     */
-  /*       unblocked here 					     */
+  /*       unblocked here 					   */
   int_init();
 #ifdef DOS
   _dpmi_lockregion((void *)&dispatch, 32768);

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -311,7 +311,7 @@ LispPTR make_atom(const char *char_base, DLword offset, DLword length, short int
 
   /* This point corresponds with LP in Lisp source */
 
-  /* following for loop never exits until it finds new hash enty or same atom */
+  /* following for loop never exits until it finds new hash entry or same atom */
   for (reprobe = Atom_reprobe(hash, first_char); (hash_entry = GETWORD(AtomHT + hash)) != 0;
        hash = ((hash + reprobe) & 0xffff)) {
     atom_index = hash_entry - 1;

--- a/src/mnxmeth.c
+++ b/src/mnxmeth.c
@@ -169,8 +169,8 @@ int gettitleheight(LispPTR medleywin)
 
 /**************************************************************/
 /* setlineattributes                                          */
-/* This function attempts to syncronize the line data in lisp */
-/* and X.                                                     */
+/* This function attempts to synchronize the line data in     */
+/* Lisp and X.                                                */
 /**************************************************************/
 void setlineattributes(Display *display, DspInterface dspif, WindowInterface wif, DISPLAYDATA *dd,
 		       LispPTR mwidth, LispPTR mdash)
@@ -606,7 +606,7 @@ int srcx, srcy, dstx, dsty, width, height, operation;
 /* Copy a drawable to a Medley bitmap. All coordinates are in X style.  */
 /* (i.e. y-coordinate assumed to be transformed)                        */
 /* Since XGetSubImage will generate an error if the drawable is outside */
-/* the rootwindow we have to get the geometry and clipp it with the     */
+/* the rootwindow we have to get the geometry and clip it with the      */
 /* geometry of the root window. (Urk!)                                  */
 /* This offcause means that anything outside the screen will have to be */
 /* ignored. (This has to be fixed. This sucks.).                        */
@@ -861,7 +861,7 @@ WindowInterface removewif(chain, wif) WindowInterface chain, wif;
 
 /************************************************************************/
 /* bubblewif                                                            */
-/* Make shure that the wif is the first wif in the chain of wifs on the */
+/* Make sure that the wif is the first wif in the chain of wifs on the  */
 /* dspif. If not, make it so.                                           */
 /* Return wif if we find wif. Return NIL if we don't find wif.          */
 /*                                                                      */
@@ -1497,13 +1497,13 @@ MNXdrawpoint(LispArgs args) /* args[0] = LispPTR to MedleyWindow */
 }
 
 /**************************************************************/
-/* MNXdrawline                                                  */
+/* MNXdrawline                                                */
 /* color not yet implemented                                  */
 /* Medleys Drawline can't handle dashing.                     */
-/* Thick lines in Medley are handled as parallellograms       */
+/* Thick lines in Medley are handled as parallelograms        */
 /* instead of rectangles.                                     */
-/* Remember that this method has an OPERATION arument in Lisp */
-/* so we have to fix that there.                              */
+/* Remember that this method has an OPERATION argument in     */
+/* Lisp so we have to fix that there.                         */
 /**************************************************************/
 MNXdrawline(LispArgs args) /* args[0] = LispPTR to MedleyWindow */
                                  /* args[1] = x1 */
@@ -2449,7 +2449,7 @@ MNXgetwindowprop(LispArgs args) /* args[0] = LispPTR to MedleyWindow */
 {}
 
 MNXputwindowprop(LispArgs args) /* args[0] = LispPTR to MedleyWindow */
-                                      /* args[1] = Lispint to despatch on. */
+                                      /* args[1] = Lispint to dispatch on. */
                                       /* args[n] = args for the method. */
 {
   int method;

--- a/src/mvs.c
+++ b/src/mvs.c
@@ -309,7 +309,7 @@ void simulate_unbind(FX2 *frame, int unbind_count, FX2 *returner) {
     /*	MAKEFREEBLOCK(stackptr, (DLword *)stackptr-nextblock); */
   }
   if (returner)
-    returner->fast = 0; /* since we've destroyed congituity */
+    returner->fast = 0; /* since we've destroyed contiguity */
                         /* in the stack, but that only
                            matters if there's a return. */
 }

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -353,7 +353,7 @@ LispPTR flush_pty() {
 #endif
     if (size == -1) return (NIL);
 
-    /* Check free space to avoid print System Error Mesage
+    /* Check free space to avoid printing System Error Message
        to /dev/console */
     TIMEOUT(rval = statvfs("/tmp", &vfsbuf));
     if (rval != 0) return (NIL);

--- a/src/rawcolor.c
+++ b/src/rawcolor.c
@@ -235,7 +235,7 @@ C_slowbltchar(LispPTR *args)
         src_y = (DLword)bottom;
       }
 
-      /* forground and bacground color */
+      /* foreground and background color */
 
       if (n_dd->ddcolor == NIL_PTR) {
         forecolor = PSEUDO_BLACK;
@@ -348,7 +348,7 @@ void ColorizeFont8_BIGBM(BITMAP *sBM, DLword sXOffset, DLword sYOffset, BIGBM *d
   dest_fragtop = 0;
   dest_fragbottom = dest_frag->bmheight;
 
-  /* search fragment of bitmaps including the desitnation top. */
+  /* search fragment of bitmaps including the destination top. */
   while (dest_fragbottom <= dYOffset) {
     GetNewFragment(dest_bmlist, dest_frag, BITMAP *);
     if (dest_frag == (BITMAP *)Addr68k_from_LADDR(NIL_PTR)) return;
@@ -362,7 +362,7 @@ void ColorizeFont8_BIGBM(BITMAP *sBM, DLword sXOffset, DLword sYOffset, BIGBM *d
 loop:
   /* height of lineBlt8 */
   if (dest_fragbottom > dest_bottom) {
-    /* this fragment inludes dest bottom. */
+    /* this fragment includes dest bottom. */
     dest_h = dest_bottom - (dest_fragtop + dest_yoffset);
   } else {
     /* remaining fragments include dest bottom. */

--- a/src/storage.c
+++ b/src/storage.c
@@ -74,7 +74,7 @@ void checkfor_storagefull(register unsigned int npages) {
       case SFS_NOTSWITCHABLE:
       case SFS_FULLYSWITCHED:
         if (pagesleft < 0) {
-          while (T) { error("MP9320:Storage completly full"); }
+          while (T) { error("MP9320:Storage completely full"); }
         } else if ((pagesleft <= GUARD1STORAGEFULL) && (*STORAGEFULL_word != NIL)) {
           *STORAGEFULL_word = S_POSITIVE;
           error(

--- a/src/subr.c
+++ b/src/subr.c
@@ -299,7 +299,7 @@ void OP_subrcall(int subr_no, int argnum) {
       break;
     case sb_COLOR_BASE:
       POP_SUBR_ARGS;
-      /* retun DLword offsetbetween LISPBASE and Lisp_world */
+      /* return DLword offset between LISPBASE and Lisp_world */
       TopOfStack = S_POSITIVE | (((int)Lisp_world >> 1) & 0xffff);
       break;
 

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -278,7 +278,7 @@ int type_num(LispPTR lispptr) {
 
 void dump_conspage(struct conspage *base, int linking)
 /* target conspage address */
-/* look for chaiing conspage ? T/NIL */
+/* look for chaining conspage ? T/NIL */
 {
   ConsCell *cell;
   int i;

--- a/src/timer.c
+++ b/src/timer.c
@@ -463,7 +463,7 @@ static void int_timer_init()
   _dpmi_lockregion((void *)prev_int_1c, sizeof(prev_int_1c));
 
   /* Set up the DOS time handler. */
-  prev_int_1c = _dos_getvect(0x1c); /* get addr of currnt 1c hndlr, */
+  prev_int_1c = _dos_getvect(0x1c); /* get addr of current 1c hndlr, */
                                     /* if any*/
   _dos_setvect(0x1c, DOStimer);     /* hook our int handler to timer int */
 
@@ -858,7 +858,7 @@ void DOStimer() {
   Irq_Stk_End = 0;
   /*   _dos_setvect(0x1c, prev_int_1c);
    } else if (tick_count <= 0) { */
-  /* I'm dead, uninstal me */
+  /* I'm dead, uninstall me */
   /*   _dos_setvect(0x1c, prev_int_1c);
      tick_count = 0;
    } */

--- a/src/ufn.c
+++ b/src/ufn.c
@@ -60,7 +60,7 @@ void ufn(DLword bytecode)
   register UFN *entry68k;
   register struct fnhead *tmp_fn;
   register unsigned int arg_num; /* Num of args */
-  register int rest;             /* use for arignments */
+  register int rest;             /* use for alignments */
 
 #ifdef TRACE
   printPC();

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -779,9 +779,9 @@ int unixpathname(char *src, char *dst, int versionp, int genp)
   *dp = '\0';
   if (!newdirflg && !genp) {
     /*
-     * If the last chracter in dst is a period, it have to be handled
+     * If the last character in dst is a period, it has to be handled
      * specially, because it might be used to specify that src has no
-     * extension field.  This case can be distinguish by examining the
+     * extension field.  This case can be distinguished by examining the
      * character just before the period.
      * If the specified pathname is one like "~>..", the last meta character
      * matches this case.  Thus we check newdirflg first so as not to be

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -73,7 +73,7 @@ loop:
 
 #include "locfile.h" /* for LispStringToCString. */
 
-/* JDS fixing protoypes char *malloc(size_t); */
+/* JDS fixing prototypes char *malloc(size_t); */
 
 int NPROCS = 100;
 

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -100,7 +100,7 @@ LispPTR *N_OP_unwind(register LispPTR *cstkptr, register LispPTR tos, int n, int
 
         find the blip down in the stack.  Similar to the LISP
         SI::UNWIND-TO-BLIP, except the target is returned instead
-        of doing the unwinding.  Note that the unwider parameter
+        of doing the unwinding.  Note that the unwinder parameter
         must already be properly set by the caller (i.e. to the
         alink if necessary).
 */

--- a/src/vgainit.c
+++ b/src/vgainit.c
@@ -88,7 +88,7 @@ unsigned long VGA_colornum(DspInterface dsp)
 unsigned long VGA_possiblecolors(DspInterface dsp)
 { return (dsp->colors); }
 
-void VGA_mono_drawline(DspInterface dsp, unsigned long startX, unsiged long startY, unsigned long width, unsigned long height,
+void VGA_mono_drawline(DspInterface dsp, unsigned long startX, unsigned long startY, unsigned long width, unsigned long height,
 		       int function, unsigned long color, unsigned long thickness, int butt,
 		       unsigned long clipX, unsigned long clipY, unsigned long clipWidth, unsigned long clipHeight,
 		       LispPTR *dashing)
@@ -97,7 +97,7 @@ void VGA_mono_drawline(DspInterface dsp, unsigned long startX, unsiged long star
   _lineto_w(width, height);
 }
 
-void VGA_color_drawline(DspInterface dsp, unsigned long startX, unsiged long startY, unsigned long width, unsigned long height,
+void VGA_color_drawline(DspInterface dsp, unsigned long startX, unsigned long startY, unsigned long width, unsigned long height,
 		       int function, unsigned long color, unsigned long thickness, int butt,
 		       unsigned long clipX, unsigned long clipY, unsigned long clipWidth, unsigned long clipHeight,
 		       LispPTR *dashing)

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -356,7 +356,7 @@ LispPTR vmem_save(char *sysout_file_name)
   vmemsize = InterfacePage->nactivepages;
 
   /*	[HH:6-Jan-89]
-          Sequnce of save image
+          Sequence of save image
           (1) Sysout image is saved to a temporary file, tempname.
           (2) if a specified file, sysout_file_name, is exist, the file is removed.
           (3) the temporary file is renamed to the specified file.

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -381,7 +381,7 @@ do_ring:
   r = RING_READ(CTopKeyevent);
   w = RING_WRITE(CTopKeyevent);
 
-  if (r == w) /* event queqe FULL */
+  if (r == w) /* event queue FULL */
     goto KBnext;
 
   kbevent = (KBEVENT *)(CTopKeyevent + w);


### PR DESCRIPTION
All space-delimited lowercase and capitalized words were extracted and run through a spelling checker.
Obvious spelling errors were corrected, along with some grammatical and punctuation errors noticed in the course of correcting the spelling.