### PR TITLE
Use FD_CLR when disabling keyboard for SUNDISPLAY.

### DIFF
--- a/src/kbdsubrs.c
+++ b/src/kbdsubrs.c
@@ -86,7 +86,7 @@ void KB_enable(LispPTR *args) /* args[0] :	ON/OFF flag
 #endif /* DOS */
   } else if (args[0] == NIL) {
 #ifdef SUNDISPLAY
-    FD_SET(LispWindowFd, &LispReadFds);
+    FD_CLR(LispWindowFd, &LispReadFds);
 #elif XWINDOW
     disable_Xkeyboard(currentdsp);
 #elif DOS


### PR DESCRIPTION
In the old code (prior to b234064d), this was:

```
   LispReadFds &= ~(1 << LispWindowFd);
```

This was inadvertently converted to `FD_SET`, but should have
been `FD_CLR`.