### PR TITLE
Change icon, cursor images and masks to const uint8_t

### DIFF
--- a/inc/xbitmaps.h
+++ b/inc/xbitmaps.h
@@ -11,40 +11,40 @@
 /*									*/
 /************************************************************************/
 
-
+#include <stdint.h>
 
 
 
 
 typedef struct {
 	short cubitsprepixel;	/* bits per pixel in the cursor, mostly 1 */
-	char *cuimage;		/* the image bitmap */
-	char *cumask;		/* the mask bitmap */
+	const uint8_t *cuimage;	/* the image bitmap */
+	const uint8_t *cumask;	/* the mask bitmap */
 	short cuhotspotx;	/* hot-spot X coordinate */
 	short cuhotspoty;	/* hot-spot Y coordinate */
 	short cudata;		/* ?? */
 } LISP_CURSOR;
 
-char defaultcursor_bitmap[]=
+const uint8_t defaultcursor_bitmap[]=
   {
-	  0x80, 0, 0xc0, 0, 0xe0, 0, 0xf0, 0 
+	  0x80, 0, 0xc0, 0, 0xe0, 0, 0xf0, 0
 	, 0xf8, 0, 0xfc, 0, 0xfe, 0, 0xf0, 0
 	, 0xd8, 0, 0x98, 0, 0x0c, 0, 0x0c, 0
 	, 0x06, 0, 0x06, 0, 0x03, 0, 0x03, 0
   };
 	
 LISP_CURSOR default_cursor =
-  { 
+  {
      1
    , defaultcursor_bitmap
    , defaultcursor_bitmap
    , 0
    , 15
-   , 0 
+   , 0
   };
 
 
-char waitcursor_bitmap[]=
+const uint8_t  waitcursor_bitmap[]=
   {
 	  0xFF, 0xFE, 0xC0, 0x06, 0x60, 0x1C, 0x3D, 0x78
 	, 0x1F, 0xF0, 0x0F, 0xE0, 0x06, 0xC0, 0x03, 0x80
@@ -62,7 +62,7 @@ LISP_CURSOR wait_cursor =
    , 0
   };
 	
-char horizscrollcursor_bitmap[]={
+const uint8_t horizscrollcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -92,7 +92,7 @@ LISP_CURSOR horizscroll_cursor = {
 	
 
 
-char horizthumbcursor_bitmap[]={
+const uint8_t horizthumbcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -122,7 +122,7 @@ LISP_CURSOR horizthumb_cursor = {
 	
 
 
-char scrolldowncursor_bitmap[]={
+const uint8_t scrolldowncursor_bitmap[]={
 		  0x03, 0x80
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -152,7 +152,7 @@ LISP_CURSOR scrolldown_cursor = {
 	
 
 
-char scrollleftcursor_bitmap[]={
+const uint8_t scrollleftcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -182,7 +182,7 @@ LISP_CURSOR scrollleft_cursor = {
 	
 
 
-char scrollrightcursor_bitmap[]={
+const uint8_t scrollrightcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -212,7 +212,7 @@ LISP_CURSOR scrollright_cursor = {
 	
 
 
-char scrollupcursor_bitmap[]={
+const uint8_t scrollupcursor_bitmap[]={
 		  0x01, 0x00
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -242,7 +242,7 @@ LISP_CURSOR scrollup_cursor = {
 	
 
 
-char vertscrollcursor_bitmap[]={
+const uint8_t vertscrollcursor_bitmap[]={
 		  0x01, 0x00
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -272,7 +272,7 @@ LISP_CURSOR vertscroll_cursor = {
 	
 
 
-char vertthumbcursor_bitmap[]={
+const uint8_t vertthumbcursor_bitmap[]={
 		 0x00,0x00
 		,0x00,0x1f
 		,0x00,0x00
@@ -303,7 +303,7 @@ LISP_CURSOR vertthumb_cursor = {
 int check_width = 16;
 int check_height = 16;
 
-static char check_bits[] = {  0x88, 0x88,
+static const uint8_t check_bits[] = {  0x88, 0x88,
 			      0x00, 0x00,
 			      0x22, 0x22,
 			      0x00, 0x00,
@@ -319,7 +319,7 @@ static char check_bits[] = {  0x88, 0x88,
 			      0x00, 0x00,
 			      0x22, 0x22,
 			      0x00, 0x00 };
-static char plain_bits[] =  {   0x00, 0x00,
+static const uint8_t plain_bits[] =  {   0x00, 0x00,
 				0x00, 0x00,
 				0x00, 0x00,
 				0x00, 0x00,
@@ -339,7 +339,7 @@ static char plain_bits[] =  {   0x00, 0x00,
 int Lisp_icon_width = 88;
 int Lisp_icon_height = 58;
 
-char Lisp_icon[] = 
+const uint8_t Lisp_icon[] =
   {
     0x82, 0x08, 0x20, 0x82, 0x08, 0x20, 0x82, 0x08, 0x20, 0x82, 0x08,
     0x20, 0x82, 0x08, 0x20, 0x82, 0x08, 0x20, 0x82, 0x08, 0x3f, 0xe2,
@@ -398,6 +398,6 @@ char Lisp_icon[] =
     0x02, 0x16, 0x50, 0x49, 0x08, 0x49, 0x42, 0x12, 0x02, 0x15, 0x20,
     0x02, 0x0a, 0x50, 0x84, 0xc8, 0x32, 0x21, 0xcc, 0x93, 0xc8, 0xe0,
     0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x20, 0x00, 0x00,
-    0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 
+    0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
   };
 #endif /* XBITMAPS_H */

--- a/inc/xcursordefs.h
+++ b/inc/xcursordefs.h
@@ -1,9 +1,10 @@
 #ifndef XCURSORDEFS_H
 #define XCURSORDEFS_H 1
+#include <stdint.h>
 #include <X11/Xlib.h>
 #include "devif.h"
 void Init_XCursor(void);
 void Set_XCursor(int x, int y);
 void init_Xcursor(Display *display, Window window);
-void set_Xcursor(DspInterface dsp, unsigned char *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp);
+void set_Xcursor(DspInterface dsp, const uint8_t *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp);
 #endif

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -74,7 +74,7 @@ void Init_XCursor() {
   cursorlist = (struct MXCURSOR *)malloc(sizeof(struct MXCURSOR));
   cursorlist->next = NULL;
   for (i = 0; i < CURSORHEIGHT; i++) cursorlist->bitmap[i] = newbm[i];
-  set_Xcursor(currentdsp, (unsigned char *)newbm, 0, 0, &(cursorlist->Xid), 1);
+  set_Xcursor(currentdsp, (uint8_t *)newbm, 0, 0, &(cursorlist->Xid), 1);
   DefineCursor(currentdsp->display_id, currentdsp->DisplayWindow, &(cursorlist->Xid));
 } /* end Init_XCursor */
 
@@ -113,9 +113,9 @@ void Set_XCursor(int x, int y)
     for (i = 0; i < CURSORHEIGHT; i++) clp->bitmap[i] = newbm[i];
 #ifdef NEWXCURSOR
     /* JDS 000521 Added "15-" to fix cursor troubles at window edge */
-    set_Xcursor(currentdsp, (unsigned char *)newbm, x, 15 - y, &(clp->Xid), 1);
+    set_Xcursor(currentdsp, (uint8_t *)newbm, x, 15 - y, &(clp->Xid), 1);
 #else
-    set_Xcursor(currentdsp, (unsigned char *)newbm, 0, 0, &(clp->Xid), 1);
+    set_Xcursor(currentdsp, (uint8_t *)newbm, 0, 0, &(clp->Xid), 1);
 #endif /* NEWXCURSOR */
     clp->next = cursorlist;
     cursorlist = clp;
@@ -191,7 +191,7 @@ void init_Xcursor(Display *display, Window window)
 /*									*/
 /************************************************************************/
 
-void set_Xcursor(DspInterface dsp, unsigned char *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp)
+void set_Xcursor(DspInterface dsp, const uint8_t *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp)
 {
   extern unsigned char reversedbits[];
   unsigned char image[32];

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -159,35 +159,35 @@ void Create_LispWindow(DspInterface dsp)
   /*********************************************************************/
 
   dsp->ScrollBarPixmap = XCreatePixmapFromBitmapData(
-      dsp->display_id, dsp->LispWindow, check_bits, check_width, check_height,
+      dsp->display_id, dsp->LispWindow, (char *)check_bits, check_width, check_height,
       BlackPixelOfScreen(screen), WhitePixelOfScreen(screen), DefaultDepthOfScreen(screen));
   dsp->GravityOnPixmap = XCreatePixmapFromBitmapData(
-      dsp->display_id, dsp->LispWindow, check_bits, 16, 16, BlackPixelOfScreen(screen),
+      dsp->display_id, dsp->LispWindow, (char *)check_bits, 16, 16, BlackPixelOfScreen(screen),
       WhitePixelOfScreen(screen), DefaultDepthOfScreen(screen));
 
   dsp->GravityOffPixmap = XCreatePixmapFromBitmapData(
-      dsp->display_id, dsp->LispWindow, plain_bits, 16, 16, BlackPixelOfScreen(screen),
+      dsp->display_id, dsp->LispWindow, (char *)plain_bits, 16, 16, BlackPixelOfScreen(screen),
       WhitePixelOfScreen(screen), DefaultDepthOfScreen(screen));
 
-  set_Xcursor(dsp, (unsigned char *)default_cursor.cuimage, (int)default_cursor.cuhotspotx,
+  set_Xcursor(dsp, default_cursor.cuimage, (int)default_cursor.cuhotspotx,
               (int)(15 - default_cursor.cuhotspoty), &DefaultCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)wait_cursor.cuimage, (int)wait_cursor.cuhotspotx,
+  set_Xcursor(dsp, wait_cursor.cuimage, (int)wait_cursor.cuhotspotx,
               (int)(15 - wait_cursor.cuhotspoty), &WaitCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)scrolldown_cursor.cuimage, (int)scrolldown_cursor.cuhotspotx,
+  set_Xcursor(dsp, scrolldown_cursor.cuimage, (int)scrolldown_cursor.cuhotspotx,
               (int)(15 - scrolldown_cursor.cuhotspoty), &ScrollDownCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)scrollleft_cursor.cuimage, (int)scrollleft_cursor.cuhotspotx,
+  set_Xcursor(dsp, scrollleft_cursor.cuimage, (int)scrollleft_cursor.cuhotspotx,
               (int)(15 - scrollleft_cursor.cuhotspoty), &ScrollLeftCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)vertscroll_cursor.cuimage, (int)vertscroll_cursor.cuhotspotx,
+  set_Xcursor(dsp, vertscroll_cursor.cuimage, (int)vertscroll_cursor.cuhotspotx,
               (int)(15 - vertscroll_cursor.cuhotspoty), &VertScrollCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)vertthumb_cursor.cuimage, (int)vertthumb_cursor.cuhotspotx,
+  set_Xcursor(dsp, vertthumb_cursor.cuimage, (int)vertthumb_cursor.cuhotspotx,
               (int)(15 - vertthumb_cursor.cuhotspoty), &VertThumbCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)horizscroll_cursor.cuimage, (int)horizscroll_cursor.cuhotspotx,
+  set_Xcursor(dsp, horizscroll_cursor.cuimage, (int)horizscroll_cursor.cuhotspotx,
               (int)(15 - horizscroll_cursor.cuhotspoty), &HorizScrollCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)horizthumb_cursor.cuimage, (int)horizthumb_cursor.cuhotspotx,
+  set_Xcursor(dsp, horizthumb_cursor.cuimage, (int)horizthumb_cursor.cuhotspotx,
               (int)(15 - horizthumb_cursor.cuhotspoty), &HorizThumbCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)scrollright_cursor.cuimage, (int)scrollright_cursor.cuhotspotx,
+  set_Xcursor(dsp, scrollright_cursor.cuimage, (int)scrollright_cursor.cuhotspotx,
               (int)(15 - scrollright_cursor.cuhotspoty), &ScrollRightCursor, 0);
-  set_Xcursor(dsp, (unsigned char *)scrollup_cursor.cuimage, (int)scrollup_cursor.cuhotspotx,
+  set_Xcursor(dsp, scrollup_cursor.cuimage, (int)scrollup_cursor.cuhotspotx,
               (int)(15 - scrollup_cursor.cuhotspoty), &ScrollUpCursor, 0);
 
   /********************************/

--- a/src/xmkicon.c
+++ b/src/xmkicon.c
@@ -12,6 +12,7 @@
 #include "version.h"
 
 #include <stdio.h>
+#include <stdint.h>
 
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -26,7 +27,7 @@
 XImage IconImage;
 
 extern int Bitmap_Pad, Default_Depth, Lisp_icon_width, Lisp_icon_height;
-extern char Lisp_icon[];
+extern uint8_t Lisp_icon[];
 
 extern Pixmap IconPixmap;
 extern char iconpixmapfile[1024];


### PR DESCRIPTION
The predefined cursors (image and mask) are better represented
as arrays of const uint8_t rather than char.  Likewise for the
window icon.  Track this change in the functions that take the
image and mask as arguments, casting only when we get to the
X library functions that take char*.