### PR TITLE
tidy: FindAvailablePty.

### DIFF
--- a/inc/unixcommdefs.h
+++ b/inc/unixcommdefs.h
@@ -6,7 +6,6 @@ void wait_for_comm_processes(void);
 char *build_socket_pathname(int desc);
 void close_unix_descriptors(void);
 int FindUnixPipes(void);
-int FindAvailablePty(char *Master, char *Slave);
 void WriteLispStringToPipe(LispPTR lispstr);
 LispPTR Unix_handlecomm(LispPTR *args);
 void WriteLispStringToPipe(LispPTR lispstr);


### PR DESCRIPTION
* Remove unused `Master` argument.
* Update documentation.
* Remove unused `MasterFD` variable in caller.
* Remove `slot` variable in caller and use `Master` in each case.
* Make `FindAvailablePty` a static function.