### PR TITLE
Remove Bitmap_Pad global.

### DIFF
--- a/src/xinit.c
+++ b/src/xinit.c
@@ -51,8 +51,6 @@ extern DLword *DisplayRegion68k;
 bool Lisp_Xinitialized = false;
 int xsync = False;
 
-int Bitmap_Pad;
-
 int LispWindowRequestedX = 0;
 int LispWindowRequestedY = 0;
 unsigned LispWindowRequestedWidth = DEF_WIN_WIDTH;

--- a/src/xmkicon.c
+++ b/src/xmkicon.c
@@ -26,7 +26,7 @@
 
 XImage IconImage;
 
-extern int Bitmap_Pad, Lisp_icon_width, Lisp_icon_height;
+extern int Lisp_icon_width, Lisp_icon_height;
 extern uint8_t Lisp_icon[];
 
 static Pixmap IconPixmap;
@@ -62,7 +62,7 @@ Pixmap make_Xicon(DspInterface dsp)
     IconImage.byte_order = MSBFirst;
 #endif /* BYTESWAP */
     IconImage.bitmap_unit = 8;
-    IconImage.bitmap_pad = Bitmap_Pad; /* TODO: Bitmap_Pad is never initialized. */
+    IconImage.bitmap_pad = 0;
     IconImage.depth = 1;
     IconImage.bytes_per_line = Lisp_icon_width / 8;
 #if defined(X_ICON_IN_X_BITMAP_FORMAT)


### PR DESCRIPTION
Since this is just being used for a 0 value, just use `0`.