### PR TITLE
Clean up missing include file when compiling for INIT

### DIFF
--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -76,6 +76,16 @@ extern IOPAGE *IOPage68K;
 #include "display.h"
 #include "dbprint.h"
 
+#ifdef INIT
+#include "initkbddefs.h"
+extern int  kbd_for_makeinit;
+
+#define init_kbd_startup   \
+  if (!kbd_for_makeinit) { \
+    init_keyboard(0);      \
+    kbd_for_makeinit = 1;  \
+  };
+#endif
 
 #if !defined(SUNDISPLAY)
 #include "devif.h"
@@ -278,12 +288,6 @@ extern int ScreenLocked; /* for mouse tracking */
   (SRCTYPE == INVERT_atom ? (OPERATION == ERASE_atom ? 0 : 1) /*  SRCTYPE == INPUT, TEXTURE */ \
                           : (OPERATION == ERASE_atom ? 1 : 0))
 
-#define init_kbd_startup   \
-  if (!kbd_for_makeinit) { \
-    init_keyboard(0);      \
-    kbd_for_makeinit = 1;  \
-  };
-
 extern struct pixrect *SrcePixRect, *DestPixRect, *TexturePixRect;
 extern struct pixrect *BlackTexturePixRect, *WhiteTexturePixRect;
 extern DLword TEXTURE_atom;
@@ -293,8 +297,6 @@ extern DLword INVERT_atom;
 extern DLword ERASE_atom;
 extern DLword PAINT_atom;
 extern DLword REPLACE_atom;
-
-extern int kbd_for_makeinit; /*** FOR INIT ***/
 
 /************************************************************************/
 /*                                                                      */

--- a/src/binds.c
+++ b/src/binds.c
@@ -13,7 +13,7 @@
 #include "lispemul.h"
 #include "lspglob.h"
 #include "emlglob.h"
-
+#include "testtooldefs.h"
 #include "bindsdefs.h"
 
 /**************************************************

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -41,6 +41,11 @@
 #include "bitbltdefs.h"
 #include "initdspdefs.h"
 
+#if defined(INIT)
+#include "initkbddefs.h"
+extern int kbd_for_makeinit;
+#endif
+
 #ifdef DOS
 #include "devif.h"
 #include "iopage.h"
@@ -50,7 +55,6 @@ extern IOPAGE *IOPage68K;
 
 extern int LispWindowFd;
 extern int ScreenLocked;
-extern int kbd_for_makeinit;
 
 #ifdef COLOR
 extern int MonoOrColor;

--- a/src/findkey.c
+++ b/src/findkey.c
@@ -10,13 +10,14 @@
 
 #include "version.h"
 
+#include <stdio.h>
 #include "lispemul.h"
 #include "lispmap.h"
 #include "emlglob.h"
 #include "stack.h"
 #include "lspglob.h"
 #include "adr68k.h"
-
+#include "testtooldefs.h"
 #include "findkeydefs.h"
 
 /***********************************************************************/

--- a/src/gc.c
+++ b/src/gc.c
@@ -15,7 +15,7 @@
 #include "lsptypes.h"
 #include "emlglob.h"
 #include "gcdata.h"
-
+#include "testtooldefs.h"
 #include "gcdefs.h"
 #include "gchtfinddefs.h"
 

--- a/src/gc2.c
+++ b/src/gc2.c
@@ -22,6 +22,7 @@
 */
 /**********************************************************************/
 
+#include <stdio.h>
 #include "lispemul.h"
 #include "lispmap.h"
 #include "lsptypes.h"
@@ -29,7 +30,7 @@
 #include "emlglob.h"
 #include "address.h"
 #include "adr68k.h"
-
+#include "testtooldefs.h"
 #include "gc2defs.h"
 #include "gcscandefs.h"
 

--- a/src/gvar2.c
+++ b/src/gvar2.c
@@ -18,7 +18,7 @@
 #include "emlglob.h"
 #include "cell.h"
 #include "dbprint.h"
-
+#include "commondefs.h"
 #include "gvar2defs.h"
 #include "gchtfinddefs.h"
 

--- a/src/return.c
+++ b/src/return.c
@@ -39,7 +39,7 @@
 #include "initatms.h"
 #include "cell.h"
 #include "return.h"
-
+#include "testtooldefs.h"
 #include "returndefs.h"
 #include "commondefs.h"
 


### PR DESCRIPTION
Missing prototypes in C99 mode are fatal in some compilation environments.  The files that conditionally reference `init_keyboard(...)` when compiling for INIT need to also conditionally include initkbddefs.h.