### PR TITLE
Remove special rules for building xc.c.

### DIFF
--- a/bin/makefile-cygwin.x86_64-x
+++ b/bin/makefile-cygwin.x86_64-x
@@ -20,7 +20,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS = -O2 -g3
 FPFLAGS =
 DFLAGS = -DAIX -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -36,18 +35,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-darwin.386-x
+++ b/bin/makefile-darwin.386-x
@@ -18,7 +18,6 @@ XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g
-DISPOPTFLAGS = -O2 -g
 FPFLAGS =
 DEBUGFLAGS = # -DDEBUG -DOPTRACE
 DFLAGS = $(DEBUGFLAGS) -DOLD_CURSOR \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -18,7 +18,6 @@ XFLAGS = -I/opt/local/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O1 -g
-DISPOPTFLAGS = -O1 -g
 FPFLAGS =
 DEBUGFLAGS = # -DDEBUG -DOPTRACE
 DFLAGS = $(DEBUGFLAGS) -DOLD_CURSOR \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -18,7 +18,6 @@ XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O1 -g
-DISPOPTFLAGS = -O1 -g
 FPFLAGS =
 DEBUGFLAGS = # -DDEBUG -DOPTRACE
 DFLAGS = $(DEBUGFLAGS) -DOLD_CURSOR \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-freebsd.386-x
+++ b/bin/makefile-freebsd.386-x
@@ -19,7 +19,6 @@ XFLAGS = -I/usr/local/include -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS = -O1 -gdwarf-2
-DISPOPTFLAGS = -O1 -gdwarf-2 
 FPFLAGS =
 DFLAGS = -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-init.386
+++ b/bin/makefile-init.386
@@ -18,7 +18,6 @@ XFLAGS = -I/opt/X11/include -DXWINDOW -DNOPIXRECT
 
 # OPTFLAGS is normally -O2, for INIT we want unoptimized in case we need to debug it
 OPTFLAGS =  -O0 -g
-DISPOPTFLAGS = -O0 -g
 FPFLAGS =
 DFLAGS = -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -34,18 +33,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-init.sparc
+++ b/bin/makefile-init.sparc
@@ -38,7 +38,6 @@ XFLAGS = -DXWINDOW -I/usr/openwin/include
 OEXT = .o
 # OPTFLAGS is normally -g for MAKEINIT, as it needs debugging often.
 OPTFLAGS = -g3 -O
-DISPOPTFLAGS = -g3 -O
 
 # Set any debugging options in DEBUGFLAGS.  E.g., to enable stack
 # checking, use -DSTACKCHECK; to enable the fn-call-time stack
@@ -84,29 +83,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 
 default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldeether
-
-# Special rules to create xc.c with GCC
-
-#run cpp to expand macros
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-	 $(INCDIR)inln68k.h
-	$(CC) -c $(DISPOPTFLAGS) $(DFLAGS) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.o
-
-#$(OBJECTDIR)xc.o:	$(SRCDIR)xc.i $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-#	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-#	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-#	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-#	 $(INCDIR)arith.h $(INCDIR)stream.h \
-#	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-#	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   \
-#	 $(INCDIR)inln68k.h
-#	$(CC) -c $(DISPOPTFLAGS) $(SRCDIR)xc.i -o $(OBJECTDIR)xc.o
-
-
-

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -19,7 +19,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS = -O2 -g3
 FPFLAGS =
 DFLAGS = -DAIX -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-linux.armv7l-x
+++ b/bin/makefile-linux.armv7l-x
@@ -19,7 +19,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS = -O2 -g3
 FPFLAGS =
 DFLAGS = -DAIX -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -20,7 +20,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS = -O2 -g3
 FPFLAGS =
 DFLAGS = -DAIX -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -36,18 +35,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde 
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h   
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-openbsd.x86_64-x
+++ b/bin/makefile-openbsd.x86_64-x
@@ -19,7 +19,6 @@ XFLAGS = -I/usr/X11R6/include -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS = -O2 -g3
 FPFLAGS =
 DFLAGS = -DAIX -DOLD_CURSOR \
 	-DBYTESWAP -DLOGINT  $(XFLAGS) \
@@ -35,18 +34,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde
-
-############
-#
-#	SPECIAL xc.o  for debugging
-#
-############
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	 $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	 $(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-sunos5.386-x
+++ b/bin/makefile-sunos5.386-x
@@ -28,7 +28,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g
-DISPOPTFLAGS =  -O2 -g
 
 # Set any debugging options in DEBUGFLAGS.  E.g., to enable stack
 # checking, use -DSTACKCHECK; to enable the fn-call-time stack
@@ -63,18 +62,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 
 default:	../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldeether
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-sunos5.i386-x
+++ b/bin/makefile-sunos5.i386-x
@@ -28,7 +28,6 @@ XFLAGS = -DXWINDOW
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS =  -O2 -g3
 
 # Set any debugging options in DEBUGFLAGS.  E.g., to enable stack
 # checking, use -DSTACKCHECK; to enable the fn-call-time stack
@@ -66,12 +65,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 
 default:	../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldeether
-
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC)  $(DISPRFLAGS) $(INLINE) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.o

--- a/bin/makefile-sunos5.sparc-x
+++ b/bin/makefile-sunos5.sparc-x
@@ -35,7 +35,6 @@ XFLAGS = -DXWINDOW
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g3
-DISPOPTFLAGS =  -O2 -g3
 
 # Set any debugging options in DEBUGFLAGS.  E.g., to enable stack
 # checking, use -DSTACKCHECK; to enable the fn-call-time stack
@@ -74,12 +73,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 
 default:	../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldeether
-
-$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h  $(INCDIR)address.h \
-	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	 $(INCDIR)arith.h $(INCDIR)stream.h \
-	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC)  $(DISPRFLAGS) $(INLINE) -I$(INCDIR) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.o

--- a/bin/makefile-sunos5.x86_64-x
+++ b/bin/makefile-sunos5.x86_64-x
@@ -28,7 +28,6 @@ XFLAGS = -DXWINDOW -DNOPIXRECT
 OEXT = .o
 # OPTFLAGS is normally -O2.
 OPTFLAGS =  -O2 -g
-DISPOPTFLAGS =  -O2 -g
 
 # Set any debugging options in DEBUGFLAGS.  E.g., to enable stack
 # checking, use -DSTACKCHECK; to enable the fn-call-time stack
@@ -64,18 +63,3 @@ BYTESWAPFILES = $(OBJECTDIR)byteswap.o
 
 
 default:	../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldeether
-
-############
-#
-#      Normal compilation for xc.o without optimized dispatch loop hacks
-#
-############
-$(OBJECTDIR)xc.o:      $(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
-	$(INCDIR)address.h \
-	$(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
-	$(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
-	$(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
-	$(INCDIR)arith.h $(INCDIR)stream.h \
-	$(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
-	$(INCDIR)tosfns.h  $(INCDIR)inlineC.h
-	$(CC) $(DISPRFLAGS) -UOPDISP  $(SRCDIR)xc.c -I$(INCDIR) -o $(OBJECTDIR)xc.o

--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -37,19 +37,10 @@
 # OSARCHDIR is the os/architecture dir, where executables all go.
 OSARCHDIR = ../$(OSARCHNAME)/
 
-#
-#  The DISPxxx flags are for compiling files which rely on 'as' much
-#  more than the other files do.  For mc68020, it'll use optimization
-#  -O rather than -O2 which is good for the other files in the system
-#  [JDS 10-26-89] Files affected: xc, arith2, arith4, fvar.
-#
-
 REQUIRED-INCS = $(INCDIR)version.h
 
 CFLAGS = $(OPTFLAGS) $(DFLAGS) $(FPFLAGS)
-DISPCFLAGS = $(DISPOPTFLAGS) $(DFLAGS) $(FPFLAGS)
 RFLAGS = -c $(CFLAGS) -I$(INCDIR) -I$(INCLUDEDIR)
-DISPRFLAGS = -c $(DISPCFLAGS) -I$(INCDIR) -I$(INCLUDEDIR)
 
 OFILES = $(OBJECTDIR)arith2.o \
 	$(OBJECTDIR)arith3.o \
@@ -239,7 +230,7 @@ $(OBJECTDIR)arith2.o :  $(SRCDIR)arith2.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h 
 	 $(INCDIR)lspglob.h  $(INCDIR)emlglob.h \
 	 $(INCDIR)adr68k.h  $(INCDIR)lispmap.h  $(INCDIR)lsptypes.h \
 	 $(INCDIR)arith.h $(INCDIR)medleyfp.h $(INLINE)
-	$(CC) $(DISPRFLAGS) $(SRCDIR)arith2.c $(INLINE) -o $(OBJECTDIR)arith2$(OEXT)
+	$(CC) $(RFLAGS) $(SRCDIR)arith2.c $(INLINE) -o $(OBJECTDIR)arith2$(OEXT)
 
 $(OBJECTDIR)arith3.o :  $(SRCDIR)arith3.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  \
 	 $(INCDIR)lispmap.h  $(INCDIR)emlglob.h  $(INLINE) \
@@ -251,7 +242,7 @@ $(OBJECTDIR)arith4.o :  $(SRCDIR)arith4.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h 
 	 $(INCDIR)lispmap.h  $(INCDIR)emlglob.h $(INLINE) \
 	 $(INCDIR)lspglob.h  $(INCDIR)lsptypes.h  $(INCDIR)address.h \
 	 $(INCDIR)adr68k.h  $(INCDIR)cell.h  $(INCDIR)arith.h $(INCDIR)medleyfp.h
-	$(CC) $(DISPRFLAGS) $(SRCDIR)arith4.c $(INLINE) -o $(OBJECTDIR)arith4$(OEXT)
+	$(CC) $(RFLAGS) $(SRCDIR)arith4.c $(INLINE) -o $(OBJECTDIR)arith4$(OEXT)
 
 $(OBJECTDIR)array.o :  $(SRCDIR)array.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  \
 	 $(INCDIR)lspglob.h  $(INCDIR)adr68k.h \
@@ -461,7 +452,7 @@ $(OBJECTDIR)fvar.o :  $(SRCDIR)fvar.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  \
 	 $(INCDIR)lspglob.h  $(INCDIR)adr68k.h \
 	 $(INCDIR)stack.h  $(INCDIR)emlglob.h  $(INCDIR)lispmap.h \
 	 $(INCDIR)gcdata.h $(INCDIR)lsptypes.h
-	$(CC) $(DISPRFLAGS) $(SRCDIR)fvar.c $(INLINE) -o $(OBJECTDIR)fvar$(OEXT)
+	$(CC) $(RFLAGS) $(SRCDIR)fvar.c $(INLINE) -o $(OBJECTDIR)fvar$(OEXT)
 
 $(OBJECTDIR)gc.o :  $(SRCDIR)gc.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  $(INCDIR)gcdata.h  \
 	 $(INCDIR)lspglob.h \
@@ -769,6 +760,16 @@ $(OBJECTDIR)sxhash.o : $(SRCDIR)sxhash.c  $(REQUIRED-INCS) $(INCDIR)lispemul.h  
 
 $(OBJECTDIR)usrsubr.o : $(SRCDIR)usrsubr.c $(REQUIRED-INCS) 
 	$(CC) $(RFLAGS) $(SRCDIR)usrsubr.c $(INLINE) -o $(OBJECTDIR)usrsubr$(OEXT)
+
+$(OBJECTDIR)xc.o:	$(SRCDIR)xc.c $(INCDIR)lispemul.h  $(INCDIR)emlglob.h \
+	 $(INCDIR)address.h \
+	 $(INCDIR)adr68k.h  $(INCDIR)stack.h  $(INCDIR)lspglob.h \
+	 $(INCDIR)lsptypes.h  $(INCDIR)lispmap.h  $(INCDIR)cell.h \
+	 $(INCDIR)initatms.h  $(INCDIR)gcdata.h  \
+	 $(INCDIR)arith.h $(INCDIR)stream.h \
+	 $(INCDIR)tos1defs.h  $(INCDIR)tosret.h \
+	 $(INCDIR)tosfns.h  $(INCDIR)inlineC.h
+	 $(CC) $(RFLAGS) $(SRCDIR)xc.c -o $(OBJECTDIR)xc.o
 
 ########
 # X-windows-specific files


### PR DESCRIPTION
This also removes the special `DISP*` flags that were used for
building some files, including `xc.c`.