### PR TITLE
Remove unnecessary (and incorrect) include in unixcomm.c

### DIFF
--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -56,10 +56,6 @@ Unix Interface Communications
 #include "byteswapdefs.h"
 #include "commondefs.h"
 
-#ifdef GCC386
-#include "inlinePS2.h"
-#endif /* GCC386 */
-
 static __inline__ int SAFEREAD(int f, unsigned char *b, int c) {
   int res;
 loop:


### PR DESCRIPTION
unixcomm.c conditionally included `"inlinePS2.h"` -- which hasn't been named that in a long while, and is not necessary anyway.