### PR TITLE
Bit of cleanup for Lisp_Xinitialized.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -249,7 +249,6 @@ char keystring[128] = {""};
 #define FALSE 0
 #define TRUE !FALSE
 
-int Lisp_Xinitialized = FALSE;
 char sysout_name[MAXPATHLEN]; /* Set by read_Xoption, in the X version. */
 int sysout_size = 0;    /* ditto */
 

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -29,7 +29,7 @@
 extern IOPAGE *IOPage;
 
 extern XGCValues gcv;
-extern int Lisp_Xinitialized, Bitmap_Pad, Default_Depth;
+extern int Bitmap_Pad, Default_Depth;
 
 GC cursor_source_gc, cursor_mask_gc;
 XColor cursor_fore_xcsd, cursor_back_xcsd, xced;

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -10,6 +10,7 @@
 
 #include "version.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -104,6 +105,8 @@ void init_Xevent(DspInterface dsp)
 /************************************************************************/
 void lisp_Xexit(DspInterface dsp)
 {
+  assert(Lisp_Xinitialized);
+
 #if defined(OS5) && defined(I_SETSIG)
   ioctl(ConnectionNumber(dsp->display_id), I_SETSIG, 0); /* so no interrupts happen during */
 #endif
@@ -172,7 +175,9 @@ void Xevent_after_raid(DspInterface dsp)
 /************************************************************************/
 void Open_Display(DspInterface dsp)
 {
-    FD_SET(ConnectionNumber(dsp->display_id), &LispReadFds);
+  assert(Lisp_Xinitialized == false);
+
+  FD_SET(ConnectionNumber(dsp->display_id), &LispReadFds);
   fcntl(ConnectionNumber(dsp->display_id), F_SETOWN, getpid());
 
   /****************************************************/

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -10,6 +10,7 @@
 
 #include "version.h"
 
+#include <stdbool.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <X11/X.h>
@@ -40,15 +41,13 @@
 #include <stropts.h>
 #endif /* OS5 */
 
-#define FALSE 0
-#define TRUE !FALSE
 #define PERCENT_OF_SCREEN 95
 #define DISPLAY_MAX 65536 * 16 * 2 /* same magic number is */
                                    /* in loadsysout.c      */
 extern DLword *Lisp_world;
-extern int Lisp_Xinitialized;
 extern char Display_Name[128];
 extern DLword *DisplayRegion68k;
+bool Lisp_Xinitialized = false;
 int xsync = False;
 
 int Byte_Order, Bitmap_Bit_Order, Bitmap_Pad, Default_Depth, Display_Height, Display_Width;
@@ -113,7 +112,7 @@ void lisp_Xexit(DspInterface dsp)
   XDestroyWindow(dsp->display_id, dsp->LispWindow);
   XCloseDisplay(dsp->display_id);
 
-  Lisp_Xinitialized = FALSE;
+  Lisp_Xinitialized = false;
 } /* end lisp_Xexit */
 
 /************************************************************************/
@@ -192,7 +191,7 @@ void Open_Display(DspInterface dsp)
   if (dsp->ScreenBitmap.data == NULL) dsp->ScreenBitmap.data = (char *)DisplayRegion68k;
 
   Create_LispWindow(dsp); /* Make the main window */
-  Lisp_Xinitialized = TRUE;
+  Lisp_Xinitialized = true;
   init_Xevent(dsp); /* Turn on the intrpts. */
 } /* end OpenDisplay */
 


### PR DESCRIPTION
* Remove the `extern` from `xcursor.c`, where it was not used.
* Move the definition from `main.c` to `xinit.c` as it is
  the only file using it.
* Use `stdbool.h` for it rather than an `int` with custom `TRUE`
  and `FALSE` values.