### PR TITLE
Remove macOS 11 from GitHub Actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11.0, macos-10.15, ubuntu-20.04, ubuntu-18.04]
+        os: [macos-10.15, ubuntu-20.04, ubuntu-18.04]
     env:
       BUILD_TYPE: Release
     steps:


### PR DESCRIPTION
This platform is experimental on their end and is having
capacity problems. We don't need it for now and the noise
of the failures is not worth it.