### PR TITLE
GitHub Actions: Only run build-pi for Interlisp/maiko

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,7 @@ jobs:
 
   build-pi:
     runs-on: [self-hosted, linux, ARM]
+    if: ${{ github.repository == 'Interlisp/maiko' }}
     steps:
       - uses: actions/checkout@v2
       - name: Build


### PR DESCRIPTION
The build-pi builder is self-hosted, so it may not be present,
and isn't present in forks of this repo, making the CI less
useful.