### PR TITLE
Add makefile fragment for INIT processing for macOS on x86_64

### DIFF
--- a/bin/makefile-init-darwin.x86_64
+++ b/bin/makefile-init-darwin.x86_64
@@ -1,0 +1,28 @@
+# Options for MacOS, x86_64 processor, X windows, for INIT processing
+
+CC = clang -m64 $(CLANG_CFLAGS)
+
+XFILES = $(OBJECTDIR)xmkicon.o \
+	$(OBJECTDIR)xbbt.o \
+	$(OBJECTDIR)dspif.o \
+	$(OBJECTDIR)xinit.o \
+	$(OBJECTDIR)xscroll.o \
+	$(OBJECTDIR)xcursor.o \
+	$(OBJECTDIR)xlspwin.o \
+	$(OBJECTDIR)xrdopt.o \
+	$(OBJECTDIR)xwinman.o
+
+
+XFLAGS = -I/opt/X11/include -DXWINDOW
+
+# OPTFLAGS is normally -O2.
+OPTFLAGS =  -O0 -g
+DEBUGFLAGS = # -DDEBUG -DOPTRACE
+DFLAGS = $(DEBUGFLAGS) $(XFLAGS) -DRELEASE=351 -DNOVERSION -DINIT
+
+LDFLAGS = -L/opt/X11/lib -lX11 -lm
+LDELDFLAGS =  -L/opt/X11/lib -lX11 -lm
+
+OBJECTDIR = ../$(RELEASENAME)/
+
+default	: ../$(OSARCHNAME)/ldeinit


### PR DESCRIPTION
We were missing the case for x86_64 macOS init processing.