### PR TITLE
GitHub Actions: Update syntax for installing a cask from homebrew.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install X11 dependencies on MacOS
         if: ${{ runner.os == 'macOS'}}
-        run: brew cask install xquartz
+        run: brew install --cask xquartz
       - name: Build
         working-directory: bin
         run: ./makeright x


### PR DESCRIPTION
Homebrew on the macOS build machines for GitHub Actions was
updated to version 2.7 and that deprecated the `brew cask install`
syntax in favor of `brew install --cask`, so we need to update
here.

The announcement for the GitHub change is:

https://github.com/actions/virtual-environments/issues/2415