### PR TITLE
Remove incorrect SUN3_OS3_OS4_il ifdef.

### DIFF
--- a/src/sxhash.c
+++ b/src/sxhash.c
@@ -111,13 +111,10 @@ static unsigned short sxhash(LispPTR obj) {
   }
 }
 
-#ifndef SUN3_OS3_OR_OS4_IL
 /* Rotates the 16-bit work to the left 7 bits (or to the right 9 bits) */
 static unsigned short sxhash_rotate(short unsigned int value) {
   return ((value << 7) | ((value >> 9) & 0x7f));
 }
-
-#endif
 
 static unsigned short sxhash_string(OneDArray *obj) {
   unsigned len, offset;


### PR DESCRIPTION
The definition of a function was ifdef'd out, making it seem
like perhaps there was an assembly implementation, but there
isn't. That platform support is dead weight also at this point,
so removing this because it isn't something that will come back
is fine.