### PR TITLE
xc.c: Remove sparc-only optimization hack.

### DIFF
--- a/src/xc.c
+++ b/src/xc.c
@@ -207,12 +207,6 @@ void dispatch(void) {
   register LispPTR tscache;
 #endif
 
-#ifdef sparc
-  register struct state *stateptrcache = MState;
-#undef MState
-#define MState stateptrcache
-#endif
-
   /* OP_FN_COMMON arguments */
 
   DefCell *fn_defcell;


### PR DESCRIPTION
It looks like this was trying to force a pointer into a register,
but only for SPARC.