### PR TITLE
Inline swapx and byte_swap_word.

### DIFF
--- a/inc/byteswapdefs.h
+++ b/inc/byteswapdefs.h
@@ -1,7 +1,24 @@
 #ifndef BYTESWAPDEFS_H
 #define BYTESWAPDEFS_H 1
-unsigned int swapx(unsigned int word);
-unsigned short byte_swap_word(unsigned short word);
+
+/****************************************************************/
+/*                                                              */
+/*                 swap halves of a single 4-byte word          */
+/*                                                              */
+/****************************************************************/
+static inline unsigned int swapx(unsigned int word) {
+  return (((word >> 16) & 0xffff) | ((word & 0xffff) << 16));
+}
+
+/****************************************************************/
+/*                                                              */
+/*                 Byte-swap a single 2-byte word               */
+/*                                                              */
+/****************************************************************/
+static inline unsigned short byte_swap_word(unsigned short word) {
+  return (((word >> 8) & 0xff) | ((word & 0xff) << 8));
+}
+
 void byte_swap_page(unsigned short *page, int wordcount);
 void word_swap_page(unsigned short *page, int longwordcount);
 void bit_reverse_region(unsigned short *top, int width, int height, int rasterwidth);

--- a/inc/inlineC.h
+++ b/inc/inlineC.h
@@ -68,7 +68,6 @@
 
 
 #define CHECK_INTERRUPT {if((UNSIGNED)CSTKPTR > Irq_Stk_Check) goto check_interrupt;} 
-#define SWAP_WORDS(x) (((unsigned int)x << 16) | (((unsigned int)x >> 16) & 0xFFFF))
 
 
 #define nextop0 {goto nextopcode; }
@@ -686,10 +685,10 @@ register LispPTR *chain;						\
 chain = (LispPTR *) (PVar + n);						\
 if(WBITSPTR(chain)->LSB){						\
 	PUSH(GetLongWord(Addr68k_from_LADDR(				\
-		POINTERMASK & SWAP_WORDS(native_newframe(n >> 1)))));	\
+		POINTERMASK & swapx(native_newframe(n >> 1)))));	\
 	nextop1;							\
     }/* if(((WBITS */							\
-PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK & SWAP_WORDS(*chain))));	\
+PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK & swapx(*chain))));	\
 nextop1;								\
 }
 
@@ -699,10 +698,10 @@ register LispPTR *chain;						\
 chain = (LispPTR *) (PVar + nn);						\
 if(WBITSPTR(chain)->LSB){						\
 	PUSH(GetLongWord(Addr68k_from_LADDR(				\
-		POINTERMASK & SWAP_WORDS(native_newframe(nn >> 1)))));	\
+		POINTERMASK & swapx(native_newframe(nn >> 1)))));	\
 	nextop2;							\
     }/* if(((WBITS */							\
-PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK & SWAP_WORDS(*chain))));	\
+PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK & swapx(*chain))));	\
 nextop2;								\
 }
 

--- a/inc/inln386i.h
+++ b/inc/inln386i.h
@@ -18,11 +18,6 @@
 /************************************************************************/
 
 
-	/* use the swapx [inline] function to swap words in a dword */
-#undef SWAP_WORDS
-#define SWAP_WORDS(x) swapx(x)
-
-
 	/* undefine these macros so we use the 386i inline code */
 #undef Get_BYTE_PCMAC0
 #undef Get_BYTE_PCMAC1

--- a/inc/inln68k.h
+++ b/inc/inln68k.h
@@ -39,10 +39,7 @@
 #undef LISTP
 #undef NTYPEX
 #undef TYPEP
-#undef SWAP_WORDS
 
-#define SWAP_WORDS(x) swapx(x)
- 
 #define DIFFERENCE {						\
 	TOPOFSTACK = op_difference(POP_TOS_1, TOPOFSTACK);	\
 	nextop1;						\

--- a/inc/inlnSPARC.h
+++ b/inc/inlnSPARC.h
@@ -145,7 +145,3 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg2);			\
 	TOPOFSTACK = POP_TOS_1 + arg2;				\
 	nextop1;}
-
-
-#undef SWAP_WORDS
-#define SWAP_WORDS(x) swapx(x)

--- a/inc/tosfns.h
+++ b/inc/tosfns.h
@@ -42,7 +42,7 @@
 #define SWAP_FNHEAD
 #else
 #undef SWAP_FNHEAD
-#define SWAP_FNHEAD(x) SWAP_WORDS(x)
+#define SWAP_FNHEAD(x) swapx(x)
 #endif /* BIGVM */
 
 
@@ -638,7 +638,7 @@ op_fn_common:								\
 									\
 		      case TYPE_NEWATOM:				\
 			nnewframe(CURRENTFX, &scratch, TOPOFSTACK);	\
-			work =	POINTERMASK & SWAP_WORDS(scratch);		\
+			work =	POINTERMASK & swapx(scratch);		\
 			lookuped = *((LispPTR *)			\
 				   (Addr68k_from_LADDR(work)));		\
 			if(lookuped==NOBIND_PTR) goto op_ufn;		\

--- a/src/byteswap.c
+++ b/src/byteswap.c
@@ -29,24 +29,6 @@
 
 /****************************************************************/
 /*                                                              */
-/*                 swap halves of a single 4-byte word          */
-/*                                                              */
-/****************************************************************/
-unsigned int swapx(unsigned int word) {
-  return (((word >> 16) & 0xffff) | ((word & 0xffff) << 16));
-}
-
-/****************************************************************/
-/*                                                              */
-/*                 Byte-swap a single 2-byte word               */
-/*                                                              */
-/****************************************************************/
-unsigned short byte_swap_word(unsigned short word) {
-  return (((word >> 8) & 0xff) | ((word & 0xff) << 8));
-}
-
-/****************************************************************/
-/*                                                              */
 /*            Byte-swap a region wordcount words long           */
 /*            This does NOT swap words in a long-word!          */
 /*                                                              */

--- a/src/dspSPARC.il
+++ b/src/dspSPARC.il
@@ -90,14 +90,6 @@ done:				!		else done;
 	be fixed through the ifdef flats.
 */
 
-/* SWAP halves of a register */
-
-.inline	_swapx,4
-	sll	%o0,16,%o1
-	srl	%o0,16,%o0
-	or	%o0,%o1,%o0
-.end
-
 /*
 	***************************************************************
 	DIFFERENCE VERSIONS sp@ - sp@(4)  i.e. (tos-1)  -  (tos)

--- a/src/xc.c
+++ b/src/xc.c
@@ -66,6 +66,7 @@
 #include "array6defs.h"
 #include "bitbltdefs.h"
 #include "bltdefs.h"
+#include "byteswapdefs.h"
 #include "car-cdrdefs.h"
 #include "commondefs.h"
 #include "conspagedefs.h"


### PR DESCRIPTION
This lets us remove `SWAP_WORDS` and some bits of assembly.