### PR TITLE
Remove unintentional coercion from float to double.

### DIFF
--- a/src/eqf.c
+++ b/src/eqf.c
@@ -219,7 +219,7 @@ arg2_small:
     register float f1, f2;
     N_MakeFloat(arg1, f1, arg2);
     N_MakeFloat(arg2, f2, arg2);
-    if ((f1 + 0.0) == (f2 + 0.0))
+    if ((f1 + 0.0f) == (f2 + 0.0f))
       return (ATOM_T);
     else
       return (NIL);

--- a/src/ubf2.c
+++ b/src/ubf2.c
@@ -66,7 +66,7 @@ LispPTR N_OP_ubfloat2(int a2, int a1, int alpha) {
         return (a1);
       else
         return (a2);
-    case 8: /* rem */ ans = fmod(arg2, arg1); break;
+    case 8: /* rem */ ans = fmodf(arg2, arg1); break;
     default: ERROR_EXIT(a1);
   } /* end switch */
 


### PR DESCRIPTION
By adding `0.0` and not `0.0f` and by calling `fmod()` rather than
`fmodf()`, we were unintentionally coercing the value from a
`float` to a `double`.

This resulted in x86_64 assembler like this:

```
    cvtss2sd %xmm0,%xmm0
    cvtss2sd %xmm1,%xmm1
    callq  403340 <fmod@plt>
    cvtsd2ss %xmm0,%xmm0
```

which is now:

```
    callq  403360 <fmodf@plt>
```

And for the `N_OP_equal` change:

```
    cvtss2sd %xmm0,%xmm0
    xorpd  %xmm2,%xmm2
    addsd  %xmm2,%xmm0
    cvtss2sd %xmm1,%xmm1
    addsd  %xmm2,%xmm1
    xor    %ecx,%ecx
    ucomisd %xmm1,%xmm0
```

is now:

```
    xorps  %xmm2,%xmm2
    addss  %xmm2,%xmm0
    addss  %xmm2,%xmm1
    xor    %ecx,%ecx
    ucomiss %xmm1,%xmm0
```

(Note `ss` rather than `sd`, along with the missing `cvtss2sd` calls.)