### PR TITLE
make makefile-tail cleanup target remove everything

### DIFF
--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -870,7 +870,7 @@ $(OBJECTDIR)lpy.tab.o : $(SRCDIR)lpy.tab.c  $(REQUIRED-INCS) $(INCDIR)lpdefs.h $
 ################################################################################
 
 cleanup :
-	rm -f $(LIBFILES) $(EXTFILES) $(OBJECTDIR)tstsout.o $(OBJECTDIR)setsout.o $(OSARCHDIR)lde $(OSARCHDIR)ldex $(OSARCHDIR)ldeether
+	rm -rf $(OBJECTDIR) $(OSARCHDIR)
 
 .c.o:
 	$(CC) $(RFLAGS) $*.c -o $@


### PR DESCRIPTION
The makefile-tail cleanup target had accumulated a few missing files that it should have cleaned up, however rather than listing each individual file to be removed we can remove the object and executable directories.  The directories are recreated as necessary.