### PR TITLE
Fix the unixfork/unixcomm code to deal with pid over 65535

### DIFF
--- a/inc/unixfork.h
+++ b/inc/unixfork.h
@@ -1,5 +1,4 @@
 #ifndef UNIXFORK_H
 #define UNIXFORK_H 1
 int fork_Unix(void);
-int ForkUnixShell(int slot, char *PtySlave, char *termtype, char *shellarg);
 #endif /* UNIXFORK_H */

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -56,14 +56,13 @@ Unix Interface Communications
 #include "byteswapdefs.h"
 #include "commondefs.h"
 
-static __inline__ int SAFEREAD(int f, unsigned char *b, int c) {
-  int res;
-loop:
-  res = read(f, b, c);
-  if ((res < 0)) {
-    if (errno == EINTR || errno == EAGAIN) goto loop;
-    perror("reading UnixPipeIn");
-  }
+static __inline__ ssize_t SAFEREAD(int f, unsigned char *b, int c) {
+  ssize_t res;
+  do {
+    res = read(f, b, c);
+    if (res >= 0) return (res);
+  } while (errno == EINTR || errno == EAGAIN);
+  perror("reading UnixPipeIn");
   return (res);
 }
 

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -118,9 +118,7 @@ int find_process_slot(register int pid)
 /* Find a slot with the specified pid */
 
 {
-  register int slot;
-
-  for (slot = 0; slot < NPROCS; slot++)
+  for (int slot = 0; slot < NPROCS; slot++)
     if (UJ[slot].PID == pid) {
       DBPRINT(("find_process_slot = %d.\n", slot));
       return slot;
@@ -196,9 +194,7 @@ char *build_socket_pathname(int desc) {
 
 void close_unix_descriptors(void) /* Get ready to shut Maiko down */
 {
-  int slot;
-
-  for (slot = 0; slot < NPROCS; slot++) {
+  for (int slot = 0; slot < NPROCS; slot++) {
     /* If this slot has an active job */
     switch (UJ[slot].type) {
       case UJUNUSED:
@@ -251,7 +247,6 @@ void close_unix_descriptors(void) /* Get ready to shut Maiko down */
 
 int FindUnixPipes(void) {
   char *envtmp;
-  register int i;
   struct unixjob cleareduj;
 
   DBPRINT(("Entering FindUnixPipes\n"));
@@ -270,7 +265,7 @@ int FindUnixPipes(void) {
   cleareduj.PID = 0;
   cleareduj.readsock = 0;
   cleareduj.type = UJUNUSED;
-  for (i = 0; i < NPROCS; i++) UJ[i] = cleareduj;
+  for (int i = 0; i < NPROCS; i++) UJ[i] = cleareduj;
 
   DBPRINT(("NPROCS is %d; leaving FindUnixPipes\n", NPROCS));
   return (UnixPipeIn == -1 || UnixPipeOut == -1 || StartTime == -1 || UnixPID == -1);
@@ -512,10 +507,9 @@ LispPTR Unix_handlecomm(LispPTR *args) {
           case UJPROCESS:
             /* First check to see it hasn't already died */
             if (UJ[slot].status == -1) {
-              int i;
               /* Kill the job */
               kill(UJ[slot].PID, SIGKILL);
-              for (i = 0; i < 10; i++) {
+              for (int i = 0; i < 10; i++) {
                 /* Waiting for the process to exit is possibly risky.
                    Sending SIGKILL is always supposed to kill
                    a process, but on very rare occurrences this doesn't

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -56,7 +56,7 @@ Unix Interface Communications
 #include "byteswapdefs.h"
 #include "commondefs.h"
 
-static __inline__ ssize_t SAFEREAD(int f, unsigned char *b, int c) {
+static inline ssize_t SAFEREAD(int f, unsigned char *b, int c) {
   ssize_t res;
   do {
     res = read(f, b, c);

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -54,7 +54,7 @@ char shcom[512]; /* Here because I'm suspicious of */
                  /* large allocations on the stack */
 
 
-static __inline__ ssize_t SAFEREAD(int f, char *b, int c)
+static inline ssize_t SAFEREAD(int f, char *b, int c)
 {
   ssize_t res;
   do {

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -54,16 +54,14 @@ char shcom[512]; /* Here because I'm suspicious of */
                  /* large allocations on the stack */
 
 
-static __inline__ ssize_t
-SAFEREAD(int f, char *b, int c)
+static __inline__ ssize_t SAFEREAD(int f, char *b, int c)
 {
   ssize_t res;
-loop:
-  res = read(f, b, c);
-  if ((res < 0)) {
-    if (errno == EINTR || errno == EAGAIN) goto loop;
-    perror("reading UnixPipeIn");
-  }
+  do {
+    res = read(f, b, c);
+    if (res >= 0) return (res);
+  } while (errno == EINTR || errno == EAGAIN);
+  perror("reading UnixPipeIn");
   return (res);
 }
 

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -79,7 +79,7 @@ loop:
 
 /* Creates a PTY connection to a csh */
 
-int ForkUnixShell(int slot, char *PtySlave, char *termtype, char *shellarg)
+static int ForkUnixShell(int slot, char *PtySlave, char *termtype, char *shellarg)
 {
   int PID, SlaveFD;
   struct termios tio;


### PR DESCRIPTION
Process ids can now be over 65535 so expand from 2-byte to 4-byte
in the packet exchange.  Rearrange some of the code to make it a little
more comprehensible.  Update (somewhat) the documentation.
The packet format should be changed/reordered, and the code should be verified
against the Medley Lisp code that drives it.  Some of the commands don't appear
to be used, or may be used inappropriately.