### PR TITLE
Fix off-by-one error in clipping_Xbitblt

### DIFF
--- a/inc/xbbtdefs.h
+++ b/inc/xbbtdefs.h
@@ -1,4 +1,4 @@
 #ifndef XBBTDEFS_H
 #define XBBTDEFS_H 1
-unsigned long clipping_Xbitblt(DspInterface dsp, int dummy, int x, int y, int w, int h);
+unsigned long clipping_Xbitblt(DspInterface dsp, DLword *dummy, int x, int y, int w, int h);
 #endif

--- a/src/xbbt.c
+++ b/src/xbbt.c
@@ -30,20 +30,23 @@
 /*	dummy is the placeholder for the bitmap to be blitted		*/
 /*									*/
 /************************************************************************/
-unsigned long clipping_Xbitblt(DspInterface dsp, int dummy, int x, int y, int w, int h)
+unsigned long clipping_Xbitblt(DspInterface dsp, DLword *dummy, int x, int y, int w, int h)
 {
   int temp_x, temp_y, LowerRightX, LowerRightY;
 
-  LowerRightX = dsp->Visible.x + dsp->Visible.width;
-  LowerRightY = dsp->Visible.y + dsp->Visible.height;
+  LowerRightX = dsp->Visible.x + dsp->Visible.width - 1;
+  LowerRightY = dsp->Visible.y + dsp->Visible.height - 1;
 
+  /* display region of interest lower right x, y pixel */
   temp_x = x + w - 1;
   temp_y = y + h - 1;
 
+  /* if the display region of interest is completely outside the visible window */
   if ((temp_x < dsp->Visible.x) || (x > LowerRightX) || (temp_y < dsp->Visible.y) ||
       (y > LowerRightY))
     return (0);
 
+  /* if the display region of interest is completely within the visible window */
   if ((x >= dsp->Visible.x) && (temp_x <= LowerRightX) && (y >= dsp->Visible.y) &&
       (temp_y <= LowerRightY)) {
     XLOCK;
@@ -51,21 +54,25 @@ unsigned long clipping_Xbitblt(DspInterface dsp, int dummy, int x, int y, int w,
               x - dsp->Visible.x, y - dsp->Visible.y, w, h);
     XFlush(dsp->display_id);
     XUNLOCK;
-    return (0);
+    return (1);
   }
 
+  /* clip left to visible window */
   if (x < dsp->Visible.x) {
     w -= dsp->Visible.x - x;
     x = dsp->Visible.x;
   }
 
+  /* clip right to visible window */
   if (temp_x > LowerRightX) w -= temp_x - LowerRightX;
 
+  /* clip top to visible window */
   if (y < dsp->Visible.y) {
     h -= dsp->Visible.y - y;
     y = dsp->Visible.y;
   }
 
+  /* clip bottom to visible window */
   if (temp_y > LowerRightY) h -= temp_y - LowerRightY;
 
   if ((w > 0) && (h > 0)) {
@@ -75,6 +82,6 @@ unsigned long clipping_Xbitblt(DspInterface dsp, int dummy, int x, int y, int w,
     XFlush(dsp->display_id);
     XUNLOCK;
   }
-  return (0);
+  return (1);
 
 } /* end clipping_Xbitblt */


### PR DESCRIPTION
The LowerRightX and LowerRightY were calculated as the X and Y coordinates of the
pixel to the right and below the last visible pixel, but are compared with the
last actually visible pixel in the source. They need an extra -1 offset to correct.

Add comments to explain what's going on.  Fix the signature of the function to reflect
that the "dummy" passed for the display region is a pointer not an integer.