### PR TITLE
clang-format: AllowShortBlocksOnASingleLine only if empty

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,7 +9,7 @@ AlignEscapedNewlinesLeft: true
 AlignOperands:   true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: true


### PR DESCRIPTION
This will cause clang-format to produce
```
while (true) {}
while (true) {
  continue;
}
```
rather than forcing the empty block to two lines, or allowing the `continue;` and brace to merge up.