### PR TITLE
warning: macro argument should be enclosed in parentheses

### DIFF
--- a/inc/address.h
+++ b/inc/address.h
@@ -29,8 +29,8 @@
 /**********************************************************************/
 
 /* NOTE: These MACRO should be used for the pointers in LISP SYSOUT */
-#define LLSH(datum , n)		((datum )<< n)
-#define LRSH(datum , n)		((datum) >> n)
+#define LLSH(datum, n)			((datum) << (n))
+#define LRSH(datum, n)			((datum) >> (n))
 
 #define HILOC(ptr)			(LRSH(((unsigned int)(ptr) & SEGMASK),16))
 #define LOLOC(ptr)			((unsigned int)(ptr) & 0x0ffff)

--- a/inc/adr68k.h
+++ b/inc/adr68k.h
@@ -48,7 +48,7 @@
 
 
 /* translate LispPage to 68k address */
-#define Addr68k_from_LPAGE(Lisp_page)	(Addr68k_from_LADDR((Lisp_page << 8) ))
+#define Addr68k_from_LPAGE(Lisp_page)	(Addr68k_from_LADDR(((Lisp_page) << 8) ))
 
 
 

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -10,20 +10,20 @@
 /************************************************************************/
 
 #define MAX_SMALL 65535  /* == 0x0000FFFF  */
-#define MIN_SMALL -65536 /* == 0xFFFF0000  */
+#define MIN_SMALL (-65536) /* == 0xFFFF0000  */
 
 #define MAX_FIXP 2147483647  /* == 0x7FFFFFFF  */
-#define MIN_FIXP -2147483648 /* == 0x80000000  */
+#define MIN_FIXP (-2147483648) /* == 0x80000000  */
 
 #define GetSmalldata(x)          \
-  (((SEGMASK & x) == S_POSITIVE) \
-       ? (0xFFFF & x)            \
-       : (((SEGMASK & x) == S_NEGATIVE) ? (0xFFFF0000 | x) : error("Not smallp address")))
+  (((SEGMASK & (x)) == S_POSITIVE)            \
+       ? (0xFFFF & (x))            \
+       : (((SEGMASK & (x)) == S_NEGATIVE) ? (0xFFFF0000 | (x)) : error("Not smallp address")))
 
 #define GetSmallp(x)                                                                  \
-  ((0xFFFF0000 & x) ? (((0xFFFF0000 & x) == 0xFFFF0000) ? (S_NEGATIVE | (0xFFFF & x)) \
+  ((0xFFFF0000 & (x)) ? (((0xFFFF0000 & (x)) == 0xFFFF0000) ? (S_NEGATIVE | (0xFFFF & (x))) \
                                                         : error("Not Smallp data"))   \
-                    : (S_POSITIVE | (0xFFFF & x)))
+                    : (S_POSITIVE | (0xFFFF & (x))))
 
 #define FIXP_VALUE(dest) *((int *)Addr68k_from_LADDR(dest))
 
@@ -31,32 +31,34 @@
 
 #define N_GETNUMBER(sour, dest, label)                        \
   do {                                                        \
-    dest = sour; /* access memory once */                     \
-    switch (SEGMASK & dest) {                                 \
-      case S_POSITIVE: dest = 0xFFFF & (dest); break;         \
-      case S_NEGATIVE: dest = 0xFFFF0000 | (dest); break;     \
+    (dest) = (sour); /* access memory once */                 \
+    switch (SEGMASK & (dest)) {                               \
+      case S_POSITIVE: (dest) = 0xFFFF & (dest); break;       \
+      case S_NEGATIVE: (dest) = 0xFFFF0000 | (dest); break;   \
       default:                                                \
+        /* NOLINTNEXTLINE(bugprone-macro-parentheses) */      \
         if (GetTypeNumber(dest) != TYPE_FIXP) goto label;     \
-        dest = FIXP_VALUE(dest);                              \
+        (dest) = FIXP_VALUE(dest);                            \
     }                                                         \
   } while (0)
 
 #define N_IGETNUMBER(sour, dest, label)                                                   \
   do {                                                                                    \
-    dest = sour; /* access memory once */                                                 \
-    switch (SEGMASK & dest) {                                                             \
-      case S_POSITIVE: dest = 0xFFFF & dest; break;                                       \
-      case S_NEGATIVE: dest = 0xFFFF0000 | dest; break;                                   \
+    (dest) = (sour); /* access memory once */                                             \
+    switch (SEGMASK & (dest)) {                                                           \
+      case S_POSITIVE: (dest) = 0xFFFF & (dest); break;                                   \
+      case S_NEGATIVE: (dest) = 0xFFFF0000 | (dest); break;                               \
       default:                                                                            \
         switch (GetTypeNumber(dest)) {                                                    \
-          case TYPE_FIXP: dest = FIXP_VALUE(dest); break;                                 \
+          case TYPE_FIXP: (dest) = FIXP_VALUE(dest); break;               \
           case TYPE_FLOATP: {                                                             \
             register float temp;                                                          \
             temp = FLOATP_VALUE(dest);                                                    \
+            /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                              \
             if ((temp > ((float)0x7fffffff)) || (temp < ((float)0x80000000))) goto label; \
-            dest = (int)temp;                                                             \
+            (dest) = (int)temp;                                                           \
           } break;                                                                        \
-          default: goto label;                                                            \
+          default: goto label; /* NOLINT(bugprone-macro-parentheses) */                   \
         }                                                                                 \
         break;                                                                            \
     }                                                                                     \
@@ -64,15 +66,15 @@
 
 #define ARITH_SWITCH(arg, result)                                          \
   do {                                                                     \
-    switch ((int)arg & 0xFFFF0000) {                                       \
-      case 0: result = (S_POSITIVE | (int)arg); break;                     \
-      case 0xFFFF0000: result = (S_NEGATIVE | (0xFFFF & (int)arg)); break; \
+    switch ((int)(arg) & 0xFFFF0000) {                                     \
+      case 0: (result) = (S_POSITIVE | (int)(arg)); break;                 \
+      case 0xFFFF0000: (result) = (S_NEGATIVE | (0xFFFF & (int)(arg))); break; \
       default: {                                                           \
         register LispPTR *wordp;                                           \
         /* arg is FIXP, call createcell */                                 \
         wordp = (LispPTR *)createcell68k(TYPE_FIXP);                       \
-        *((int *)wordp) = (int)arg;                                        \
-        result = (LADDR_from_68k(wordp));                                  \
+        *((int *)wordp) = (int)(arg);                                      \
+        (result) = (LADDR_from_68k(wordp));                                \
         break;                                                             \
       }                                                                    \
     }                                                                      \
@@ -104,9 +106,9 @@
 
 #define N_ARITH_SWITCH(arg)                                  \
   do {                                                       \
-    switch (arg & 0xFFFF0000) {                              \
-      case 0: return (S_POSITIVE | arg);                     \
-      case 0xFFFF0000: return (S_NEGATIVE | (0xFFFF & arg)); \
+    switch ((arg) & 0xFFFF0000) {                              \
+      case 0: return (S_POSITIVE | (arg));                     \
+      case 0xFFFF0000: return (S_NEGATIVE | (0xFFFF & (arg))); \
       default: {                                             \
         register LispPTR *fixpp;                             \
         /* arg is FIXP, call createcell */                   \

--- a/inc/bb.h
+++ b/inc/bb.h
@@ -140,7 +140,7 @@
 #define  B_src_word_in_postloop  src32lbit >= dst32lbit
 
 /*   VARIABLES   */
-#define  F_num_loop  ((dst32lbit + w) >> 5) - 1
+#define  F_num_loop  (((dst32lbit + w) >> 5) - 1)
 #define  B_num_loop  ((w - dst32rbit - 1) > 0) ? ((w - dst32rbit - 1) >> 5) : 0
 #define  F_preloop_mask  ((dst32lbit) ? (~(0xFFFFFFFF << (32 - dst32lbit))) : 0xFFFFFFFF)
 #define  F_postloop_mask  0xFFFFFFFF << (31 - dst32rbit)

--- a/inc/bitblt.h
+++ b/inc/bitblt.h
@@ -27,16 +27,16 @@
 #define	ERROR	PIX_SRC
 
 #define PixOperation( SRCTYPE, OPERATION )	\
-	( SRCTYPE == ERASE ? \
-		(OPERATION == REPLACE ? PIX_NOT(PIX_SRC) : \
-		(OPERATION == PAINT   ? PIX_NOT(PIX_SRC) | PIX_DST : \
-		(OPERATION == ERASE   ? PIX_NOT(PIX_SRC) & PIX_DST : \
-		(OPERATION == INVERT  ? PIX_NOT(PIX_SRC) ^ PIX_DST : ERROR)))) : \
+        ( (SRCTYPE) == ERASE ?                                 \
+		((OPERATION) == REPLACE ? PIX_NOT(PIX_SRC) : \
+		((OPERATION) == PAINT   ? PIX_NOT(PIX_SRC) | PIX_DST : \
+		((OPERATION) == ERASE   ? PIX_NOT(PIX_SRC) & PIX_DST : \
+		((OPERATION) == INVERT  ? PIX_NOT(PIX_SRC) ^ PIX_DST : ERROR)))) : \
 	/*  SRCTYPE == INPUT */ \
-		(OPERATION == REPLACE ? PIX_SRC : \
-		(OPERATION == PAINT   ? PIX_SRC | PIX_DST : \
-		(OPERATION == ERASE   ? PIX_SRC & PIX_DST : \
-		(OPERATION == INVERT  ? PIX_SRC ^ PIX_DST : ERROR)))))
+		((OPERATION) == REPLACE ? PIX_SRC : \
+		((OPERATION) == PAINT   ? PIX_SRC | PIX_DST : \
+		((OPERATION) == ERASE   ? PIX_SRC & PIX_DST : \
+		((OPERATION) == INVERT  ? PIX_SRC ^ PIX_DST : ERROR)))))
 
 
 extern DLword	*EmMouseX68K, *EmMouseY68K;

--- a/inc/cell.h
+++ b/inc/cell.h
@@ -29,7 +29,7 @@
 /* On 68010,68000 This Macro does not effect */
 
 #ifdef NEWCDRCODING
-#define CARFIELD(x) ((int)x & 0x0fffffff)
+#define CARFIELD(x) ((int)(x) & 0x0fffffff)
 
 /* CDR-Codes defs */
 #define CDR_ONPAGE 8
@@ -124,7 +124,7 @@ typedef struct freec {
 
 #endif /* BYTESWAP */
 
-#define FREECONS(page, offset) ((freecons *)((DLword *)page + offset))
+#define FREECONS(page, offset) ((freecons *)((DLword *)(page) + (offset)))
 
 /************************************************************************/
 /*									*/
@@ -375,20 +375,20 @@ struct cadr_cell {
 
 #else
 /* Good for old LITATOMS and new NEW-ATOMs */
-#define GetDEFCELL68k(index)                                                               \
-  (((index & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_DEFN_OFFSET) \
+#define GetDEFCELL68k(index)                                                                 \
+  ((((index) & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_DEFN_OFFSET) \
                             : GetDEFCELLlitatom(index))
 
-#define GetVALCELL68k(index)                                                                \
-  (((index & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_VALUE_OFFSET) \
+#define GetVALCELL68k(index)                                                                  \
+  ((((index) & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_VALUE_OFFSET) \
                             : GetVALCELLlitatom(index))
 
-#define GetPnameCell(index)                                                                 \
-  (((index & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_PNAME_OFFSET) \
+#define GetPnameCell(index)                                                                   \
+  ((((index) & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_PNAME_OFFSET) \
                             : GetPnameCelllitatom(index))
 
-#define GetPropCell(index)                                                                  \
-  (((index & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_PLIST_OFFSET) \
+#define GetPropCell(index)                                                                    \
+  ((((index) & SEGMASK) != 0) ? (LispPTR *)(Addr68k_from_LADDR(index) + NEWATOM_PLIST_OFFSET) \
                             : GetPropCelllitatom(index))
 
 /* Good only for old-style LITATOMS */
@@ -420,6 +420,6 @@ struct cadr_cell {
     if (GetTypeNumber(parm) != TYPE_LISTP) { \
       ERROR_EXIT(tos);                       \
     } else                                   \
-      dest = cadr(parm);                     \
+      (dest) = cadr(parm);                   \
   }
 #endif

--- a/inc/devif.h
+++ b/inc/devif.h
@@ -271,7 +271,7 @@ typedef struct
 }
 #endif /* XWINDOW */
 
-#define OUTER_SB_WIDTH(dsp) (dsp->ScrollBarWidth + 2*(dsp->InternalBorderWidth))
+#define OUTER_SB_WIDTH(dsp) ((dsp)->ScrollBarWidth + 2*((dsp)->InternalBorderWidth))
 
 #ifndef min
 #define min( a, b ) (((a)<(b))?(a):(b))

--- a/inc/display.h
+++ b/inc/display.h
@@ -66,8 +66,8 @@ extern DLword *DISP_MAX_Address;
 extern DLword *DisplayRegion68k;
 
 #define in_display_segment(baseaddr)  \
-            (((DisplayRegion68k <= baseaddr) && \
-	      (baseaddr <=DISP_MAX_Address)) ? T :NIL )
+    (((DisplayRegion68k <= (baseaddr)) &&               \
+      ((baseaddr) <= DISP_MAX_Address)) ? T : NIL )
 #endif
 
 #ifdef XWINDOW

--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -48,7 +48,7 @@
    /* IncAllocCnt is called only when *Reclaim_cnt_word != NIL */
 
 #define IncAllocCnt(n) {\
-	if ((*Reclaim_cnt_word -= n) <= S_POSITIVE) {\
+	if ((*Reclaim_cnt_word -= (n)) <= S_POSITIVE) { \
 		/* time for GC */\
 		Irq_Stk_Check = Irq_Stk_End = 0;\
 		*Reclaim_cnt_word = S_POSITIVE;\
@@ -57,35 +57,35 @@
 
    /* DecAllocCnt only called when *Reclaim_cnt_word != NIL */
 
-#define DecAllocCnt(n) { *Reclaim_cnt_word += n; }
+#define DecAllocCnt(n) { *Reclaim_cnt_word += (n); }
 
-#define FreeLink(link) {\
-	GETGC(link) = 0;\
-	GETGC(link+1) = GETGC(HTcoll);\
-	GETGC(HTcoll) = (link - HTcoll);\
+#define FreeLink(link) {                        \
+	GETGC(link) = 0;                        \
+	GETGC((link)+1) = GETGC(HTcoll);        \
+	GETGC(HTcoll) = ((link) - HTcoll);      \
 }
 
 
   /* Given the contents of an HTMAIN or HTCOLL entry,
 	 get the link pointer (i.e., turn off the low bit) */
-#define GetLinkptr(entry)       (entry & 0x0fffffffe)
+#define GetLinkptr(entry)       ((entry) & 0x0fffffffe)
 
 
 #define DelLink(link, prev, entry) {                                    \
-  if (prev != (GCENTRY *)0)                                             \
+  if ((prev) != (GCENTRY *)0)                                           \
     {                                                                   \
-      GETGC((GCENTRY *)prev + 1) = GETGC((GCENTRY *)link + 1);          \
+      GETGC((GCENTRY *)(prev) + 1) = GETGC((GCENTRY *)(link) + 1);      \
     }                                                                   \
   else                                                                  \
     {                                                                   \
-      GETGC((GCENTRY *)entry) = GETGC((GCENTRY *)link + 1) | 1;         \
+      GETGC((GCENTRY *)(entry)) = GETGC((GCENTRY *)(link) + 1) | 1;     \
     }                                                                   \
-  FreeLink((GCENTRY *)link);                                            \
-  link = (GCENTRY *)(HTcoll + GetLinkptr(GETGC((GCENTRY *)entry)));     \
-  if (GETGC((GCENTRY *)link + 1) == 0)                                  \
+  FreeLink((GCENTRY *)(link));                                          \
+  (link) = (GCENTRY *)(HTcoll + GetLinkptr(GETGC((GCENTRY *)(entry)))); \
+  if (GETGC((GCENTRY *)(link) + 1) == 0)                                \
     {                                                                   \
-      GETGC((GCENTRY *)entry) = GETGC((GCENTRY *)link);                 \
-      FreeLink((GCENTRY *)link);                                        \
+      GETGC((GCENTRY *)(entry)) = GETGC((GCENTRY *)(link));             \
+      FreeLink((GCENTRY *)(link));                                      \
     }                                                                   \
 }
 
@@ -104,18 +104,18 @@
 #define GCLOOKUPV(ptr, case, val) {                                          \
 	if (RefCntP(ptr)) {                                                  \
 		if (*Reclaim_cnt_word != NIL)                                \
-		  val = htfind(ptr, case);                                   \
+                  (val) = htfind((ptr), (case));                             \
 		else                                                         \
-		  val = rec_htfind(ptr, case);                               \
-	} else val = NIL;                                                    \
+                  (val) = rec_htfind((ptr), (case));                         \
+	} else (val) = NIL;                                                  \
 }
 
 #define REC_GCLOOKUP(ptr, case) { if (RefCntP(ptr)) rec_htfind(ptr, case); }
 #define REC_GCLOOKUPV(ptr, case, val) {                                      \
 	if (RefCntP(ptr))                                                    \
-	  val = rec_htfind(ptr, case);                                       \
+          (val) = rec_htfind((ptr), (case));                                 \
 	else                                                                 \
-	  val = NIL;                                                         \
+          (val) = NIL;                                                       \
 }
 
 #define FRPLPTR(old , new) { \

--- a/inc/inlineC.h
+++ b/inc/inlineC.h
@@ -211,7 +211,7 @@
 #define JUMPMACRO(x) \
   do {               \
     CHECK_INTERRUPT; \
-    PCMACL += x;     \
+    PCMACL += (x);   \
     nextop0;         \
   } while (0)
 
@@ -221,7 +221,7 @@
     {                                         \
       CHECK_INTERRUPT;                        \
       POP;                                    \
-      PCMACL += x;                            \
+      PCMACL += (x);                          \
       nextop0;                                \
     }                                         \
   } while (0)
@@ -231,7 +231,7 @@
     {                                         \
       CHECK_INTERRUPT;                        \
       POP;                                    \
-      PCMACL += x;                            \
+      PCMACL += (x);                          \
       nextop0;                                \
     }                                         \
   } while (0)
@@ -239,13 +239,13 @@
 #define GETBASE_N(N)                                                                          \
   do {                                                                                        \
     TOPOFSTACK =                                                                              \
-        (S_POSITIVE | GETWORD((DLword *)Addr68k_from_LADDR((POINTERMASK & TOPOFSTACK) + N))); \
+      (S_POSITIVE | GETWORD((DLword *)Addr68k_from_LADDR((POINTERMASK & TOPOFSTACK) + (N)))); \
     nextop2;                                                                                  \
   } while (0)
 
 #define GETBASEPTR_N(N)                                                                            \
   do {                                                                                             \
-    TOPOFSTACK = (POINTERMASK & *((LispPTR *)Addr68k_from_LADDR((POINTERMASK & TOPOFSTACK) + N))); \
+    TOPOFSTACK = (POINTERMASK & *((LispPTR *)Addr68k_from_LADDR((POINTERMASK & TOPOFSTACK) + (N)))); \
     nextop2;                                                                                       \
   } while (0)
 #define PUTBASEBYTE                                                                    \
@@ -288,44 +288,44 @@
     nextop1;                                                                                       \
   } while (0)
 
-#define PUTBASEPTR_N(n)                                      \
-  do {                                                       \
-    register int base;                                       \
-    base = POINTERMASK & POP_TOS_1;                          \
-    *((LispPTR *)Addr68k_from_LADDR(base + n)) = TOPOFSTACK; \
-    TOPOFSTACK = base;                                       \
-    nextop2;                                                 \
+#define PUTBASEPTR_N(n)                                        \
+  do {                                                         \
+    register int base;                                         \
+    base = POINTERMASK & POP_TOS_1;                            \
+    *((LispPTR *)Addr68k_from_LADDR(base + (n))) = TOPOFSTACK; \
+    TOPOFSTACK = base;                                         \
+    nextop2;                                                   \
   } while (0)
 
-#define PUTBASE_N(n)                                                         \
-  do {                                                                       \
-    register int base;                                                       \
-    if (GetHiWord(TOPOFSTACK) != (S_POSITIVE >> 16)) goto op_ufn;            \
-    base = POINTERMASK & POP_TOS_1;                                          \
-    GETWORD((DLword *)Addr68k_from_LADDR(base + n)) = GetLoWord(TOPOFSTACK); \
-    TOPOFSTACK = base;                                                       \
-    nextop2;                                                                 \
+#define PUTBASE_N(n)                                                           \
+  do {                                                                         \
+    register int base;                                                         \
+    if (GetHiWord(TOPOFSTACK) != (S_POSITIVE >> 16)) goto op_ufn;              \
+    base = POINTERMASK & POP_TOS_1;                                            \
+    GETWORD((DLword *)Addr68k_from_LADDR(base + (n))) = GetLoWord(TOPOFSTACK); \
+    TOPOFSTACK = base;                                                         \
+    nextop2;                                                                   \
   } while (0)
 
-#define PVARX(x)                           \
-  do {                                     \
-    PUSH(GetLongWord((DLword *)PVAR + x)); \
-    nextop2;                               \
+#define PVARX(x)                             \
+  do {                                       \
+    PUSH(GetLongWord((DLword *)PVAR + (x))); \
+    nextop2;                                 \
   } while (0)
-#define PVARX_(x)                                    \
-  do {                                               \
-    *((LispPTR *)((DLword *)PVAR + x)) = TOPOFSTACK; \
-    nextop2;                                         \
+#define PVARX_(x)                                      \
+  do {                                                 \
+    *((LispPTR *)((DLword *)PVAR + (x))) = TOPOFSTACK; \
+    nextop2;                                           \
   } while (0)
-#define IVARX(x)                           \
-  do {                                     \
-    PUSH(GetLongWord((DLword *)IVAR + x)); \
-    nextop2;                               \
+#define IVARX(x)                             \
+  do {                                       \
+    PUSH(GetLongWord((DLword *)IVAR + (x))); \
+    nextop2;                                 \
   } while (0)
-#define IVARX_(x)                                    \
-  do {                                               \
-    *((LispPTR *)((DLword *)IVAR + x)) = TOPOFSTACK; \
-    nextop2;                                         \
+#define IVARX_(x)                                      \
+  do {                                                 \
+    *((LispPTR *)((DLword *)IVAR + (x))) = TOPOFSTACK; \
+    nextop2;                                           \
   } while (0)
 
 #ifndef BIGATOMS
@@ -565,14 +565,14 @@
     nextop1;                                         \
   } while (0)
 
-#define GETBITS_N_M(a, b)                                                                        \
-  do {                                                                                           \
-    register int temp, bb = b;                                                                   \
-    temp = 0xF & bb;                                                                             \
-    TOPOFSTACK = S_POSITIVE | (((GETWORD(Addr68k_from_LADDR(POINTERMASK & (TOPOFSTACK + a)))) >> \
-                                (16 - ((0xF & (bb >> 4)) + temp + 1))) &                         \
-                               n_mask_array[temp]);                                              \
-    nextop3;                                                                                     \
+#define GETBITS_N_M(a, b)                                                                          \
+  do {                                                                                             \
+    register int temp, bb = b;                                                                     \
+    temp = 0xF & bb;                                                                               \
+    TOPOFSTACK = S_POSITIVE | (((GETWORD(Addr68k_from_LADDR(POINTERMASK & (TOPOFSTACK + (a))))) >> \
+                                (16 - ((0xF & (bb >> 4)) + temp + 1))) &                           \
+                               n_mask_array[temp]);                                                \
+    nextop3;                                                                                       \
   } while (0)
 
 #define PUTBITS_N_M(a, b)                                                                \
@@ -583,7 +583,7 @@
     register int shift_size, field_size, fmask;                                          \
     if ((SEGMASK & TOPOFSTACK) != S_POSITIVE) { goto op_ufn; };                          \
     base = POINTERMASK & POP_TOS_1;                                                      \
-    pword = (DLword *)Addr68k_from_LADDR(base + a);                                      \
+    pword = (DLword *)Addr68k_from_LADDR(base + (a));                                    \
     field_size = 0xF & bb;                                                               \
     shift_size = 15 - (0xF & (bb >> 4)) - field_size;                                    \
     fmask = n_mask_array[field_size] << shift_size;                                      \
@@ -633,16 +633,16 @@
     nextop1;                                                       \
   } while (0)
 
-#define TYPEP(n)                                                      \
-  do {                                                                \
-    if ((DLword)GetTypeNumber(TOPOFSTACK) != n) TOPOFSTACK = NIL_PTR; \
-    nextop2;                                                          \
+#define TYPEP(n)                                                        \
+  do {                                                                  \
+    if ((DLword)GetTypeNumber(TOPOFSTACK) != (n)) TOPOFSTACK = NIL_PTR; \
+    nextop2;                                                            \
   } while (0)
 
-#define TYPEMASK(n)                                                                         \
-  do {                                                                                      \
-    if ((((DLword)GetTypeEntry(TOPOFSTACK)) & ((DLword)n << 8)) == 0) TOPOFSTACK = NIL_PTR; \
-    nextop2;                                                                                \
+#define TYPEMASK(n)                                                                           \
+  do {                                                                                        \
+    if ((((DLword)GetTypeEntry(TOPOFSTACK)) & ((DLword)(n) << 8)) == 0) TOPOFSTACK = NIL_PTR; \
+    nextop2;                                                                                  \
   } while (0)
 
 #define INSTANCEP(atom_index)                            \
@@ -651,16 +651,16 @@
     nextop_atom;                                         \
   } while (0)
 
-#define STOREN(n)                             \
-  do {                                        \
-    *(CSTKPTR - ((n + 2) >> 1)) = TOPOFSTACK; \
-    nextop2;                                  \
+#define STOREN(n)                               \
+  do {                                          \
+    *(CSTKPTR - (((n) + 2) >> 1)) = TOPOFSTACK; \
+    nextop2;                                    \
   } while (0)
 
-#define COPYN(n)                       \
-  do {                                 \
-    PUSH(*(CSTKPTR - ((n + 2) >> 1))); \
-    nextop2;                           \
+#define COPYN(n)                         \
+  do {                                   \
+    PUSH(*(CSTKPTR - (((n) + 2) >> 1))); \
+    nextop2;                             \
   } while (0)
 
 #define POPN(n)                            \
@@ -792,16 +792,16 @@
   } while (0)
 #endif /* BIGVM */
 
-#define FVAR(n)                                                                           \
-  do {                                                                                    \
-    register LispPTR *chain;                                                              \
-    chain = (LispPTR *)(PVar + n);                                                        \
-    if (WBITSPTR(chain)->LSB) {                                                           \
-      PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(native_newframe(n >> 1))))); \
-      nextop1;                                                                            \
-    } /* if(((WBITS */                                                                    \
-    PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(*chain))));                    \
-    nextop1;                                                                              \
+#define FVAR(n)                                                                             \
+  do {                                                                                      \
+    register LispPTR *chain;                                                                \
+    chain = (LispPTR *)(PVar + (n));                                                        \
+    if (WBITSPTR(chain)->LSB) {                                                             \
+      PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(native_newframe((n) >> 1))))); \
+      nextop1;                                                                              \
+    } /* if(((WBITS */                                                                      \
+    PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(*chain))));                      \
+    nextop1;                                                                                \
   } while (0)
 
 #define FVARX(n)                                                                           \

--- a/inc/lispemul.h
+++ b/inc/lispemul.h
@@ -97,16 +97,16 @@ struct state {
 
 /***** Get_DLword(ptr) ptr is char* ***/
 #ifndef UNALIGNED_FETCH_OK
-#define Get_DLword(ptr) ((Get_BYTE(ptr) << 8) | Get_BYTE(ptr + 1))
+#define Get_DLword(ptr) ((Get_BYTE(ptr) << 8) | Get_BYTE((ptr) + 1))
 #else
 #define Get_DLword(ptr) *(((DLword *)WORDPTR(ptr)))
 #endif
 
 #ifdef BIGVM
 #define Get_Pointer(ptr) \
-  ((Get_BYTE(ptr) << 24) | (Get_BYTE(ptr + 1) << 16) | (Get_BYTE(ptr + 2) << 8) | Get_BYTE(ptr + 3))
+  ((Get_BYTE(ptr) << 24) | (Get_BYTE((ptr) + 1) << 16) | (Get_BYTE((ptr) + 2) << 8) | Get_BYTE((ptr) + 3))
 #else
-#define Get_Pointer(ptr) ((Get_BYTE(ptr) << 16) | (Get_BYTE(ptr + 1) << 8) | Get_BYTE(ptr + 2))
+#define Get_Pointer(ptr) ((Get_BYTE(ptr) << 16) | (Get_BYTE((ptr) + 1) << 8) | Get_BYTE((ptr) + 2))
 #endif /* BIGVM */
 
 #define Get_code_BYTE Get_BYTE
@@ -241,11 +241,11 @@ struct state {
 
 /* Fetching 2 bytes to make a word -- always do it the hard way */
 /* if we're byte-swapped:  You can't rely on byte ordering!!    */
-#define Get_DLword(ptr) ((Get_BYTE(ptr) << 8) | Get_BYTE(ptr + 1))
+#define Get_DLword(ptr) ((Get_BYTE(ptr) << 8) | Get_BYTE((ptr) + 1))
 
 #ifdef BIGVM
 #define Get_Pointer(ptr) \
-  ((Get_BYTE(ptr) << 24) | (Get_BYTE(ptr + 1) << 16) | (Get_BYTE(ptr + 2) << 8) | Get_BYTE(ptr + 3))
+  ((Get_BYTE(ptr) << 24) | (Get_BYTE((ptr) + 1) << 16) | (Get_BYTE((ptr) + 2) << 8) | Get_BYTE((ptr) + 3))
 #else
 #define Get_Pointer(ptr) ((Get_BYTE(ptr) << 16) | (Get_BYTE(ptr + 1) << 8) | Get_BYTE(ptr + 2))
 #endif /* BIGVM */
@@ -336,7 +336,7 @@ extern struct state MachineState;
         offset:	word offset from base
         return:	DLword*
 ****************************************************/
-#define MakeAddr(base, offset) ((DLword *)(base + (int)offset))
+#define MakeAddr(base, offset) ((DLword *)((base) + (int)(offset)))
 
 /****************************************************
 GetHiWord:
@@ -369,10 +369,10 @@ PopCStack:
 PopStackTo:  CSTK -> Place
 #define PopStackTo(Place)	{Place= *((LispPTR *)(--CurrentStackPTR)); CurrentStackPTR--; }
 *****************************************************/
-#define PopStackTo(Place)                    \
-  do {                                       \
-    Place = *((LispPTR *)(CurrentStackPTR)); \
-    CurrentStackPTR -= 2;                    \
+#define PopStackTo(Place)                      \
+  do {                                         \
+    (Place) = *((LispPTR *)(CurrentStackPTR)); \
+    CurrentStackPTR -= 2;                      \
   } while (0)
 
 /****************************************************
@@ -399,7 +399,7 @@ PushStack:
 SmashStack:
 #define SmashStack(x)	(*((LispPTR *)(CurrentStackPTR-1))=x)
 *****************************************************/
-#define SmashStack(x) (*((LispPTR *)(CurrentStackPTR)) = x)
+#define SmashStack(x) (*((LispPTR *)(CurrentStackPTR)) = (x))
 
 /*********************************************************
 Get_BYTE(byteptr)	byteptr: pointer to  8 bit data
@@ -416,7 +416,7 @@ DOSTACKOVERFLOW(argnum,bytenum) if it needs hardreturn-cleanup
 #define DOSTACKOVERFLOW(argnum, bytenum) \
   do {                                   \
     if (do_stackoverflow(T)) {           \
-      PushStack(S_POSITIVE | argnum);    \
+      PushStack(S_POSITIVE | (argnum));  \
       contextsw(SubovFXP, bytenum, 1);   \
       return;                            \
     }                                    \
@@ -505,7 +505,7 @@ DOSTACKOVERFLOW(argnum,bytenum) if it needs hardreturn-cleanup
 #define SFS_ARRAYSWITCHED 3
 #define SFS_FULLYSWITCHED 4
 
-#define AtomHTSIZE 256 * DLWORDSPER_PAGE
+#define AtomHTSIZE (256 * DLWORDSPER_PAGE)
 
 #define MAXPNCHARS 255 /* Maximum length of PnChars */
 
@@ -586,7 +586,7 @@ typedef struct newatom {
 
 #ifdef BIGVM
 #define GETFPTOVP(b, o) b[o]
-#define GETPAGEOK(b, o) (b[o] >> 16)
+#define GETPAGEOK(b, o) ((b)[o] >> 16)
 #else
 #define GETFPTOVP GETWORDBASEWORD
 #define GETPAGEOK GETWORDBASEWORD

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -36,12 +36,12 @@
 extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 
-#define	ToLispTime(x)	((int)x + 29969152)
+#define	ToLispTime(x)	((int)(x) + 29969152)
 			/* For getfileinfo. For WDATE&RDATE */
 			/* 29969152 == (timer.c)LISP_UNIX_TIME_DIFF */
 			/* - 61200 == - 17hours */
 
-#define	ToUnixTime(x)	((int)x - 29969152)
+#define	ToUnixTime(x)	((int)(x) - 29969152)
 			/* For getfileinfo. For WDATE&RDATE */
 			/* 29969152 == (timer.c)LISP_UNIX_TIME_DIFF */
 
@@ -92,7 +92,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		lf_base = ((char *)(Addr68k_from_LADDR(lf_arrayp->base)))  	\
 		       + ((int)(lf_arrayp->offset));			\
 		strncpy(C, lf_base, lf_length);				\
-		C[lf_length] = '\0';					\
+		(C)[lf_length] = '\0';					\
 		break;							\
 									\
 	case FAT_CHAR_TYPENUMBER:					\
@@ -121,7 +121,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		lf_base = ((char *)(Addr68k_from_LADDR(lf_arrayp->base)))  	\
 		       + ((int)(lf_arrayp->offset));			\
 		StrNCpyFromLispToC(C , lf_base , lf_length );		\
-		C[lf_length] = '\0';					\
+		(C)[lf_length] = '\0';					\
 		break;							\
 									\
 	case FAT_CHAR_TYPENUMBER:					\
@@ -153,16 +153,16 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
   {									\
     OneDArray	*lf_arrayp;						\
     lf_arrayp = (OneDArray *)(Addr68k_from_LADDR(LispString));		\
-    switch(lf_arrayp->typenumber)						\
+    switch(lf_arrayp->typenumber)					\
       {									\
 	case THIN_CHAR_TYPENUMBER:					\
-		Length = lf_arrayp->fillpointer;				\
-		FatP = 0;						\
+        	(Length) = lf_arrayp->fillpointer;			\
+		(FatP) = 0;						\
 		break;							\
 									\
 	case FAT_CHAR_TYPENUMBER:					\
-		Length = lf_arrayp->fillpointer * 2;			\
-		FatP = 1;						\
+            	(Length) = lf_arrayp->fillpointer * 2;			\
+            	(FatP) = 1;                                             \
 		break;							\
 	default:							\
 		error("LispStringLength: Not a character array.\n");	\
@@ -183,24 +183,24 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
   {				\
 	LispPTR	*lf_naddress;				  \
 	lf_naddress = (LispPTR *)(Addr68k_from_LADDR(lstringp));		  \
-	cstringp  = (char *)(Addr68k_from_LADDR(((OneDArray *)lf_naddress)->base));  \
+	(cstringp) = (char *)(Addr68k_from_LADDR(((OneDArray *)lf_naddress)->base)); \
   }
 
 #ifndef min
-#define min(a, b) ((a <= b)?a:b)
+#define min(a, b) (((a) <= (b))?(a):(b))
 #endif /* min */
 
 #define	LispNumToCInt(Lisp)					\
-		( ((Lisp & SEGMASK) == S_POSITIVE) ?		\
-		(Lisp & 0xFFFF) : (*((int *)(Addr68k_from_LADDR(Lisp)))) )
+	( (((Lisp) & SEGMASK) == S_POSITIVE) ?                  \
+          ((Lisp) & 0xFFFF) : (*((int *)(Addr68k_from_LADDR(Lisp)))) )
 
 #define	UPLOWDIFF	0x20
 
 #define	DOWNCASE(name){						\
 								\
-	char	*lf_cp;					\
+	char	*lf_cp;						\
 								\
-	for(lf_cp = name; *lf_cp!='\0'; ++lf_cp)				\
+	for(lf_cp = (name); *lf_cp!='\0'; ++lf_cp)                      \
 	  if((*lf_cp >= 'A') && (*lf_cp <= 'Z')) *lf_cp += UPLOWDIFF;	\
 }
 
@@ -208,7 +208,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 								\
 	char	*lf_cp;					\
 								\
-	for(lf_cp = name; *lf_cp!='\0'; ++lf_cp)				\
+	for(lf_cp = (name); *lf_cp!='\0'; ++lf_cp)                      \
 	  if((*lf_cp >= 'a') && (*lf_cp <= 'z')) *lf_cp -= UPLOWDIFF;	\
 }
 
@@ -219,16 +219,16 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	TIMEOUT(lf_result = stat(name, &lf_statbuf));		\
 	if (lf_result < 0) {					\
 		*Lisp_errno = errno;				\
-		type = 0;					\
+		(type) = 0;					\
 	} else {  						\
 		switch (lf_statbuf.st_mode & S_IFMT) {		\
 								\
 		      case S_IFDIR:				\
-			type = -1;				\
+                        (type) = -1;				\
 			break;					\
 								\
 		      case S_IFREG:				\
-			type = 1;				\
+                        (type) = 1;				\
 			break;					\
 								\
 		      default:					\
@@ -236,7 +236,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			 * Should we deal with the other	\
 			 * types?				\
 			 */					\
-			type = 0;				\
+                        (type) = 0;				\
 			break;					\
 		}						\
 	}							\
@@ -272,20 +272,21 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		}
 
 #define	STREQ(name1, name2)(	\
-		(*name1 == *name2) && (strcmp(name1, name2) == 0)	\
-		)
+                (*(name1) == *(name2)) && (strcmp(name1, name2) == 0)   \
+                )
 
-#define	SPECIALFILEMARK		-1
+#define	SPECIALFILEMARK		(-1)
 
 #define NumericStringP(str, truetag, falsetag) {			\
 	char	*lfn_cp;						\
 									\
-	if (*str == '\0') goto falsetag;				\
+        /* NOLINTNEXTLINE(bugprone-macro-parentheses) */		\
+	if (*(str) == '\0') goto falsetag;				\
 									\
 	for(lfn_cp = str; *lfn_cp!='\0'; ++lfn_cp)			\
 	  if(*lfn_cp < '0' || '9' < *lfn_cp)				\
-	    goto falsetag;						\
-	goto truetag;							\
+	    goto falsetag; /* NOLINT(bugprone-macro-parentheses) */	\
+	goto truetag;	/* NOLINT(bugprone-macro-parentheses) */	\
 }
 
 /*		
@@ -392,16 +393,16 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 										\
 		      NO:							\
 			/* Dealt with as version 1 unless vlessp */		\
-			if (!vlessp) strcat(pathname, ";1");			\
+			if (!(vlessp)) strcat(pathname, ";1");                  \
 		      CONT:							\
-			lf_cp--;	/* Just for label */				\
+			lf_cp--;	/* Just for label */			\
 		} else {							\
 			/* Dealt with as version 1 unless vlessp. */		\
-			if (!vlessp) strcat(pathname, ";1");			\
+                        if (!(vlessp)) strcat(pathname, ";1");                  \
 		}								\
 	} else {								\
 		/* Dealt with as version 1 unless vlessp. */			\
-		if (!vlessp) strcat(pathname, ";1");				\
+                if (!(vlessp)) strcat(pathname, ";1");                          \
 	}									\
 }
 
@@ -444,7 +445,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		}							\
 	}								\
 	if (lf_cp1 == (lf_cp2 - 1)) {						\
-		if (lf_cp1 == dir) {					\
+                if (lf_cp1 == (dir)) {					\
 			/* dir is a root directory. */			\
 			strcpy(fname, "/");				\
 			strcat(fname, name);				\
@@ -479,7 +480,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
  */
 
 #define ConcNameAndVersion(name, ver, rname){				\
-	if (*ver != '\0') {						\
+	if (*(ver) != '\0') {						\
 		strcpy(rname, name);					\
 		strcat(rname, ".~");					\
 		strcat(rname, ver);					\
@@ -493,18 +494,18 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 #define	MAXVERSION		999999999
 
-#define	LASTVERSIONARRAY	-1
+#define	LASTVERSIONARRAY	(-1)
 #define	VERSIONARRAYLENGTH	200
 
 #define NoFileP(varray)						\
-	((varray->version_no == LASTVERSIONARRAY)? 1 : 0)
+        (((varray)->version_no == LASTVERSIONARRAY)? 1 : 0)
 
 
 #ifdef DOS
 #define OnlyVersionlessP(varray) 0
 #else
-#define OnlyVersionlessP(varray)							\
-	((varray->version_no == 0 && (varray + 1)->version_no == LASTVERSIONARRAY) ?	\
+#define OnlyVersionlessP(varray)							 \
+        (((varray)->version_no == 0 && ((varray) + 1)->version_no == LASTVERSIONARRAY) ? \
 	 1 : 0)
 #endif /* DOS */
 

--- a/inc/my.h
+++ b/inc/my.h
@@ -38,20 +38,20 @@
 /*									*/
 /************************************************************************/
 #define	N_MakeFloat(arg, dest, tos){					\
-	switch (SEGMASK & (LispPTR)arg) {				\
+	switch (SEGMASK & (LispPTR)(arg)) {				\
 	case S_POSITIVE:						\
-		dest = (float)(0xFFFF & (LispPTR)arg);			\
+		(dest) = (float)(0xFFFF & (LispPTR)(arg));		\
 		break;							\
 	case S_NEGATIVE:						\
-		dest = (float)((int)(0xFFFF0000 | (LispPTR)arg));		\
+		(dest) = (float)((int)(0xFFFF0000 | (LispPTR)(arg)));	\
 		break;							\
 	default:							\
 		switch (GetTypeNumber(arg)) {				\
 		  case TYPE_FLOATP: 					\
-		    dest = *((float *)Addr68k_from_LADDR(arg));		\
+		    (dest) = *((float *)Addr68k_from_LADDR(arg));	\
 		    break; 						\
 		  case TYPE_FIXP: 					\
-		    dest = (float)(*((int *)Addr68k_from_LADDR(arg)));	\
+		    (dest) = (float)(*((int *)Addr68k_from_LADDR(arg)));\
 		    break;						\
 		  default: ERROR_EXIT(tos);				\
 		}							\
@@ -61,11 +61,11 @@
 
 
 #define	N_GetPos(arg, dest, tos){					\
-	if ((arg & SEGMASK) == S_POSITIVE)				\
-		dest = arg & 0xFFFF;					\
+	if (((arg) & SEGMASK) == S_POSITIVE)				\
+		(dest) = (arg) & 0xFFFF;				\
 	else	{							\
 	if (GetTypeNumber(arg) != TYPE_FIXP) ERROR_EXIT(tos);		\
-	if ((dest = *((int *)Addr68k_from_LADDR(arg))) & 0x80000000)	\
+	if (((dest) = *((int *)Addr68k_from_LADDR(arg))) & 0x80000000)	\
 		ERROR_EXIT(tos);					\
 		}							\
 	}

--- a/inc/return.h
+++ b/inc/return.h
@@ -71,9 +71,9 @@
     midpunt = LOLOC(LADDR_from_68k(CURRENTFX));			\
     PVar=(DLword *)							\
 	    Addr68k_from_StkOffset(					\
-			(GETWORD(((DLword *)InterfacePage) +fxnum)))	\
+                        (GETWORD(((DLword *)InterfacePage) + (fxnum)))) \
 		+ FRAMESIZE; 						\
-    GETWORD(((DLword *)InterfacePage) +fxnum) = midpunt ;		\
+    GETWORD(((DLword *)InterfacePage) + (fxnum)) = midpunt ;		\
   }
 
 

--- a/inc/stack.h
+++ b/inc/stack.h
@@ -301,13 +301,13 @@ typedef struct stackp {
 #define DUMMYBF(fx) (((DLword *)(fx)) - DLWORDSPER_CELL)
 #define SLOWP(fx) (((FXBLOCK *)(fx))->slowp)
 #define FASTP(fx) (!SLOWP(fx))
-#define SET_FASTP_NIL(fx68k)                                     \
-  {                                                              \
-    if (FASTP(fx68k)) {                                          \
-      ((FX *)fx68k)->blink = StkOffset_from_68K(DUMMYBF(fx68k)); \
-      ((FX *)fx68k)->clink = ((FX *)fx68k)->alink;               \
-      SLOWP(fx68k) = T;                                          \
-    }                                                            \
+#define SET_FASTP_NIL(fx68k)                                       \
+  {                                                                \
+    if (FASTP(fx68k)) {                                            \
+      ((FX *)(fx68k))->blink = StkOffset_from_68K(DUMMYBF(fx68k)); \
+      ((FX *)(fx68k))->clink = ((FX *)(fx68k))->alink;             \
+      SLOWP(fx68k) = T;                                            \
+    }                                                              \
   }
 
 #define GETALINK(fx) ((((fx)->alink) & 0xfffe) - FRAMESIZE)
@@ -354,10 +354,10 @@ typedef struct stackp {
 #define SWAP_FNHEAD(x) swapx(x)
 #endif /* BIGVM */
 
-#define GETNAMETABLE(fx)                                                                      \
-  ((struct fnhead *)Addr68k_from_LADDR(                                                       \
-      SWAP_FNHEAD(                                                                            \
-          ((((FX2 *)fx)->validnametable) ? ((FX2 *)fx)->nametable : ((FX2 *)fx)->fnheader)) & \
+#define GETNAMETABLE(fx)                                                                          \
+  ((struct fnhead *)Addr68k_from_LADDR(                                                           \
+      SWAP_FNHEAD(                                                                                \
+        ((((FX2 *)(fx))->validnametable) ? ((FX2 *)(fx))->nametable : ((FX2 *)(fx))->fnheader)) & \
       POINTERMASK))
 
 #define MAKEFREEBLOCK(ptr68k, size)                                   \
@@ -429,7 +429,7 @@ typedef struct stackp {
 
 #endif /* STACKCHECK */
 
-#define STK_MIN(fnobj) ((fnobj->stkmin /* NOT NEEDED in stkmin +STK_SAFE */) << 1)
+#define STK_MIN(fnobj) (((fnobj)->stkmin /* NOT NEEDED in stkmin +STK_SAFE */) << 1)
 
 #define STK_END_COMPUTE(stk_end, fnobj) ((UNSIGNED)(stk_end)-STK_MIN(fnobj))
 

--- a/inc/tosfns.h
+++ b/inc/tosfns.h
@@ -203,13 +203,13 @@
     FN_STACK_CHECK;                                                                    \
     {                                                                                  \
       register UNSIGNED newivar;                                                       \
-      newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR - argcount + 1));                \
+      newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR - (argcount) + 1));              \
       BCE_CURRENTFX->nextblock = NEXTBLOCK = StkOffset_from_68K(newivar);              \
     }                                                                                  \
     HARD_PUSH(TOPOFSTACK); /* save TOS */                                              \
     if (LOCFNCELL->na >= 0) {                                                          \
       register int RESTARGS;                                                           \
-      RESTARGS = argcount - LOCFNCELL->na;                                             \
+      RESTARGS = (argcount) - LOCFNCELL->na;                                           \
       while (RESTARGS < 0) {                                                           \
         HARD_PUSH(NIL_PTR);                                                            \
         RESTARGS++;                                                                    \

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -249,29 +249,29 @@ extern int ScreenLocked; /* for mouse tracking */
                                        (EQ Operation (QUOTE ERASE))) 0)
                                   (T 1))))))
 *****************************************************************/
-#define PixOperationLisp(SRCTYPE, OPERATION)                                                     \
-  (SRCTYPE == INVERT_atom                                                                        \
-       ? (OPERATION == REPLACE_atom                                                              \
-              ? PIX_NOT(PIX_SRC)                                                                 \
-              : (OPERATION == PAINT_atom                                                         \
-                     ? PIX_NOT(PIX_SRC) | PIX_DST                                                \
-                     : (OPERATION == ERASE_atom                                                  \
-                            ? PIX_SRC & PIX_DST                                                  \
-                            : (OPERATION == INVERT_atom ? PIX_NOT(PIX_SRC) ^ PIX_DST : ERROR)))) \
-       : /*  SRCTYPE == INPUT, TEXTURE */                                                        \
-       (OPERATION == REPLACE_atom                                                                \
-            ? PIX_SRC                                                                            \
-            : (OPERATION == PAINT_atom                                                           \
-                   ? PIX_SRC | PIX_DST                                                           \
-                   : (OPERATION == ERASE_atom                                                    \
-                          ? PIX_NOT(PIX_SRC) & PIX_DST                                           \
-                          : (OPERATION == INVERT_atom ? PIX_SRC ^ PIX_DST : ERROR)))))
+#define PixOperationLisp(SRCTYPE, OPERATION)                                                       \
+  ((SRCTYPE) == INVERT_atom                                                                        \
+       ? ((OPERATION) == REPLACE_atom                                                              \
+              ? PIX_NOT(PIX_SRC)                                                                   \
+              : ((OPERATION) == PAINT_atom                                                         \
+                     ? PIX_NOT(PIX_SRC) | PIX_DST                                                  \
+                     : ((OPERATION) == ERASE_atom                                                  \
+                            ? PIX_SRC & PIX_DST                                                    \
+                            : ((OPERATION) == INVERT_atom ? PIX_NOT(PIX_SRC) ^ PIX_DST : ERROR)))) \
+       : /*  SRCTYPE == INPUT, TEXTURE */                                                          \
+       ((OPERATION) == REPLACE_atom                                                                \
+            ? PIX_SRC                                                                              \
+            : ((OPERATION) == PAINT_atom                                                           \
+                   ? PIX_SRC | PIX_DST                                                             \
+                   : ((OPERATION) == ERASE_atom                                                    \
+                          ? PIX_NOT(PIX_SRC) & PIX_DST                                             \
+                          : ((OPERATION) == INVERT_atom ? PIX_SRC ^ PIX_DST : ERROR)))))
 
-#define bbop(SRCTYPE, OPERATION)              \
-  (OPERATION == PAINT_atom                    \
-       ? op_fn_or                             \
-       : (OPERATION == ERASE_atom ? op_fn_and \
-                                  : (OPERATION == INVERT_atom ? op_fn_xor : op_repl_src)))
+#define bbop(SRCTYPE, OPERATION)                \
+  ((OPERATION) == PAINT_atom                    \
+       ? op_fn_or                               \
+       : ((OPERATION) == ERASE_atom ? op_fn_and \
+                                    : ((OPERATION) == INVERT_atom ? op_fn_xor : op_repl_src)))
 
 /********************************************************/
 /*                                                      */
@@ -284,9 +284,9 @@ extern int ScreenLocked; /* for mouse tracking */
 /*                                                      */
 /********************************************************/
 
-#define bbsrc_type(SRCTYPE, OPERATION)                                                         \
-  (SRCTYPE == INVERT_atom ? (OPERATION == ERASE_atom ? 0 : 1) /*  SRCTYPE == INPUT, TEXTURE */ \
-                          : (OPERATION == ERASE_atom ? 1 : 0))
+#define bbsrc_type(SRCTYPE, OPERATION)                                                             \
+  ((SRCTYPE) == INVERT_atom ? ((OPERATION) == ERASE_atom ? 0 : 1) /*  SRCTYPE == INPUT, TEXTURE */ \
+                          : ((OPERATION) == ERASE_atom ? 1 : 0))
 
 extern struct pixrect *SrcePixRect, *DestPixRect, *TexturePixRect;
 extern struct pixrect *BlackTexturePixRect, *WhiteTexturePixRect;

--- a/src/dbgtool.c
+++ b/src/dbgtool.c
@@ -777,7 +777,7 @@ void nts(struct frameex1 *fxp) {
 #define VARTYPE_PVAR (2)
 #define VARTYPE_IVAR (0)
 
-#define VAROFFSET(X) (X & 0xFFFFFFF)
+#define VAROFFSET(X) ((X) & 0xFFFFFFF)
 
 void nt1(LispPTR *start, int size, char *str) {
   LispPTR *endp, *entry2p;

--- a/src/dir.c
+++ b/src/dir.c
@@ -77,14 +77,14 @@ extern int Dummy_errno;
     separate_version(tname, tver, 0);                \
                                                      \
     if ((pp = (char *)strrchr(tname, '.')) == NULL) { \
-      *text = '\0';                                  \
+      *(text) = '\0';                                  \
     } else {                                         \
       *pp = '\0';                                    \
       strcpy(text, pp + 1);                          \
     }                                                \
                                                      \
     if ((pp = (char *)strrchr(pname, '.')) == NULL) { \
-      *pext = '\0';                                  \
+      *(pext) = '\0';                                  \
     } else {                                         \
       *pp = '\0';                                    \
       strcpy(pext, pp + 1);                          \
@@ -104,9 +104,9 @@ extern int Dummy_errno;
     SetupMatch(tname, pname, text, pext, tver);                                               \
                                                                                               \
     if (match_pattern(tname, pname) && match_pattern(text, pext) && match_pattern(tver, ver)) \
-      goto matchtag;                                                                          \
+      goto matchtag; /* NOLINT(bugprone-macro-parentheses) */                                 \
     else                                                                                      \
-      goto unmatchtag;                                                                        \
+      goto unmatchtag; /* NOLINT(bugprone-macro-parentheses) */                               \
   }
 
 #define MatchP_Case(target, name, ver, matchtag, unmatchtag)                                  \
@@ -120,9 +120,9 @@ extern int Dummy_errno;
     SetupMatch(tname, pname, text, pext, tver);                                               \
                                                                                               \
     if (match_pattern(tname, pname) && match_pattern(text, pext) && match_pattern(tver, ver)) \
-      goto matchtag;                                                                          \
+      goto matchtag; /* NOLINT(bugprone-macro-parentheses) */                                 \
     else                                                                                      \
-      goto unmatchtag;                                                                        \
+      goto unmatchtag; /* NOLINT(bugprone-macro-parentheses) */                               \
   }
 
 /*
@@ -292,13 +292,13 @@ int MAXFINFO;
 #define AllocFinfo(fp)                                                   \
   {                                                                      \
     if (FreeFinfoList != (FINFO *)NULL) {                                \
-      fp = FreeFinfoList;                                                \
-      FreeFinfoList = fp->next;                                          \
-    } else if ((fp = (FINFO *)calloc(1, sizeof(FINFO))) == NULL) {       \
-      fp = (FINFO *)NULL;                                                \
-    } else if ((fp->prop = (FPROP *)calloc(1, sizeof(FPROP))) == NULL) { \
+      (fp) = FreeFinfoList;                                                \
+      FreeFinfoList = (fp)->next;                                          \
+    } else if (((fp) = (FINFO *)calloc(1, sizeof(FINFO))) == NULL) {       \
+      (fp) = (FINFO *)NULL;                                                \
+    } else if (((fp)->prop = (FPROP *)calloc(1, sizeof(FPROP))) == NULL) { \
       free(fp);                                                          \
-      fp = (FINFO *)NULL;                                                \
+      (fp) = (FINFO *)NULL;                                                \
     }                                                                    \
   }
 

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2830,10 +2830,10 @@ static int make_directory(register char *dir)
 #define FindHighestVersion(varray, mentry, max_no)                                        \
   {                                                                                       \
     register FileName *centry;                                                            \
-    for (centry = varray, max_no = 0; centry->version_no != LASTVERSIONARRAY; centry++) { \
-      if (centry->version_no > max_no) {                                                  \
-        max_no = centry->version_no;                                                      \
-        mentry = centry;                                                                  \
+    for (centry = (varray), (max_no) = 0; centry->version_no != LASTVERSIONARRAY; centry++) { \
+      if (centry->version_no > (max_no)) {                                                  \
+        (max_no) = centry->version_no;                                                      \
+        (mentry) = centry;                                                                  \
       }                                                                                   \
     }                                                                                     \
   }
@@ -2878,10 +2878,10 @@ static int make_directory(register char *dir)
 #define FindLowestVersion(varray, mentry, min_no)                                                  \
   {                                                                                                \
     register FileName *centry;                                                                     \
-    for (centry = varray, min_no = MAXVERSION; centry->version_no != LASTVERSIONARRAY; centry++) { \
-      if (centry->version_no < min_no && centry->version_no != 0) {                                \
-        min_no = centry->version_no;                                                               \
-        mentry = centry;                                                                           \
+    for (centry = (varray), (min_no) = MAXVERSION; centry->version_no != LASTVERSIONARRAY; centry++) { \
+      if (centry->version_no < (min_no) && centry->version_no != 0) {                                \
+        (min_no) = centry->version_no;                                                               \
+        (mentry) = centry;                                                                           \
       }                                                                                            \
     }                                                                                              \
   }
@@ -2915,10 +2915,10 @@ static int make_directory(register char *dir)
   {                                                                         \
     register FileName *centry;                                              \
                                                                             \
-    sentry = (FileName *)NULL;                                              \
+    (sentry) = (FileName *)NULL;                                              \
     for (centry = varray; centry->version_no != LASTVERSIONARRAY; centry++) \
-      if (centry->version_no == ver_no) {                                   \
-        sentry = centry;                                                    \
+      if (centry->version_no == (ver_no)) {                                   \
+        (sentry) = centry;                                                    \
         break;                                                              \
       }                                                                     \
   }

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -68,12 +68,12 @@ BIGNUM  (integer that can't be represented bigger than 32 bits)
 
 */
 
-#define IF_IMMEDIATE(arg, doit, doitsmall) \
-  switch (SEGMASK & arg) {                 \
-    case ATOM_OFFSET: doit;                \
-    case S_CHARACTER: doit;                \
-    case S_POSITIVE: doitsmall;            \
-    case S_NEGATIVE: doitsmall;            \
+#define IF_IMMEDIATE(arg, doit, doitsmall)                                 \
+  switch (SEGMASK & (arg)) {                                               \
+    case ATOM_OFFSET: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
+    case S_CHARACTER: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
+    case S_POSITIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
+    case S_NEGATIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
   }
 
 /************************************************************************/

--- a/src/fvar.c
+++ b/src/fvar.c
@@ -374,7 +374,7 @@ LispPTR N_OP_fvar_(register LispPTR tos, register int n) {
 
 #define VALS_HI_RET(x) ((int)(x) << 17) + VALS_HI + ((unsigned short)(x) >> 15)
 
-#define STK_HI_RET(x) ((int)(x) << 16) | 1 | ((unsigned int)(x) >> 16)
+#define STK_HI_RET(x) (((int)(x) << 16) | 1 | ((unsigned int)(x) >> 16))
 
 
 #else
@@ -389,7 +389,7 @@ LispPTR N_OP_fvar_(register LispPTR tos, register int n) {
                              : (swapx((int)(x) + NEWATOM_VALUE_OFFSET)))
 #endif /* BIGVM */
 
-#define STK_HI_RET(x) ((unsigned int)(x) << 16) | 1 | ((unsigned int)(x) >> 16)
+#define STK_HI_RET(x) (((unsigned int)(x) << 16) | 1 | ((unsigned int)(x) >> 16))
 
 #endif /* BIGATOMS */
 

--- a/src/gccode.c
+++ b/src/gccode.c
@@ -46,15 +46,15 @@
 #include "commondefs.h"
 #include "gchtfinddefs.h"
 
-#define min(a, b) ((a > b) ? b : a)
+#define min(a, b) (((a) > (b)) ? (b) : (a))
 
 #define ENDOFX 0
 #define GCONST 111
 
-#define Reprobefn(bits, index) (((bits ^ ((bits) >> 8)) & min(63, index)) | 1)
-#define Fn16bits(a, b) ((a + b) & 0x0ffff)
+#define Reprobefn(bits, index) ((((bits) ^ ((bits) >> 8)) & min(63, index)) | 1)
+#define Fn16bits(a, b) (((a) + (b)) & 0x0ffff)
 #define Hashingbits(item) (HILOC(item) ^ (((LOLOC(item) & 0x1fff) << 3) ^ (LOLOC(item) >> 9)))
-#define Getikvalue(base, index) (*(LispPTR *)Addr68k_from_LADDR(base + (index << 1)))
+#define Getikvalue(base, index) (*(LispPTR *)Addr68k_from_LADDR((base) + ((index) << 1)))
 
 #ifndef BYTESWAP
 typedef struct implicit_key_hash_table {

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -72,8 +72,8 @@
 #define Boundp(frame_field) ((frame_field == 0) ? 1 : 0)
 #endif /* NEVER */
 
-#define min(a, b) ((a > b) ? b : a)
-#define Trailer(ldatum, datum68) (ldatum + 2 * (datum68->arlen - ARRAYBLOCKTRAILERCELLS))
+#define min(a, b) (((a) > (b)) ? (b) : (a))
+#define Trailer(ldatum, datum68) ((ldatum) + 2 * ((datum68)->arlen - ARRAYBLOCKTRAILERCELLS))
 #define BucketIndex(n) min(integerlength(n), MAXBUCKETINDEX)
 #define FreeBlockChainN(n) ((POINTERMASK & *FreeBlockBuckets_word) + 2 * BucketIndex(n))
 

--- a/src/gcmain3.c
+++ b/src/gcmain3.c
@@ -74,7 +74,7 @@
 #define Boundp(frame_field) ((frame_field) == 0)
 #define Stkref(ptr) REC_GCLOOKUP(ptr, STKREF)
 #define GcreclaimLp(ptr) \
-  while ((ptr = gcreccell(ptr)) != NIL) REC_GCLOOKUP(ptr, ADDREF)
+  while (((ptr) = gcreccell(ptr)) != NIL) REC_GCLOOKUP(ptr, ADDREF)
 #define HTLPTR ((struct htlinkptr *)(entry))
 #define HENTRY ((struct hashentry *)(entry))
 #define HTMAIN_ENTRY_COUNT (HTMAIN_SIZE >> 1)

--- a/src/gcoflow.c
+++ b/src/gcoflow.c
@@ -44,12 +44,12 @@
 #define HTBIGENTRYSIZE 4
 #define WORDSPERPAGE 256
 #define MAXTYPENUMBER INIT_TYPENUM
-#define Oddp(num) (((num % 2) != 0) ? 1 : 0)
-#define Evenp(num, prim) (((num % prim) == 0) ? 1 : 0)
+#define Oddp(num) ((((num) % 2) != 0) ? 1 : 0)
+#define Evenp(num, prim) ((((num) % (prim)) == 0) ? 1 : 0)
 #define Increment_Allocation_Count(n) \
   if (*Reclaim_cnt_word != NIL) {     \
-    if (*Reclaim_cnt_word > n)        \
-      (*Reclaim_cnt_word) -= n;       \
+    if (*Reclaim_cnt_word > (n))      \
+      (*Reclaim_cnt_word) -= (n);     \
     else {                            \
       *Reclaim_cnt_word = NIL;        \
       doreclaim();                    \

--- a/src/gcrcell.c
+++ b/src/gcrcell.c
@@ -91,16 +91,16 @@
 #endif /* NEWCDRCODING */
 
 #define TODO_LIMIT 1000
-#define ADD_TO_DO(ptr, offset)                             \
-  if (do_count < TODO_LIMIT) {                             \
-    if (ptr & 0xF0000000) error("illegal ptr in addtodo"); \
-    to_do[do_count] = (ptr);                               \
-    to_do_offset[do_count] = offset;                       \
-    todo_uses++;                                           \
-    /*REC_GCLOOKUP((ptr), ADDREF);*/                       \
-    do_count++;                                            \
-  } else { /* error("GC missing some to-do's"); */         \
-    todo_misses++;                                         \
+#define ADD_TO_DO(ptr, offset)                               \
+  if (do_count < TODO_LIMIT) {                               \
+    if ((ptr) & 0xF0000000) error("illegal ptr in addtodo"); \
+    to_do[do_count] = (ptr);                                 \
+    to_do_offset[do_count] = offset;                         \
+    todo_uses++;                                             \
+    /*REC_GCLOOKUP((ptr), ADDREF);*/                         \
+    do_count++;                                              \
+  } else { /* error("GC missing some to-do's"); */           \
+    todo_misses++;                                           \
   }
 
 unsigned todo_uses = 0;

--- a/src/gcscan.c
+++ b/src/gcscan.c
@@ -56,7 +56,7 @@
 #ifdef BIGVM
 #define HTSTKBIT 0x10000 /* = 512 */
 #define HTENDS ((struct hashentry *)htlptr)
-#define GetStkCnt(entry1) (entry1 >> 16)
+#define GetStkCnt(entry1) ((entry1) >> 16)
 #else
 #define HTSTKBIT 0x200 /* = 512 */
 #define HTENDS ((struct hashentry *)htlptr)

--- a/src/hardrtn.c
+++ b/src/hardrtn.c
@@ -41,7 +41,7 @@
 #define MAKE_FXCOPY(fx68k)                                                                   \
   {                                                                                          \
     BEFORE_CONTEXTSW;                                                                        \
-    if ((fx68k = (FX *)make_FXcopy(fx68k)) == 0) { return (1); /* Whole space exhausted */ } \
+    if (((fx68k) = (FX *)make_FXcopy(fx68k)) == 0) { return (1); /* Whole space exhausted */ } \
     AFTER_CONTEXTSW;                                                                         \
     CHECK_FX(fx68k);                                                                         \
   }

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -545,22 +545,22 @@ typedef struct {
   LispPTR CUDATA;
 } CURSOR;
 
-#define CursorClippingX(posx, width)                     \
-  {                                                      \
-    if (displaywidth < (posx + HARD_CURSORWIDTH)) {      \
-      LastCursorClippingX = width = displaywidth - posx; \
-    } else {                                             \
-      LastCursorClippingX = width = HARD_CURSORWIDTH;    \
-    }                                                    \
+#define CursorClippingX(posx, width)                         \
+  {                                                          \
+    if (displaywidth < ((posx) + HARD_CURSORWIDTH)) {        \
+      LastCursorClippingX = (width) = displaywidth - (posx); \
+    } else {                                                 \
+      LastCursorClippingX = (width) = HARD_CURSORWIDTH;      \
+    }                                                        \
   }
 
-#define CursorClippingY(posy, height)                      \
-  {                                                        \
-    if (displayheight < (posy + HARD_CURSORHEIGHT)) {      \
-      LastCursorClippingY = height = displayheight - posy; \
-    } else {                                               \
-      LastCursorClippingY = height = HARD_CURSORHEIGHT;    \
-    }                                                      \
+#define CursorClippingY(posy, height)                          \
+  {                                                            \
+    if (displayheight < ((posy) + HARD_CURSORHEIGHT)) {        \
+      LastCursorClippingY = (height) = displayheight - (posy); \
+    } else {                                                   \
+      LastCursorClippingY = (height) = HARD_CURSORHEIGHT;      \
+    }                                                          \
   }
 
 extern int displaywidth, displayheight;

--- a/src/lineblt8.c
+++ b/src/lineblt8.c
@@ -31,13 +31,13 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
 /***************************************************************
         Macro:WriteLongW
 **************************************************************/
-#define WriteLongW(srcpattern, destptr, op1, op2)                                    \
-  {                                                                                  \
-    register int cnt;                                                                \
-    register u_char *des, *src;                                                      \
-    for (cnt = 0, des = (u_char *)destptr, src = (u_char *)(&(srcpattern)); cnt < 4; \
-         cnt++, des++, src++)                                                        \
-      (*des) op1(*src);                                                              \
+#define WriteLongW(srcpattern, destptr, op1, op2)                                      \
+  {                                                                                    \
+    register int cnt;                                                                  \
+    register u_char *des, *src;                                                        \
+    for (cnt = 0, des = (u_char *)(destptr), src = (u_char *)(&(srcpattern)); cnt < 4; \
+         cnt++, des++, src++)                                                          \
+      (*des) op1(*src);                                                                \
   }
 
 /***************************************************************
@@ -104,14 +104,14 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
       case 1:                                                                              \
       case 2:                                                                              \
       case 3:                                                                              \
-        destc = (u_char *)dstLptr;                                                         \
-        while (width--) {                                                                  \
-          if (BitMaskArray[mod = (offset % 16)] & *srcw)                                   \
+        destc = (u_char *)(dstLptr);                                                       \
+        while ((width)--) {                                                                \
+          if (BitMaskArray[mod = ((offset) % 16)] & *srcw)                                 \
             (*destc++) op1(color1);                                                        \
           else                                                                             \
             (*destc++) op1(color0);                                                        \
           if (mod == 15) srcw++;                                                           \
-          offset++;                                                                        \
+          (offset)++;                                                                      \
         } /* WHILE END */                                                                  \
         break;                                                                             \
       default:; /* error */                                                                \

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -58,7 +58,7 @@ static const char il_string[] = "INTERLISP";
 #define METH_CACHE_INDEX(CLASS, SELECTOR) (1023 & ((CLASS) ^ (SELECTOR)))
 #define IV_CACHE_INDEX(VARLIST, IV) (1023 & ((VARLIST) ^ (IV)))
 
-#define LC_TYPEP(obj, typeATOM) (DTD_FROM_LADDR((obj)) == typeATOM)
+#define LC_TYPEP(obj, typeATOM) (DTD_FROM_LADDR((obj)) == (typeATOM))
 
 #define INSTANCEP(obj) (LC_TYPEP((obj), atom_instance))
 #define CLASSP(obj) (LC_TYPEP((obj), atom_class))
@@ -80,10 +80,10 @@ static const char il_string[] = "INTERLISP";
 #define GET_IV_INDEX(objptr, iv, dest, otherwise)                 \
   {                                                               \
     register struct LCIVCacheEntry *ce;                           \
-    register LispPTR iNames = objptr->iNames;                     \
+    register LispPTR iNames = (objptr)->iNames;                   \
                                                                   \
     ce = &(LCIVCache[IV_CACHE_INDEX(iNames, iv)]);                \
-    if (ce->iNames == iNames && ce->iv == iv) {                   \
+    if (ce->iNames == iNames && ce->iv == (iv)) {                 \
       (dest) = POSINT_FROM_SMALLP(ce->index);                     \
     } else {                                                      \
       if (!Listp(iNames)) {                                       \
@@ -91,8 +91,8 @@ static const char il_string[] = "INTERLISP";
       } else {                                                    \
         register int i = 0;                                       \
         while (1) {                                               \
-          if (car(iNames) == iv) {                                \
-            ce->iNames = objptr->iNames;                          \
+          if (car(iNames) == (iv)) {                              \
+            ce->iNames = (objptr)->iNames;                        \
             ce->iv = iv;                                          \
             ce->index = SMALLP_FROM_POSINT(i);                    \
             (dest) = i;                                           \

--- a/src/lsthandl.c
+++ b/src/lsthandl.c
@@ -87,7 +87,7 @@ LispPTR fmemb(register LispPTR item, register LispPTR list) {
     if (GetTypeNumber(parm) != TYPE_LISTP) {      \
       SAVE_ERROR_EXIT2(tcstk, tos);               \
     } else                                        \
-      dest = cadr(parm);                          \
+      (dest) = cadr(parm);                        \
   }
 
 LispPTR N_OP_listget(register LispPTR plist, register LispPTR tos) {

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -243,10 +243,10 @@ v filename\t\tSaves the virtual memory on the filename (Not Bootable)\n\
 ?\t\t\tDisplays this summary";
 #endif /* DOS */
 
-#define ADD_RANGEP(address)                       \
-  if ((address < 0) || (POINTERMASK < address)) { \
-    printf("Address out of range.\n");            \
-    return (T);                                   \
+#define ADD_RANGEP(address)                           \
+  if (((address) < 0) || (POINTERMASK < (address))) { \
+    printf("Address out of range.\n");                \
+    return (T);                                       \
   }
 
 #define URMAXCOMM 512

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -67,12 +67,12 @@
 
 /* Error return values from VMEMSAVE */
 #define COMPLETESYSOUT NIL
-#define BADFILENAME S_POSITIVE | 1
-#define NOFILESPACE S_POSITIVE | 2
-#define FILECANNOTOPEN S_POSITIVE | 3
-#define FILECANNOTSEEK S_POSITIVE | 4
-#define FILECANNOTWRITE S_POSITIVE | 5
-#define FILETIMEOUT S_POSITIVE | 6
+#define BADFILENAME (S_POSITIVE | 1)
+#define NOFILESPACE (S_POSITIVE | 2)
+#define FILECANNOTOPEN (S_POSITIVE | 3)
+#define FILECANNOTSEEK (S_POSITIVE | 4)
+#define FILECANNOTWRITE (S_POSITIVE | 5)
+#define FILETIMEOUT (S_POSITIVE | 6)
 
 extern int LispWindowFd;
 extern struct pixrect *CursorBitMap, *InvisibleCursorBitMap;

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -43,8 +43,9 @@
 #endif /* OS5 */
 
 #define PERCENT_OF_SCREEN 95
-#define DISPLAY_MAX 65536 * 16 * 2 /* same magic number is */
-                                   /* in loadsysout.c      */
+/* DISPLAY_MAX same magic number is in ldsout.c */
+#define DISPLAY_MAX (65536 * 16 * 2)
+
 extern DLword *Lisp_world;
 extern char Display_Name[128];
 extern DLword *DisplayRegion68k;


### PR DESCRIPTION
Cleanup for warning [bugprone-macro-parentheses]

... except where the expansion would be syntactically invalid, for example "goto macroarg;" which seems to be an [overreaction by clang-tidy](https://bugs.llvm.org/show_bug.cgi?id=49634) 