### PR TITLE
Use the C99 floating point error code on Solaris.

### DIFF
--- a/inc/medleyfp.h
+++ b/inc/medleyfp.h
@@ -39,11 +39,6 @@ extern volatile sig_atomic_t FP_error;
 #define FPCLEAR         FP_error = 0;
 #define FPTEST(result)  FP_error
 
-#elif defined(OS5)
-#include <ieeefp.h>
-#define FPCLEAR
-#define FPTEST(result) (!finite(result))
-
 #elif defined(DOS)
 #include <i32.h>
 #define FPCLEAR


### PR DESCRIPTION
Previously, we were building as C89 and the new code required
the C99 flag on Solaris with Sun Studio. Now that we build as
C99, this should work now and we can remove the special case
code.