### PR TITLE
tidy: Remove last `caddr_t`.

### DIFF
--- a/src/rpc.c
+++ b/src/rpc.c
@@ -121,7 +121,7 @@ LispPTR rpc(LispPTR *args)
   /* Resolve the host address. */
   if (hp) {
     sin1.sin_family = hp->h_addrtype;
-    memcpy((caddr_t)&sin1.sin_addr, hp->h_addr, hp->h_length);
+    memcpy(&sin1.sin_addr, hp->h_addr, hp->h_length);
   } else
     goto handle_error;
 


### PR DESCRIPTION
This cast isn't needed here and `caddr_t` is obsolete / not POSIX.