### PR TITLE
Already there, OS-dependent variable SysReq

### DIFF
--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -291,7 +291,7 @@ void getsignaldata(int sig)
   int i;
 
 #ifdef XWINDOW
-#if defined(sun)
+#if defined(sun) || defined(__CYGWIN__)
   if (Event_Req) {
     if (!XLocked++)
       getXsignaldata(currentdsp);


### PR DESCRIPTION
in xc.c
```c
#ifdef XWINDOW
extern int Event_Req; /* != 0 when it's time to check X events
                                                 on machines that don't get them reliably
                                                 (e.g. Suns running OpenWindows) */
#endif                /* XWINDOW */
```
and only one place to patch.