### PR TITLE
Address older versions of C compiler which don't have __BYTE_ORDER__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 # build directories
 *.386-x/**
 *.386/**
+*.ppc-x/**
+*.ppc/**
 *.sparc-x/**
 *.sparc/**
 *.x86_64-x/**

--- a/bin/makefile-darwin.ppc-x
+++ b/bin/makefile-darwin.ppc-x
@@ -1,0 +1,30 @@
+# Options for MacOS, x86 processor, X windows
+
+CC = cc $(GCC_CFLAGS)
+OEXT=.o
+
+XFILES = $(OBJECTDIR)xmkicon.o \
+	$(OBJECTDIR)xbbt.o \
+	$(OBJECTDIR)dspif.o \
+	$(OBJECTDIR)xinit.o \
+	$(OBJECTDIR)xscroll.o \
+	$(OBJECTDIR)xcursor.o \
+	$(OBJECTDIR)xlspwin.o \
+	$(OBJECTDIR)xrdopt.o \
+	$(OBJECTDIR)xwinman.o
+
+
+XFLAGS = -I/usr/X11/include -DXWINDOW
+
+# OPTFLAGS is normally -O2.
+OPTFLAGS =  -O2 -g
+DEBUGFLAGS = # -DDEBUG -DOPTRACE
+DFLAGS = $(DEBUGFLAGS) $(XFLAGS) \
+	-DRELEASE=351
+
+LDFLAGS = -L/usr/X11/lib -lX11 -lm
+LDELDFLAGS =  -L/usr/X11/lib -lX11 -lm
+
+OBJECTDIR = ../$(RELEASENAME)/
+
+default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex

--- a/inc/maiko/platform.h
+++ b/inc/maiko/platform.h
@@ -137,6 +137,9 @@
 #  define MAIKO_ARCH_DETECTED 1
 #endif
 
+/* Modern GNU C, Clang, Sun Studio  provide __BYTE_ORDER__
+ * Older GNU C (ca. 4.0.1) provides __BIG_ENDIAN__/__LITTLE_ENDIAN__
+ */
 #if defined(__BYTE_ORDER__)
 #  if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #    define BYTESWAP 1

--- a/inc/maiko/platform.h
+++ b/inc/maiko/platform.h
@@ -145,6 +145,10 @@
 #  else
 #    error "Unknown byte order"
 #  endif
+#elif __BIG_ENDIAN__ == 1
+#    undef BYTESWAP
+#elif __LITTLE_ENDIAN__ == 1
+#    define BYTESWAP 1
 #else
 #  error "Could not detect byte order"
 #endif

--- a/inc/version.h
+++ b/inc/version.h
@@ -204,7 +204,13 @@ error Must specify RELEASE to build Medley.
 	/********************************************************/
 	/*							*/
 	/********************************************************/
-#ifdef __GNUC__
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_sadd_overflow) && \
+  __has_builtin(__builtin_ssub_overflow) && \
+  __has_builtin(__builtin_smul_overflow)
 #define USE_OVERFLOW_BUILTINS
 #endif
 


### PR DESCRIPTION
Older versions of gcc, such as 4.0.1, found on a PowerPC macs running 10.5, don't have `__BYTE_ORDER__ ` but do define `__BIG_ENDIAN__` (or, presumably on other hardware, `__LITTLE_ENDIAN__`) so we can add checks for those if the preferred method for detecting byte order isn't available.