### PR TITLE
cmake: Don't link maiko into setsout, tstsout.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,17 +43,13 @@ IF(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64" OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL "AMD64" OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL "x86" OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL "i386" OR
-   CMAKE_SYSTEM_PROCESSOR STREQUAL "i686")
-  LIST(APPEND MAIKO_DEFINITIONS
-    "-DBYTESWAP"
-  )
-ENDIF()
-
-IF(CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*" OR
+   CMAKE_SYSTEM_PROCESSOR STREQUAL "i686" OR
+   CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*" OR
    CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
   LIST(APPEND MAIKO_DEFINITIONS
     "-DBYTESWAP"
   )
+  SET(BYTESWAP_SRCS src/byteswap.c)
 ENDIF()
 
 IF(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -112,6 +108,7 @@ SET(BAD_SRCS
 )
 
 SET(MAIKO_SRCS
+    ${BYTESWAP_SRCS}
     src/allocmds.c
     src/arith2.c
     src/arith3.c
@@ -128,7 +125,6 @@ SET(MAIKO_SRCS
     src/binds.c
     src/bitblt.c
     src/blt.c
-    src/byteswap.c
     src/car-cdr.c
     src/chardev.c
     src/common.c
@@ -433,10 +429,10 @@ ADD_EXECUTABLE(mkvdate src/mkvdate.c)
 TARGET_COMPILE_DEFINITIONS(mkvdate PUBLIC ${MAIKO_DEFINITIONS})
 TARGET_INCLUDE_DIRECTORIES(mkvdate PUBLIC inc)
 
-# In the old build system, this didn't link in everything.
-ADD_EXECUTABLE(setsout src/setsout.c)
-TARGET_LINK_LIBRARIES(setsout maiko)
+ADD_EXECUTABLE(setsout src/setsout.c ${BYTESWAP_SRCS})
+TARGET_COMPILE_DEFINITIONS(setsout PUBLIC ${MAIKO_DEFINITIONS})
+TARGET_INCLUDE_DIRECTORIES(setsout PUBLIC inc)
 
-# In the old build system, this didn't link in everything.
-ADD_EXECUTABLE(tstsout src/tstsout.c)
-TARGET_LINK_LIBRARIES(tstsout maiko)
+ADD_EXECUTABLE(tstsout src/tstsout.c ${BYTESWAP_SRCS})
+TARGET_COMPILE_DEFINITIONS(tstsout PUBLIC ${MAIKO_DEFINITIONS})
+TARGET_INCLUDE_DIRECTORIES(tstsout PUBLIC inc)


### PR DESCRIPTION
These only need byteswap utils, not the fully maiko set of
sources. This makes this behave like the old make-based
build system.