### PR TITLE
Define RM in makefile if it is not already defined

### DIFF
--- a/bin/makefile-header
+++ b/bin/makefile-header
@@ -9,6 +9,7 @@ LIBDIR = ../lib
 BINDIR = ./
 RANLIB = ranlib
 AR = ar rcv
+RM ?= rm -f
 
 # Compiler flags
 CLANG_CFLAGS = -std=gnu99 -fno-strict-aliasing

--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -871,7 +871,7 @@ $(OBJECTDIR)lpy.tab.o : $(SRCDIR)lpy.tab.c  $(REQUIRED-INCS) $(INCDIR)lpdefs.h $
 ################################################################################
 
 cleanup :
-	rm -rf $(OBJECTDIR) $(OSARCHDIR)
+	$(RM) -r $(OBJECTDIR) $(OSARCHDIR)
 
 .c.o:
 	$(CC) $(RFLAGS) $*.c -o $@


### PR DESCRIPTION
Some versions of "make" do not predefine make variable RM (looking at you, FreeBSD)
so if it has NOT been defined we define it as "rm -f"

Also, update the cleanup target to use $(RM) rather than refering directly to "rm".