### PR TITLE
Remove unnecessary codepaths for ISC.

### DIFF
--- a/src/mvs.c
+++ b/src/mvs.c
@@ -80,11 +80,7 @@ newframe:
 #endif /* RESWAPPEDCODESTREAM */
 
 newpc:
-#ifdef ISC
-  opcode = (short)((unsigned char)*((char *)pc));
-#else
   opcode = (short)((unsigned char)GETBYTE((char *)pc));
-#endif
   switch (opcode) {
     case opc_RETURN:
     case opc_SLRETURN:
@@ -116,11 +112,7 @@ newpc:
 
     case opc_JUMPX: {
       register short displacement;
-#ifdef ISC
-      displacement = (short)(*((char *)pc + 1));
-#else
       displacement = (short)(GETBYTE((char *)pc + 1));
-#endif
       if (displacement >= 128) displacement -= 256;
       pc += displacement;
       goto newpc;
@@ -185,11 +177,7 @@ newframe:
 #endif /* RESWAPPEDCODESTREAM */
 
 newpc:
-#ifdef ISC
-  opcode = (short)((unsigned char)*((char *)pc));
-#else
   opcode = (short)((unsigned char)GETBYTE((char *)pc));
-#endif
   switch (opcode) {
     case opc_RETURN:
     case opc_SLRETURN:
@@ -221,11 +209,7 @@ newpc:
 
     case opc_JUMPX: {
       register short displacement;
-#ifdef ISC
-      displacement = (short)(*((char *)pc + 1));
-#else
       displacement = (short)(GETBYTE((char *)pc + 1));
-#endif
       if (displacement >= 128) displacement -= 256;
       pc += displacement;
       goto newpc;

--- a/src/xc.c
+++ b/src/xc.c
@@ -197,20 +197,15 @@ void dispatch(void) {
   InstPtr *table;
 #else
 #if defined(OPDISP) || defined(SPARCDISP)
-#ifdef ISC
   InstPtr *table;
-#else
-  register InstPtr *table;
-#endif
 #endif /* OPDISP */
 #endif /* I386 */
 
-#ifdef ISC
-#elif (DOS && OPDISP)
+#if (DOS && OPDISP)
 #else
   register LispPTR *cspcache;
   register LispPTR tscache;
-#endif /* ISC */
+#endif
 
 #ifdef sparc
   register struct state *stateptrcache = MState;
@@ -286,11 +281,7 @@ void dispatch(void) {
   UFN_CALLS;
 
 op_ufn : {
-#ifdef ISC
   UFN *entry68k;
-#else
-  register UFN *entry68k;
-#endif
   entry68k = (UFN *)GetUFNEntry(Get_BYTE_PCMAC0);
   fn_num_args = entry68k->arg_num;
   fn_opcode_size = entry68k->byte_num + 1;


### PR DESCRIPTION
ISC support had some extra code paths that were largely
duplicates of what was for non-ISC. They are not needed
any longer.