### PR TITLE
Fix bbtsub.c compilation without XWINDOW or DOS.

### DIFF
--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -76,10 +76,10 @@ extern IOPAGE *IOPage68K;
 #include "dbprint.h"
 
 
-#if (defined(DOS) || defined(XWINDOW))
+#if !defined(SUNDISPLAY)
 #include "devif.h"
 extern DspInterface currentdsp;
-#endif /* DOS || WXINDOW */
+#endif /* SUNDISPLAY */
 
 #ifdef COLOR
 extern int MonoOrColor;


### PR DESCRIPTION
Without those, it wasn't including `devif.h`, which is where
we define `min` and `max`. I make an assumption here that any
new display would be using the current display device support
code.