### PR TITLE
unixfork.c needs to define `flushing`.

### DIFF
--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -42,7 +42,7 @@
 
 #ifdef DEBUG
 /* required by DBPRINT from dbprint.h */
-extern int flushing = 0;
+int flushing = 0;
 #endif
 
 /* The following globals are used to communicate between Unix


### PR DESCRIPTION
This shouldn't be an `extern` decl here as `unixfork.c` is built
into `lde` which doesn't get a copy of `main.c` linked in.