### PR TITLE
Cleanup USE_DPLI usage

### DIFF
--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -21,7 +21,7 @@ int main(int argc, char *argv[]) { return (0); }
 #include <string.h>
 #include <unistd.h>
 
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
 #include <sys/stream.h>
 #include <sys/stropts.h>
 #include <sys/pfmod.h>
@@ -53,14 +53,14 @@ char *devices[] = {"le0",   "le1",   "le2",   "le3",   "le4",   "ie0", "ie1", "i
 #include <netinet/in.h>
 #include <netinet/if_ether.h>
 #include <sys/ioctl.h>
-#ifndef USE_DLPI
+#if defined(USE_NIT)
 #include <net/nit.h>
 #ifdef OS4
 #include <stropts.h>
 #include <net/nit_if.h>
 #include <net/nit_pf.h>
 #endif /* OS4 */
-#endif /* USE_DLPI */
+#endif /* USE_NIT */
 
 #include <nlist.h>
 #include <fcntl.h>
@@ -75,7 +75,7 @@ char filetorun[30] = "lde";
 int main(int argc, char *argv[]) {
   char Earg[30], Ename[30], **newargv;
   int i;
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
   static struct packetfilt pf = {0, 1, {ENF_PUSHZERO}};
   struct strioctl si;
 #endif /* USE_DLPI */
@@ -97,7 +97,7 @@ int main(int argc, char *argv[]) {
   */
 
   if (!geteuid()) {
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
     /* Use DLPI to connect to the ethernet.  This code is stolen
        from NFSWATCH4.3
     */
@@ -127,13 +127,10 @@ int main(int argc, char *argv[]) {
 
       fcntl(ether_fd, F_SETFL, fcntl(ether_fd, F_GETFL, 0) | O_NONBLOCK);
 
-#else
-/*    N O T   D L P I   C O D E   */
-
+#elif defined(USE_NIT)
 #ifndef OS4
     if ((ether_fd = socket(AF_NIT, SOCK_RAW, NITPROTO_RAW)) >= 0) {
 #else  /* OS4 */
-
     if ((ether_fd = open("/dev/nit", O_RDWR)) >= 0) {
 #endif /* OS4 */
 
@@ -230,10 +227,10 @@ int main(int argc, char *argv[]) {
   /* then if the net is active, spit out the ether info */
   if (ether_fd > 0) {
     newargv[i++] = "-E";
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
     sprintf(Earg, "%d:%x:%x:%x:%x:%x:%x", ether_fd, ether_host[0], ether_host[1], ether_host[2],
             ether_host[3], ether_host[4], ether_host[5]);
-#else
+#elif defined(USE_NIT)
     sprintf(Earg, "%d:%x:%x:%x:%x:%x:%x:%s", ether_fd, ether_host[0], ether_host[1], ether_host[2],
             ether_host[3], ether_host[4], ether_host[5], Ename);
 #endif /* USE_DLPI */

--- a/src/main.c
+++ b/src/main.c
@@ -36,7 +36,7 @@
 #endif /* DOS */
 
 #ifdef MAIKO_ENABLE_ETHERNET
-#ifndef USE_DLPI
+#if defined(USE_NIT)
 #include <net/nit.h> /* needed for Ethernet stuff below */
 #endif               /* USE_DLPI */
 #endif               /* MAIKO_ENABLE_ETHERNET */
@@ -428,7 +428,7 @@ int main(int argc, char *argv[])
     else if (!strcmp(argv[i], "-E")) { /**** ethernet info	****/
 #ifdef MAIKO_ENABLE_ETHERNET
       int b0, b1, b2, b3, b4, b5;
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
       if (argc > ++i &&
           sscanf(argv[i], "%d:%x:%x:%x:%x:%x:%x", &ether_fd, &b0, &b1, &b2, &b3, &b4, &b5) == 7)
 #else

--- a/src/timer.c
+++ b/src/timer.c
@@ -45,7 +45,7 @@ unsigned long tick_count = 0; /* approx 18 ticks per sec            */
 #include <sys/time.h>
 #endif /* DOS */
 
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
 #include <stropts.h>
 extern int ether_fd;
 #endif
@@ -546,7 +546,7 @@ static void int_io_init() {
     perror("ioctl on X fd - SETSIG for input handling failed");
 #endif
 
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
   DBPRINT(("INIT ETHER:  Doing I_SETSIG.\n"));
   if (ether_fd > 0)
     if (ioctl(ether_fd, I_SETSIG, S_INPUT) != 0) {

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -1083,7 +1083,7 @@ int device_after_raid() {
 
 #ifdef MAIKO_ENABLE_ETHERNET
   init_ether();
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
   if (ether_fd > 0)
     if (ioctl(ether_fd, I_SETSIG, S_INPUT) != 0) {
       perror("after-uraid: I_SETSIG for ether failed:\n");

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -19,9 +19,9 @@
 #include <unistd.h>
 #include <limits.h>
 #ifdef MAIKO_ENABLE_ETHERNET
-#ifndef USE_DLPI
+#if defined(USE_NIT)
 #include <net/nit.h> /* needed for Ethernet stuff below */
-#endif               /* USE_DLPI */
+#endif               /* USE_NIT */
 #endif               /* MAIKO_ENABLE_ETHERNET */
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
@@ -92,9 +92,9 @@ extern int sysout_size, for_makeinit, please_fork;
 #ifdef MAIKO_ENABLE_ETHERNET
 extern int ether_fd;
 extern u_char ether_host[6];
-#ifndef USE_DLPI
+#if defined(USE_NIT)
 extern struct sockaddr_nit snit;
-#endif /* USE_DLPI */
+#endif /* USE_NIT */
 #endif /* MAIKO_ENABLE_ETHERNET */
 
 /************************************************************************/
@@ -297,12 +297,12 @@ void read_Xoption(int *argc, char *argv[])
   if (XrmGetResource(rDB, "ldex.EtherNet", "Ldex.EtherNet", str_type, &value) == True) {
     int b0, b1, b2, b3, b4, b5;
     (void)strncpy(tmp, value.addr, (int)value.size);
-#ifdef USE_DLPI
+#if defined(USE_DLPI)
     if (sscanf(tmp, "%d:%x:%x:%x:%x:%x:%x", &ether_fd, &b0, &b1, &b2, &b3, &b4, &b5) == 7)
-#else
+#elif defined(USE_NIT)
     if (sscanf(tmp, "%d:%x:%x:%x:%x:%x:%x:%s", &ether_fd, &b0, &b1, &b2, &b3, &b4, &b5,
                snit.snit_ifname) == 8)
-#endif /* USE_DLPI */
+#endif /* USE_NIT */
     {
       ether_host[0] = b0;
       ether_host[1] = b1;


### PR DESCRIPTION
Until now, the only differentiation between using DLPI and using NIT for
the ethernet interface was expressed as a function of USE_DLPI.

This commit makes explicit when code is for the DLPI interface or the NIT
interface, with USE_DLPI and USE_NIT.  This is setup for using the BPF
interface to the ethernet as an alternative.