### PR TITLE
Remove -m32/-m64 args from makefiles.

### DIFF
--- a/bin/makefile-cygwin.x86_64-x
+++ b/bin/makefile-cygwin.x86_64-x
@@ -1,7 +1,7 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 $(GCC_CFLAGS)
-CC = clang -m64 $(CLANG_CFLAGS)
+#CC = gcc $(GCC_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.386-x
+++ b/bin/makefile-darwin.386-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -m32 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -m64 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-freebsd.386-x
+++ b/bin/makefile-freebsd.386-x
@@ -1,6 +1,6 @@
 # Options for FreeBSD, Intel 386/486 and X Windows
 
-CC = clang -m32 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-init.386
+++ b/bin/makefile-init.386
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows, for INIT processing
 
-CC = clang -m32 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-linux.386-x
+++ b/bin/makefile-linux.386-x
@@ -1,7 +1,8 @@
 # Options for Linux, Intel 386/486 and X-Window
 
-#CC = gcc -m32 $(GCC_CFLAGS)
-CC = clang -m32 $(CLANG_CFLAGS)
+#CC = gcc $(GCC_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
+
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \
 	$(OBJECTDIR)dspif.o \

--- a/bin/makefile-linux.x86_64-x
+++ b/bin/makefile-linux.x86_64-x
@@ -1,7 +1,7 @@
 # Options for Linux, Intel x86_64 and X-Window
 
-#CC = gcc -m64 $(GCC_CFLAGS)
-CC = clang -m64 $(CLANG_CFLAGS)
+#CC = gcc $(GCC_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-openbsd.x86_64-x
+++ b/bin/makefile-openbsd.x86_64-x
@@ -1,6 +1,6 @@
 # Options for OpenBSD, Intel x86_64 and X-Window
 
-CC = clang -m64 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-sunos5.386-x
+++ b/bin/makefile-sunos5.386-x
@@ -10,7 +10,7 @@
 #*									*/
 #************************************************************************/
 
-CC = clang -m32 $(CLANG_CFLAGS)
+CC = clang $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-sunos5.sparc-x
+++ b/bin/makefile-sunos5.sparc-x
@@ -15,9 +15,9 @@
 # Setup for using gcc
 #  CC = gcc $(GCC_CFLAGS)
 # Setup for using Solaris Developer Studio 12.6 cc
-#  CC = cc -m32 $(DEVSTUDIO_CFLAGS)
+#  CC = cc $(DEVSTUDIO_CFLAGS)
 
-CC = cc -m32 $(DEVSTUDIO_CFLAGS)
+CC = cc $(DEVSTUDIO_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \


### PR DESCRIPTION
We detect machinetype and build for the native CPU type as it
is, so we don't need to repeat this here in each makefile.