### PR TITLE
Remove -funsigned-char from standard compilation options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,11 @@ IF(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_ID MATCHES "GNU")
   IF(UNIX AND CMAKE_GENERATOR STREQUAL "Ninja")
     SET(CMAKE_C_FLAGS "-fdiagnostics-color=always ${CMAKE_C_FLAGS}")
   ENDIF()
-  SET(CMAKE_C_FLAGS "-funsigned-char -fno-strict-aliasing -fwrapv ${CMAKE_C_FLAGS}")
+  SET(CMAKE_C_FLAGS "-fno-strict-aliasing -fwrapv ${CMAKE_C_FLAGS}")
+ENDIF()
+
+IF(CMAKE_C_COMPILER_ID MATCHES "SunPro")
+  SET(CMAKE_C_FLAGS "-fno-strict-aliasing ${CMAKE_C_FLAGS}")
 ENDIF()
 
 INCLUDE(CheckLibraryExists)

--- a/bin/makefile-header
+++ b/bin/makefile-header
@@ -14,8 +14,9 @@ AR = ar rcv
 ANSICC = $(CC)
 
 # Compiler flags
-CLANG_CFLAGS = -std=gnu99 -funsigned-char -fno-strict-aliasing -fwrapv
-GCC_CFLAGS = -std=gnu99 -funsigned-char -fno-strict-aliasing -fwrapv
+CLANG_CFLAGS = -std=gnu99 -fno-strict-aliasing -fwrapv
+GCC_CFLAGS = -std=gnu99 -fno-strict-aliasing -fwrapv
+DEVSTUDIO_CFLAGS = -std=gnu99 -fno-strict-aliasing
 
 # for the files that need to be included in byte-swapped implementations:
 BYTESWAPFILES =

--- a/bin/makefile-sunos5.sparc-x
+++ b/bin/makefile-sunos5.sparc-x
@@ -15,9 +15,9 @@
 # Setup for using gcc
 #  CC = gcc $(GCC_CFLAGS)
 # Setup for using Solaris Developer Studio 12.6 cc
-#  CC = cc -m32 -funsigned-char
+#  CC = cc -m32 $(DEVSTUDIO_CFLAGS)
 
-CC = cc -m32 -funsigned-char -O2
+CC = cc -m32 $(DEVSTUDIO_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \


### PR DESCRIPTION
Using -funsigned-char causes the Oracle Developer Studio C compiler typedefs for
int8_t to become unsigned (uint8_t) rather than signed, with no warning or
other indication that this has happened.

Add standardized options for Oracle Developer Studio C compiler (aka SunPro C)

Fixes Interlisp/medley#152