### PR TITLE
Sprinkle some `const` on `char *` params.

### DIFF
--- a/inc/gcarraydefs.h
+++ b/inc/gcarraydefs.h
@@ -1,7 +1,7 @@
 #ifndef GCARRAYDEFS_H
 #define GCARRAYDEFS_H 1
 LispPTR aref1(LispPTR array, int index);
-LispPTR find_symbol(char *char_base, DLword offset, DLword length, LispPTR hashtbl, DLword fatp, DLword lispp);
-LispPTR get_package_atom(char *char_base, DLword charlen, char *packname, DLword packlen, int externalp);
+LispPTR find_symbol(const char *char_base, DLword offset, DLword length, LispPTR hashtbl, DLword fatp, DLword lispp);
+LispPTR get_package_atom(const char *char_base, DLword charlen, const char *packname, DLword packlen, int externalp);
 LispPTR with_symbol(LispPTR char_base, LispPTR offset, LispPTR charlen, LispPTR fatp, LispPTR hashtbl, LispPTR result);
 #endif

--- a/inc/testtooldefs.h
+++ b/inc/testtooldefs.h
@@ -4,7 +4,7 @@
 #include "cell.h"
 void print_package_name(int index);
 void print_atomname(LispPTR index);
-int find_package_from_name(char *packname, int len);
+int find_package_from_name(const char *packname, int len);
 void print_package_name(int index);
 void dump_dtd(void);
 void check_type_68k(int type, LispPTR *ptr);

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -146,7 +146,7 @@ LispPTR aref1(LispPTR array, int index) {
 /*									*/
 /************************************************************************/
 
-LispPTR find_symbol(char *char_base, DLword offset, DLword length, LispPTR hashtbl, DLword fatp,
+LispPTR find_symbol(const char *char_base, DLword offset, DLword length, LispPTR hashtbl, DLword fatp,
                     DLword lispp)
 
 /* T => the "chars" coming in are 16-bit */
@@ -253,7 +253,7 @@ retry:
 /*									*/
 /************************************************************************/
 
-LispPTR get_package_atom(char *char_base, DLword charlen, char *packname, DLword packlen,
+LispPTR get_package_atom(const char *char_base, DLword charlen, const char *packname, DLword packlen,
                          int externalp) {
   int packindex;
   PACKAGE *packaddr;

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -34,7 +34,7 @@
 #include "gcarraydefs.h"
 #include "gchtfinddefs.h"
 
-static char il_string[] = "INTERLISP";
+static const char il_string[] = "INTERLISP";
 #define GET_IL_ATOM(string) get_package_atom((string), (sizeof(string) - 1), il_string, 9, NIL)
 
 #define AtomValPtr(index) Addr68k_from_LADDR(*(GetVALCELL68k(index)))

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -107,7 +107,7 @@ void print_atomname(LispPTR index)
 
 #define PACKAGES_LIMIT 255
 /** GET PACKAGE INDEX from PACKAGE FULL NAME */
-int find_package_from_name(char *packname, int len) {
+int find_package_from_name(const char *packname, int len) {
   int index;
   PACKAGE *package;
   NEWSTRINGP *namestring;


### PR DESCRIPTION
This is enough to let us move `il_string` in `loopsops.c`
into read-only storage.