### PR TITLE
Remove cursor_source_gc.

### DIFF
--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -28,9 +28,6 @@
 
 extern IOPAGE *IOPage;
 
-extern XGCValues gcv;
-
-GC cursor_source_gc;
 XColor cursor_fore_xcsd, cursor_back_xcsd, xced;
 extern Colormap Colors;
 
@@ -148,20 +145,6 @@ void init_Xcursor(Display *display, Window window)
   TPRINT(("TRACE: init_Xcursor()\n"));
 
   XLOCK; /* Take no X signals during this activity (ISC 386) */
-  gcv.function = GXcopy;
-  gcv.foreground = BlackPixelOfScreen(ScreenOfDisplay(display, DefaultScreen(display)));
-  gcv.background = WhitePixelOfScreen(ScreenOfDisplay(display, DefaultScreen(display)));
-#ifdef AIX
-  gcv.plane_mask = 1;
-#endif /* AIX */
-
-  cursor_source_gc = XCreateGC(display, window,
-                               GCForeground | GCBackground | GCFunction
-#ifdef AIX
-                                   | GCPlaneMask
-#endif /* AIX */
-                               ,
-                               &gcv);
 
   XAllocNamedColor(display, Colors, "black", &cursor_fore_xcsd, &xced);
   XAllocNamedColor(display, Colors, "white", &cursor_back_xcsd, &xced);

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -50,9 +50,6 @@ extern char **save_argv;
 
 extern DspInterface currentdsp;
 
-#if 0
-extern GC cursor_source_gc;
-#endif
 XGCValues gcv;
 XEvent report;
 
@@ -304,14 +301,6 @@ void lisp_Xvideocolor(int flag)
       event.xexpose.height = currentdsp->Visible.height;
       XSendEvent(currentdsp->display_id, currentdsp->DisplayWindow, True, 0, &event);
   }
-
-#if 0
-  /* Cursor */
-  gcv.function = GXcopy;
-  XChangeGC(currentdsp->display_id, cursor_source_gc, GCFunction, &gcv);
-  /* JDS 011213: Remember set_xcursor does 15-y val, so do it here! */
-  Set_XCursor(Current_Hot_X, 15 - Current_Hot_Y);
-#endif
 
   XFlush(currentdsp->display_id);
   XUNLOCK;


### PR DESCRIPTION
This was only used in commented out code, which is now removed
as well. In that code, it was used to set the function to `GXcopy`,
but it would already have been that as that's the only thing
we set function to.

This also lets us remove the `gcv` code in `xcursor.c`, since
we no longer need those values there.