### PR TITLE
Fix NOPIXRECT in llcolor.

### DIFF
--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -12,7 +12,7 @@
 
 #include <stdio.h>
 
-#ifndef NOPIXRECT
+#if defined(COLOR) && !defined(NOPIXRECT)
 #include <sunwindow/window_hs.h>
 #include <sunwindow/cms.h>
 #include <sunwindow/win_ioctl.h>
@@ -20,7 +20,7 @@
 #include <sun/fbio.h>
 #include <pixrect/pr_planegroups.h>
 #include <sys/mman.h>
-#endif /* NOPIXRECT */
+#endif /* COLOR && !NOPIXRECT */
 
 #include <sys/ioctl.h>
 #include <sys/types.h>


### PR DESCRIPTION
This code is all currently set up to be used if `COLOR` is
defined.

If we were to start supporting color under X11, this would
have to change, but so would much of the rest of the file.