### PR TITLE
Fix sunwindow include ifdefery on vmemsave.c.

### DIFF
--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -36,9 +36,9 @@
 #define alarm(x) 1
 #endif /* DOS */
 
-#ifndef NOPIXRECT
+#if defined(SUNDISPLAY) && defined(OLD_CURSOR)
 #include <sunwindow/win_cursor.h>
-#endif /* NOPIXRECT */
+#endif
 
 #include "hdw_conf.h"
 #include "lispemul.h"


### PR DESCRIPTION
The cursor management code is `#ifdef` `SUNDISPLAY` and
`OLD_CURSOR`, not `NOPIXRECT`, so do the same for the
header include.