### PR TITLE
Fix the FastRetCALL macro to use do {} while (0) style

### DIFF
--- a/inc/return.h
+++ b/inc/return.h
@@ -35,7 +35,7 @@
 /* FAST case return use */
 #ifndef RESWAPPEDCODESTREAM
 #define FastRetCALL							\
-  {									\
+  do {									\
     /* Get IVar from Returnee's IVAR offset slot(BF) */ 			\
     IVar = Addr68k_from_LADDR(STK_OFFSET | GETWORD((DLword *)CURRENTFX -1)); \
     /* Get FuncObj from Returnee's FNHEAD slot in FX */ 			\
@@ -43,10 +43,10 @@
 		Addr68k_from_LADDR(FX_FNHEADER);	\
     /* Get PC from Returnee's pc slot in FX */ 				\
     PC = (ByteCode *)FuncObj + CURRENTFX->pc ; 				\
-  }
+  } while (0)
 #else
 #define FastRetCALL							\
-  {									\
+  do {									\
     /* Get IVar from Returnee's IVAR offset slot(BF) */ 			\
     IVar = Addr68k_from_LADDR(STK_OFFSET | GETWORD((DLword *)CURRENTFX -1)); \
     /* Get FuncObj from Returnee's FNHEAD slot in FX */ 			\
@@ -59,7 +59,7 @@
 	byte_swap_code_block(FuncObj);				\
 	FuncObj->byteswapped = 1;				\
       }								\
-  }
+  } while (0)
 #endif /* RESWAPPEDCODESTREAM */
 
 

--- a/src/return.c
+++ b/src/return.c
@@ -168,7 +168,8 @@ void contextsw(register DLword fxnum, register DLword bytenum, register DLword f
     CHECKFX;
     if (EndSTKP < CurrentStackPTR) error("contextsw:Illegal ESP");
 #endif
-    FastRetCALL return;
+    FastRetCALL;
+    return;
   }
 
 } /* end contextsw */


### PR DESCRIPTION
Fixes the macro (in return.h) and the one usage site (in return.c) which did not already have a trailing semicolon.