### PR TITLE
Remove OPCODEFAIL / FIXTOS1

### DIFF
--- a/inc/inlineC.h
+++ b/inc/inlineC.h
@@ -1049,23 +1049,3 @@ if ((int)(TOPOFSTACK = (LispPTR)op_name(				\
 	goto fix_tos_ufn;						\
 CSTKPTRL -= 8;								\
 nextop1;
-
-
-#ifdef SUN3_OS3_OR_OS4_IL
-
-/* need jump point for inline asm code, e.g., for IPLUS */
-
-#define OPCODEFAIL							\
-									\
-fixtos1:								\
-	fixtos1_label();						\
-	FIXTOS1;							\
-	goto op_ufn;
-
-#else
-
-/* no opcode fail point necessary */
-
-#define OPCODEFAIL
-
-#endif

--- a/inc/tos1defs.h
+++ b/inc/tos1defs.h
@@ -35,7 +35,6 @@
 #define GET_POPPED	*CSTKPTR
 #define POP_TOS_1	*(--CSTKPTRL)
 #define TOPOFSTACK	tscache
-#define FIXTOS1		CSTKPTRL++
 #define GET_TOS_1_HI	*((DLword *)(CSTKPTR - 1))
 #define GET_TOS_1_LO	*((DLword *)(CSTKPTR - 1)+1)
 
@@ -55,7 +54,6 @@
 #define GET_POPPED	*CSTKPTR
 #define POP_TOS_1	*(--CSTKPTRL)
 #define TOPOFSTACK	tscache
-#define FIXTOS1		CSTKPTRL++
 #define GET_TOS_1_HI	GETWORD((DLword *)(CSTKPTR - 1))
 #define GET_TOS_1_LO	GETWORD((DLword *)(CSTKPTR - 1)+1)
 

--- a/src/xc.c
+++ b/src/xc.c
@@ -218,10 +218,7 @@ void dispatch(void) {
   goto nextopcode;
 #endif /* OPDISP */
 
-  /* INLINE OPCODE FAIL ENTRY POINTS, CALL EXTERNAL ROUTINES HERE */
-  OPCODEFAIL;
   /* OPCODE FAIL ENTRY POINTS, CALL UFNS HERE */
-
   UFN_CALLS;
 
 op_ufn : {


### PR DESCRIPTION
These had been used on Sun3 in the ancient past, but not after
that in the current code.