### PR TITLE
Correct some ifdefs from ISC to RESWAPPEDCODESTREAM.

### DIFF
--- a/inc/return.h
+++ b/inc/return.h
@@ -33,7 +33,7 @@
 
 
 /* FAST case return use */
-#ifndef ISC
+#ifndef RESWAPPEDCODESTREAM
 #define FastRetCALL							\
   {									\
     /* Get IVar from Returnee's IVAR offset slot(BF) */ 			\
@@ -60,7 +60,7 @@
 	FuncObj->byteswapped = 1;				\
       }								\
   }
-#endif /* ISC */
+#endif /* RESWAPPEDCODESTREAM */
 
 
 

--- a/src/mvs.c
+++ b/src/mvs.c
@@ -72,12 +72,12 @@ newframe:
     fnhead = (struct fnhead *)Addr68k_from_LADDR(POINTERMASK & SWA_FNHEAD((int)caller->fnheader));
     pc = (ByteCode *)fnhead + (caller->pc);
   }
-#ifdef ISC
+#ifdef RESWAPPEDCODESTREAM
   if (!fnhead->byteswapped) {
     byte_swap_code_block(fnhead);
     fnhead->byteswapped = 1;
   }
-#endif /* ISC */
+#endif /* RESWAPPEDCODESTREAM */
 
 newpc:
 #ifdef ISC
@@ -177,12 +177,12 @@ newframe:
     pc = (ByteCode *)fnhead + (caller->pc);
   }
 
-#ifdef ISC
+#ifdef RESWAPPEDCODESTREAM
   if (!fnhead->byteswapped) {
     byte_swap_code_block(fnhead);
     fnhead->byteswapped = 1;
   }
-#endif /* ISC */
+#endif /* RESWAPPEDCODESTREAM */
 
 newpc:
 #ifdef ISC


### PR DESCRIPTION
`RESWAPPEDCODESTREAM` was only used on ISC, so some `#ifdef`'s were
previously set up incorrectly.