### PR TITLE
Rename _curXXX structures to curXXX to avoid leading underscore

### DIFF
--- a/src/dspif.c
+++ b/src/dspif.c
@@ -21,9 +21,8 @@
 #include "dspifdefs.h"
 #include "xinitdefs.h"
 
-DspInterfaceRec _curdsp;
-
-DspInterface currentdsp = &_curdsp;
+DspInterfaceRec curdsp;
+DspInterface currentdsp = &curdsp;
 
 #ifdef XWINDOW
 extern int LispDisplayRequestedWidth;

--- a/src/kbdif.c
+++ b/src/kbdif.c
@@ -16,8 +16,8 @@
 #include "dbprint.h"
 #include "devif.h"
 
-KbdInterfaceRec _curkbd;
-KbdInterface currentkbd = &_curkbd;
+KbdInterfaceRec curkbd;
+KbdInterface currentkbd = &curkbd;
 
 #ifdef DOS
 extern void Kbd_event();

--- a/src/mouseif.c
+++ b/src/mouseif.c
@@ -17,8 +17,8 @@
 #include "dbprint.h"
 #include "devif.h"
 
-MouseInterfaceRec _curmouse;
-MouseInterface currentmouse = &_curmouse;
+MouseInterfaceRec curmouse;
+MouseInterface currentmouse = &curmouse;
 
 #ifdef DOS
 #include <dos.h>


### PR DESCRIPTION
It's not an issue in C, really, but checkers like to complain about leading underscores on identifiers
