### PR TITLE
build: Don't run ls -l when building ldeether.

### DIFF
--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -187,7 +187,6 @@ $(OSARCHDIR)$(LDENAME) :       $(LIBFILES) $(EXTFILES) $(OSARCHDIR)mkvdate
 
 $(OSARCHDIR)ldeether :  $(SRCDIR)ldeether.c $(DLPIFILES)
 	$(CC) $(CFLAGS) -I$(INCDIR) $(SRCDIR)ldeether.c $(DLPIFILES) $(LDEETHERLDFLAGS) -o $(OSARCHDIR)ldeether
-	ls -l $(OSARCHDIR)ldeether
 
 $(OSARCHDIR)mkvdate	: $(SRCDIR)mkvdate.c $(REQUIRED-INCS)
 	$(CC) $(CFLAGS) -I$(INCDIR) $(SRCDIR)mkvdate.c -o $(OSARCHDIR)mkvdate


### PR DESCRIPTION
Perhaps this was there as a reminder about it needing to be
`setuid`, but it shouldn't be in the default build output.