### PR TITLE
Add aarch64 Linux makefile

### DIFF
--- a/bin/makefile-linux.aarch64-x
+++ b/bin/makefile-linux.aarch64-x
@@ -1,0 +1,27 @@
+# Options for Linux, ARMv7 and X-Window
+
+CC = gcc $(GCC_CFLAGS)
+#CC = clang $(CLANG_CFLAGS)
+
+XFILES = $(OBJECTDIR)xmkicon.o \
+	$(OBJECTDIR)xbbt.o \
+	$(OBJECTDIR)dspif.o \
+	$(OBJECTDIR)xinit.o \
+	$(OBJECTDIR)xscroll.o \
+	$(OBJECTDIR)xcursor.o \
+	$(OBJECTDIR)xlspwin.o \
+	$(OBJECTDIR)xrdopt.o \
+	$(OBJECTDIR)xwinman.o
+
+XFLAGS = -DXWINDOW
+
+# OPTFLAGS is normally -O2.
+OPTFLAGS =  -O2 -g3
+DFLAGS = $(XFLAGS) -DRELEASE=351
+
+LDFLAGS = -L/usr/X11/lib -lX11 -lc -lm
+LDELDFLAGS =  -L/usr/X11/lib -lX11 -lc -lm
+
+OBJECTDIR = ../$(RELEASENAME)/
+
+default	: ../$(OSARCHNAME)/lde 


### PR DESCRIPTION
`machinetype` reports `aarch64` on 64-bit ARM (at least under Docker for Mac), so we need a makefile for that configuration. It's a duplicate of `makefile-linux.armv7l-x` for now; that makefile isn't doing anything armv7-specific.