### PR TITLE
Remove unnecessary (re)definitions of TRUE/FALSE

### DIFF
--- a/inc/devif.h
+++ b/inc/devif.h
@@ -285,14 +285,6 @@ typedef struct
 #define mid(a, b, c) max( min( b, max( a, c ), min( a, max( b, c ))))
 #endif /* mid */
 
-#ifndef FALSE
-#define FALSE 0
-#endif /* FALSE */
-
-#ifndef TRUE
-#define TRUE  !FALSE
-#endif /* TRUE */
-
 #define MINKEYEVENT	2	/* leave 2 words for read,write offsets */
 #define NUMBEROFKEYEVENTS 383
 

--- a/inc/kbdif.h
+++ b/inc/kbdif.h
@@ -31,10 +31,4 @@ typedef struct {
   int	device_locked;
 #endif /* DOS */
 } KbdInterfaceRec, *KbdInterface;
-
-
-#ifndef TRUE
-#define FALSE 0
-#define TRUE  !FALSE
-#endif /* TRUE */
 #endif /* KBDIF_H */

--- a/src/main.c
+++ b/src/main.c
@@ -243,9 +243,6 @@ extern int maxpages;
 extern int *Lisp_errno;
 extern int Dummy_errno; /* If errno cell is not provided by Lisp, dummy_errno is used. */
 
-#define FALSE 0
-#define TRUE !FALSE
-
 char sysout_name[MAXPATHLEN]; /* Set by read_Xoption, in the X version. */
 int sysout_size = 0;    /* ditto */
 

--- a/src/mnwevent.c
+++ b/src/mnwevent.c
@@ -26,11 +26,6 @@
 #include "adr68k.h"
 #include "cell.h"
 
-#ifndef FALSE
-#define FALSE 0
-#define TRUE !FALSE
-#endif /* FALSE */
-
 extern XEvent report;
 
 extern DLword *CTopMNWEvent;

--- a/src/picture.c
+++ b/src/picture.c
@@ -23,9 +23,6 @@
 #include "adr68k.h"
 #include "lspglob.h"
 
-#define FALSE 0
-#define TRUE !FALSE
-
 #include "picture.h"
 
 #define min(x, y) (((x) > (y)) ? (y) : (x))

--- a/src/timer.c
+++ b/src/timer.c
@@ -88,8 +88,6 @@ extern DspInterface currentdsp;
 int TIMEOUT_TIME; /* For file system timeout */
 
 #ifdef XWINDOW
-#define FALSE 0
-#define TRUE !FALSE
 volatile sig_atomic_t Event_Req = FALSE;
 #endif /* XWINDOW */
 

--- a/src/truecolor.c
+++ b/src/truecolor.c
@@ -24,9 +24,6 @@
 
 #include "picture.h"
 
-#define FALSE 0
-#define TRUE !FALSE
-
 #define COLOR_INIT 0
 #define COLOR_OVERLAYREGION 1
 #define COLOR_VIDEOREGION 2


### PR DESCRIPTION
There are definitions for TRUE and FALSE in lispemul.h, which is included by most files that use them, so we can remove them from a number of (but not all) other files.