### PR TITLE
Remove -fwrapv compiler flag.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ IF(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_COMPILER_ID MATCHES "GNU")
   IF(UNIX AND CMAKE_GENERATOR STREQUAL "Ninja")
     SET(CMAKE_C_FLAGS "-fdiagnostics-color=always ${CMAKE_C_FLAGS}")
   ENDIF()
-  SET(CMAKE_C_FLAGS "-fno-strict-aliasing -fwrapv ${CMAKE_C_FLAGS}")
+  SET(CMAKE_C_FLAGS "-fno-strict-aliasing ${CMAKE_C_FLAGS}")
 ENDIF()
 
 IF(CMAKE_C_COMPILER_ID MATCHES "SunPro")

--- a/bin/makefile-header
+++ b/bin/makefile-header
@@ -11,8 +11,8 @@ RANLIB = ranlib
 AR = ar rcv
 
 # Compiler flags
-CLANG_CFLAGS = -std=gnu99 -fno-strict-aliasing -fwrapv
-GCC_CFLAGS = -std=gnu99 -fno-strict-aliasing -fwrapv
+CLANG_CFLAGS = -std=gnu99 -fno-strict-aliasing
+GCC_CFLAGS = -std=gnu99 -fno-strict-aliasing
 DEVSTUDIO_CFLAGS = -std=gnu99 -fno-strict-aliasing
 
 DLPIFILES =


### PR DESCRIPTION
This was making sure that the overflow in some our opcode
implementations was visible to the C code so that overflow
detection would work in gcc and clang.

This is now handled on those compilers by using some built-ins
that detect overflow.

The `-fwrapv` should no longer be needed.

Closes Interlisp/medley#90.