### PR TITLE
Remove GetNumber.

### DIFF
--- a/inc/arith.h
+++ b/inc/arith.h
@@ -25,26 +25,6 @@
 #define GetSmallp(x)	((0xFFFF0000 & x) ? (((0xFFFF0000 & x)==0xFFFF0000) ? (S_NEGATIVE | (0xFFFF & x)) : error("Not Smallp data") ) : (S_POSITIVE | (0xFFFF & x)))
 
 
-/* arg sour is Lisp address, arg dest is a box to store the number */
-#define	GetNumber(sour, dest){		\
-		switch(SEGMASK & sour){\
-		case S_POSITIVE:		\
-			dest = 0xFFFF & sour;	\
-			break;			\
-		case S_NEGATIVE:		\
-			dest = 0xFFFF0000 | sour;	\
-			break;			\
-		default:			\
-			if(GetTypeNumber( sour ) != TYPE_FIXP){	\
-				ufn(0xFF & (*PC));	\
-				return;		\
-			}			\
-			dest = *((int *)Addr68k_from_LADDR(sour));	\
-		}				\
-	}
-
-
-
 #define FIXP_VALUE(dest) *((int *)Addr68k_from_LADDR(dest))
 
 #define FLOATP_VALUE(dest) *((float *)Addr68k_from_LADDR(dest))


### PR DESCRIPTION
This isn't used and if it were, it wouldn't compile. It calls
`ufn`, which doesn't get compiled in either (unless `C_ONLY`
is defined, which it isn't, and if it were, that wouldn't
compile either due to a missing `StkLim0`).

A subsequent PR will remove `ufn` and related code.