### PR TITLE
Cleanup for ERROR_EXIT/TIMER_EXIT/WARN style, remove unused typedef

### DIFF
--- a/inc/lispemul.h
+++ b/inc/lispemul.h
@@ -23,7 +23,6 @@ typedef char  DLbyte;
 typedef unsigned int  LispPTR;
 /* 32 bit Cell Chang. 14 Jan 87 take */
 typedef DLword mds_page;  /* Top word of the MDS */
-typedef int (*CFuncPTR)();
 
 #ifdef BIGVM
 typedef struct  consstr
@@ -181,7 +180,6 @@ typedef char  DLbyte;
 typedef unsigned int  LispPTR;
 /* 32 bit Cell Chang. 14 Jan 87 take */
 typedef DLword mds_page;  /* Top word of the MDS */
-typedef int (*CFuncPTR)();
 
 #ifdef BIGVM
 typedef struct  consstr
@@ -482,11 +480,11 @@ DOSTACKOVERFLOW(argnum,bytenum) if it needs hardreturn-cleanup
 /*									*/
 /************************************************************************/
 
-#define ERROR_EXIT(tos)		{TopOfStack=tos; Error_Exit = 1; return(-1);}
-#define TIMER_EXIT(tos)		{TopOfStack=tos; Error_Exit = 1; return(-2);}
+#define ERROR_EXIT(tos)		do {TopOfStack=tos; Error_Exit = 1; return(-1);} while (0)
+#define TIMER_EXIT(tos)		do {TopOfStack=tos; Error_Exit = 1; return(-2);} while (0)
 
 
-#define WARN(message,operation)	{warn(message);operation;}
+#define WARN(message,operation)	do {warn(message);operation;} while (0)
 #define NO_WOP	{}
 
 #define NIL	0	/* added 29-jan */

--- a/src/car-cdr.c
+++ b/src/car-cdr.c
@@ -399,7 +399,7 @@ LispPTR N_OP_rplaca(register LispPTR tosm1, register LispPTR tos) {
   if (Listp(tosm1) == NIL) {
     if (tosm1 == NIL_PTR) {
       if (tos != NIL_PTR)
-        ERROR_EXIT(tos)
+        ERROR_EXIT(tos);
       else
         return (tosm1);
     } else
@@ -439,7 +439,7 @@ LispPTR N_OP_rplacd(register LispPTR tosm1, register LispPTR tos) {
   if (Listp(tosm1) == NIL) {
     if (tosm1 == NIL_PTR) {
       if (tos != NIL_PTR)
-        ERROR_EXIT(tos)
+        ERROR_EXIT(tos);
       else
         return (tosm1);
     } else

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -102,7 +102,7 @@ LispPTR N_OP_clequal(register int arg1, register int arg2) {
     if (IsNumber(arg2)) {
       return (NIL);
     } else
-      ERROR_EXIT(arg2)
+      ERROR_EXIT(arg2);
   }
 
   /* now we know both are numbers */
@@ -194,7 +194,7 @@ arg2_small:
     if (IsNumber(arg2)) {
       return (NIL);
     } else
-      ERROR_EXIT(arg2)
+      ERROR_EXIT(arg2);
   }
 
   /* now we know both are numbers */


### PR DESCRIPTION
Convert ERROR_EXIT, TIMER_EXIT, and WARN to "do {} while (0)" style and
  fix a few usage points that were missing trailing semi-colons.
Remove unused typedef for CFuncPtr.