### PR TITLE
Compiling with ethernet support requires etherdefs.h in certain places

### DIFF
--- a/src/initsout.c
+++ b/src/initsout.c
@@ -47,6 +47,10 @@
 #include "mkcelldefs.h"
 #include "testtooldefs.h"
 
+#ifdef MAIKO_ENABLE_ETHERNET
+#include "etherdefs.h"
+#endif
+
 /********** definitions for bitblt. add by osamu **********/
 DLword TEXTURE_atom;
 DLword MERGE_atom;

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -66,6 +66,10 @@ void Mouse_hndlr(void); /* Fields mouse events from driver        */
 #include "osmsgdefs.h"
 #include "xwinmandefs.h"
 
+#ifdef MAIKO_ENABLE_ETHERNET
+#include "etherdefs.h"
+#endif /* MAIKO_ENABLE_ETHERNET */
+
 #include "dbprint.h"
 #if (defined(DOS) || defined(XWINDOW))
 #include "devif.h"

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -85,6 +85,9 @@ extern int Win_security_p;
 #include "testtooldefs.h"
 #include "timerdefs.h"
 #include "vmemsavedefs.h"
+#ifdef MAIKO_ENABLE_ETHERNET
+#include "etherdefs.h"
+#endif
 
 #ifdef DOS
 #define vfork() printf("No forking around here.\n")


### PR DESCRIPTION
A number of files conditionally (if MAIKO_ENABLE_ETHERNET) refer to ethernet related functions that are declared in etherdefs.h, which was not (even conditionally) included.  This has been checked for compilation errors on Solaris with MAIKO_ENABLE_ETHERNET defined.