### PR TITLE
Remove SIGPOLL usage

### DIFF
--- a/inc/MyWindow.h
+++ b/inc/MyWindow.h
@@ -77,7 +77,7 @@ typedef struct
 						, White_Pixel ); \
 			XLOCK;					\
 			XFlush( display ); 	\
-			XUNLOCK;		\
+			XUNLOCK( display );                 \
 			(child_win)->parent = parent_win; \
 			if( (child_win)->after_create ) \
 			    ((child_win)->after_create)(parent_win,child_win);\
@@ -96,7 +96,7 @@ typedef struct
 					, (window)->width 					\
 					, (window)->height ); 				\
 			XFlush( display ); 							\
-			XUNLOCK;									\
+			XUNLOCK( display );                               \
 			if( (window)->after_resize ) 				\
 				((window)->after_resize)( window ); 	\
 		} \
@@ -106,7 +106,7 @@ typedef struct
 		XLOCK;													\
 		XDefineCursor( display, (window)->win, *(mycursor) ); \
 		XFlush( display ); 	 \
-		XUNLOCK;										\
+		XUNLOCK( display );            \
 		(window)->cursor = mycursor; \
 }
 

--- a/inc/devif.h
+++ b/inc/devif.h
@@ -264,11 +264,12 @@ typedef struct
 
 
 #ifdef XWINDOW
-#define DefineCursor(display, window, mycursor) { \
-	XLOCK;\
-	XDefineCursor( display, window, *(mycursor) );\
-	XUNLOCK;\
-}
+#define DefineCursor(dsp, window, mycursor)                     \
+  do {								\
+    XLOCK;                                                      \
+    XDefineCursor((dsp)->display_id, window, *(mycursor) );     \
+    XUNLOCK(dsp);                                               \
+  } while (0)
 #endif /* XWINDOW */
 
 #define OUTER_SB_WIDTH(dsp) ((dsp)->ScrollBarWidth + 2*((dsp)->InternalBorderWidth))

--- a/inc/ldeXdefs.h
+++ b/inc/ldeXdefs.h
@@ -14,12 +14,12 @@
 
 #ifdef LOCK_X_UPDATES
 #define XLOCK { XLocked++; /* printf("L"); fflush(stdout);*/}
-#define XUNLOCK					\
+#define XUNLOCK(dsp)                           \
   { XLocked--;/* printf("U"); fflush(stdout);*/	\
     if (XNeedSignal)				\
       {						\
 	XNeedSignal = 0;			\
-	kill(getpid(), SIGPOLL);		\
+	getXsignaldata(dsp);			\
       };						\
   }
 #else

--- a/inc/xcursordefs.h
+++ b/inc/xcursordefs.h
@@ -6,6 +6,6 @@
 #include "devif.h"     /* for DspInterface */
 void Init_XCursor(void);
 void Set_XCursor(int x, int y);
-void init_Xcursor(Display *display, Window window);
+void init_Xcursor(DspInterface dsp);
 void set_Xcursor(DspInterface dsp, const uint8_t *bitmap, int hotspot_x, int hotspot_y, Cursor *return_cursor, int from_lisp);
 #endif

--- a/inc/xdefs.h
+++ b/inc/xdefs.h
@@ -32,22 +32,24 @@
 
 #include <unistd.h>
 #include <signal.h>
+#include "xwinmandefs.h"
+
 extern int XLocked;
 extern int XNeedSignal;
 /* this is !0 if we're locked; it should be 0 or larger always */
 
 #define XLOCK do { XLocked++; /* printf("L"); fflush(stdout);*/} while (0)
-#define XUNLOCK					\
+#define XUNLOCK(dsp)					\
   do { XLocked--;/* printf("U"); fflush(stdout);*/	\
     if (XNeedSignal)				\
       {						\
 	XNeedSignal = 0;			\
-	kill(getpid(), SIGPOLL);		\
+	getXsignaldata(dsp);			\
       };					\
   } while (0)
 #else
 #define XLOCK
-#define XUNLOCK
+#define XUNLOCK(dsp)
 #endif	/* LOCK_X_UPDATES */
 
 #endif /* XDEFS_H */

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -484,9 +484,7 @@ do_it_now:
 #endif
 
 #ifdef XWINDOW
-  XLOCK;
   if (in_display_segment(dstbase)) flush_display_region(dx, dty, w, h);
-  XUNLOCK;
 #endif /* XWINDOW */
 
 #ifdef DOS
@@ -841,9 +839,7 @@ do_it_now:
 #endif
 
 #ifdef XWINDOW
-  XLOCK;
   if (in_display_segment(dstbase)) flush_display_region(dlx, dty, width, height);
-  XUNLOCK;
 #endif /* XWINDOW */
 
 #ifdef DOS
@@ -1090,9 +1086,7 @@ do_it_now:
 #endif
 
 #ifdef XWINDOW
-  XLOCK;
   if (in_display_segment(dstbase)) flush_display_region(left, dty, width, height);
-  XUNLOCK;
 #endif /* XWINDOW */
 
 #ifdef DOS
@@ -1222,9 +1216,7 @@ void bltchar(LispPTR *args)
 #endif
 
 #ifdef XWINDOW
-  XLOCK;
   if (in_display_segment(dstbase)) flush_display_lineregion(dx, dstbase, w, h);
-  XUNLOCK;
 #endif /* XWINDOW */
 
 #ifdef DOS
@@ -1315,10 +1307,8 @@ LispPTR bltchar(LispPTR *args)
 #endif
 
 #ifdef XWINDOW
-  XLOCK;
   if (in_display_segment(dstbase))
     flush_display_lineregion(((BLTC *)args)->left, dstbase, (((BLTC *)args)->right - ((BLTC *)args)->left), pbt->pbtheight);
-  XUNLOCK;
 #endif /* XWINDOW */
 
 #ifdef DOS

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -411,7 +411,7 @@ static u_char *make_X_keymap() {
   XDisplayKeycodes(currentdsp->display_id, &minkey, &maxkey);
   codecount = maxkey + 1 - minkey;
   mapping = XGetKeyboardMapping(currentdsp->display_id, minkey, codecount, &symspercode);
-  XUNLOCK;
+  XUNLOCK(currentdsp);
 
   for (; *key_sym_pairs != -1;) {
     int reusable = *key_sym_pairs++, code = *key_sym_pairs++, sym = *key_sym_pairs++, xcode;

--- a/src/xbbt.c
+++ b/src/xbbt.c
@@ -53,7 +53,7 @@ unsigned long clipping_Xbitblt(DspInterface dsp, DLword *dummy, int x, int y, in
     XPutImage(dsp->display_id, dsp->DisplayWindow, dsp->Copy_GC, &dsp->ScreenBitmap, x, y,
               x - dsp->Visible.x, y - dsp->Visible.y, w, h);
     XFlush(dsp->display_id);
-    XUNLOCK;
+    XUNLOCK(dsp);
     return (1);
   }
 
@@ -80,7 +80,7 @@ unsigned long clipping_Xbitblt(DspInterface dsp, DLword *dummy, int x, int y, in
     XPutImage(dsp->display_id, dsp->DisplayWindow, dsp->Copy_GC, &dsp->ScreenBitmap, x, y,
               x - dsp->Visible.x, y - dsp->Visible.y, w, h);
     XFlush(dsp->display_id);
-    XUNLOCK;
+    XUNLOCK(dsp);
   }
   return (1);
 

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -66,7 +66,7 @@ void Init_XCursor() {
   cursorlist->next = NULL;
   for (i = 0; i < CURSORHEIGHT; i++) cursorlist->bitmap[i] = newbm[i];
   set_Xcursor(currentdsp, (uint8_t *)newbm, 0, 0, &(cursorlist->Xid), 1);
-  DefineCursor(currentdsp->display_id, currentdsp->DisplayWindow, &(cursorlist->Xid));
+  DefineCursor(currentdsp, currentdsp->DisplayWindow, &(cursorlist->Xid));
 } /* end Init_XCursor */
 
 /************************************************************************/
@@ -120,8 +120,8 @@ void Set_XCursor(int x, int y)
     clp->next = cursorlist;
     cursorlist = clp;
   }
-  DefineCursor(currentdsp->display_id, currentdsp->DisplayWindow, &(clp->Xid));
-  XUNLOCK; /* Signals OK now */
+  DefineCursor(currentdsp, currentdsp->DisplayWindow, &(clp->Xid));
+  XUNLOCK(currentdsp); /* Signals OK now */
 
 #ifdef NEWXCURSOR
   /* Save the hotspot for later position reporting/setting */
@@ -140,16 +140,16 @@ void Set_XCursor(int x, int y)
 /*									*/
 /************************************************************************/
 
-void init_Xcursor(Display *display, Window window)
+void init_Xcursor(DspInterface dsp)
 {
   TPRINT(("TRACE: init_Xcursor()\n"));
 
   XLOCK; /* Take no X signals during this activity (ISC 386) */
 
-  XAllocNamedColor(display, Colors, "black", &cursor_fore_xcsd, &xced);
-  XAllocNamedColor(display, Colors, "white", &cursor_back_xcsd, &xced);
+  XAllocNamedColor(dsp->display_id, Colors, "black", &cursor_fore_xcsd, &xced);
+  XAllocNamedColor(dsp->display_id, Colors, "white", &cursor_back_xcsd, &xced);
 
-  XUNLOCK; /* OK to take signals again */
+  XUNLOCK(dsp); /* OK to take signals again */
 
 } /* end init_Xcursor */
 
@@ -190,6 +190,6 @@ void set_Xcursor(DspInterface dsp, const uint8_t *bitmap, int hotspot_x, int hot
   XFreePixmap(dsp->display_id, Cursor_msk);
 
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 
 } /* end set_Xcursor */

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -140,7 +140,7 @@ void Xevent_before_raid(DspInterface dsp)
 
   XLOCK;
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 } /* end Xevent_before_raid */
 
 /************************************************************************/
@@ -158,7 +158,7 @@ void Xevent_after_raid(DspInterface dsp)
                           dsp->Visible.height);
   XLOCK;
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 
 } /* end Xevent_after_raid */
 

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -140,7 +140,7 @@ void Create_LispWindow(DspInterface dsp)
                    save_argc, &szhint, &Lisp_WMhints, &xclasshint);
 
   XSelectInput(dsp->display_id, dsp->LispWindow, dsp->EnableEventMask);
-  init_Xcursor(dsp->display_id, dsp->LispWindow);
+  init_Xcursor(dsp);
 
   dsp->DisplayWindow = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, 0, 0,
                                            dsp->Visible.width, dsp->Visible.height, 0,
@@ -195,7 +195,7 @@ void Create_LispWindow(DspInterface dsp)
                                           dsp->ScrollBarWidth,          /* width */
                                           dsp->Visible.height, dsp->InternalBorderWidth,
                                           BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
-  DefineCursor(dsp->display_id, dsp->VerScrollBar, &VertScrollCursor);
+  DefineCursor(dsp, dsp->VerScrollBar, &VertScrollCursor);
   XMapWindow(dsp->display_id, dsp->VerScrollBar);
 
   dsp->HorScrollBar = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow,
@@ -203,7 +203,7 @@ void Create_LispWindow(DspInterface dsp)
                                           dsp->Visible.width,                /* width */
                                           dsp->ScrollBarWidth, dsp->InternalBorderWidth,
                                           BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
-  DefineCursor(dsp->display_id, dsp->HorScrollBar, &HorizScrollCursor);
+  DefineCursor(dsp, dsp->HorScrollBar, &HorizScrollCursor);
   XChangeWindowAttributes(dsp->display_id, dsp->HorScrollBar, CWOverrideRedirect,
                           &Lisp_SetWinAttributes);
   XMapWindow(dsp->display_id, dsp->HorScrollBar);
@@ -237,7 +237,7 @@ void Create_LispWindow(DspInterface dsp)
                                     GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
                                     WhitePixelOfScreen(screen));
   XSetWindowBackgroundPixmap(dsp->display_id, dsp->NWGrav, dsp->GravityOnPixmap);
-  DefineCursor(dsp->display_id, dsp->NWGrav, &DefaultCursor);
+  DefineCursor(dsp, dsp->NWGrav, &DefaultCursor);
   XChangeWindowAttributes(dsp->display_id, dsp->NWGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
   XClearWindow(dsp->display_id, dsp->NWGrav);
   XMapWindow(dsp->display_id, dsp->NWGrav);
@@ -246,7 +246,7 @@ void Create_LispWindow(DspInterface dsp)
                                     GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
                                     WhitePixelOfScreen(screen));
   XSetWindowBackgroundPixmap(dsp->display_id, dsp->SEGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp->display_id, dsp->SEGrav, &DefaultCursor);
+  DefineCursor(dsp, dsp->SEGrav, &DefaultCursor);
   XChangeWindowAttributes(dsp->display_id, dsp->SEGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
   XClearWindow(dsp->display_id, dsp->NWGrav);
   XMapWindow(dsp->display_id, dsp->SEGrav);
@@ -255,7 +255,7 @@ void Create_LispWindow(DspInterface dsp)
                                     GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
                                     WhitePixelOfScreen(screen));
   XSetWindowBackgroundPixmap(dsp->display_id, dsp->SWGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp->display_id, dsp->SWGrav, &DefaultCursor);
+  DefineCursor(dsp, dsp->SWGrav, &DefaultCursor);
   XClearWindow(dsp->display_id, dsp->NWGrav);
   XMapWindow(dsp->display_id, dsp->SWGrav);
 
@@ -263,16 +263,16 @@ void Create_LispWindow(DspInterface dsp)
                                     GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
                                     WhitePixelOfScreen(screen));
   XSetWindowBackgroundPixmap(dsp->display_id, dsp->NEGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp->display_id, dsp->NEGrav, &DefaultCursor);
+  DefineCursor(dsp, dsp->NEGrav, &DefaultCursor);
   XClearWindow(dsp->display_id, dsp->NWGrav);
   XMapWindow(dsp->display_id, dsp->NEGrav);
 
-  /* DefineCursor( dsp->display_id, dsp->DisplayWindow, &WaitCursor ); */
+  /* DefineCursor( dsp, dsp->DisplayWindow, &WaitCursor ); */
 
   XLOCK;
   XMapWindow(dsp->display_id, dsp->LispWindow);
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 }
 
 void lisp_Xvideocolor(int flag)
@@ -303,7 +303,7 @@ void lisp_Xvideocolor(int flag)
   }
 
   XFlush(currentdsp->display_id);
-  XUNLOCK;
+  XUNLOCK(currentdsp);
 
 } /* end lisp_Xvideocolor */
 
@@ -322,7 +322,7 @@ void set_Xmouseposition(int x, int y)
     XWarpPointer(currentdsp->display_id, (Window)NULL, currentdsp->DisplayWindow, 0, 0, 0, 0,
                  dest_x, dest_y);
     XFlush(currentdsp->display_id);
-    XUNLOCK;
+    XUNLOCK(currentdsp);
   }
 } /* end set_Xmouseposition */
 

--- a/src/xwinman.c
+++ b/src/xwinman.c
@@ -83,7 +83,7 @@ void Set_BitGravity(XButtonEvent *event, DspInterface dsp, Window window, int gr
 
   XSetWindowBackgroundPixmap(event->display, window, dsp->GravityOnPixmap);
   XClearWindow(event->display, window);
-  XUNLOCK;
+  XUNLOCK(dsp);
 } /* end Set_BitGravity */
 
 static void lisp_Xconfigure(DspInterface dsp, int x, int y, int lspWinWidth, int lspWinHeight)
@@ -137,7 +137,7 @@ static void lisp_Xconfigure(DspInterface dsp, int x, int y, int lspWinWidth, int
   XMoveResizeWindow(dsp->display_id, dsp->SWGrav, Col2, Row3, GravSize, GravSize);
   Scroll(dsp, dsp->Visible.x, dsp->Visible.y);
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 } /* end lisp_Xconfigure */
 
 void enable_Xkeyboard(DspInterface dsp)
@@ -145,7 +145,7 @@ void enable_Xkeyboard(DspInterface dsp)
   XLOCK;
   XSelectInput(dsp->display_id, dsp->DisplayWindow, dsp->EnableEventMask);
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 }
 
 void disable_Xkeyboard(DspInterface dsp)
@@ -153,7 +153,7 @@ void disable_Xkeyboard(DspInterface dsp)
   XLOCK;
   XSelectInput(dsp->display_id, dsp->DisplayWindow, dsp->DisableEventMask);
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 }
 
 void beep_Xkeyboard(DspInterface dsp)
@@ -165,7 +165,7 @@ void beep_Xkeyboard(DspInterface dsp)
   XLOCK;
   XBell(dsp->display_id, (int)50);
   XFlush(dsp->display_id);
-  XUNLOCK;
+  XUNLOCK(dsp);
 
 } /* end beep_Xkeyboard */
 
@@ -241,7 +241,7 @@ void getXsignaldata(DspInterface dsp)
           (dsp->bitblt_to_screen)(dsp, 0, report.xexpose.x + dsp->Visible.x,
                                   report.xexpose.y + dsp->Visible.y, report.xexpose.width,
                                   report.xexpose.height);
-          XUNLOCK;
+          XUNLOCK(dsp);
           break;
         default: break;
       }
@@ -266,14 +266,14 @@ void getXsignaldata(DspInterface dsp)
         case ButtonPress:
           switch (report.xbutton.button) {
             case Button1:
-              DefineCursor(dsp->display_id, dsp->HorScrollBar, &ScrollLeftCursor);
+              DefineCursor(dsp, dsp->HorScrollBar, &ScrollLeftCursor);
               ScrollLeft(dsp);
               break;
             case Button2:
-              DefineCursor(dsp->display_id, dsp->HorScrollBar, &HorizThumbCursor);
+              DefineCursor(dsp, dsp->HorScrollBar, &HorizThumbCursor);
               break;
             case Button3:
-              DefineCursor(dsp->display_id, dsp->HorScrollBar, &ScrollRightCursor);
+              DefineCursor(dsp, dsp->HorScrollBar, &ScrollRightCursor);
               ScrollRight(dsp);
               break;
             default: break;
@@ -282,14 +282,14 @@ void getXsignaldata(DspInterface dsp)
         case ButtonRelease:
           switch (report.xbutton.button) {
             case Button1:
-              DefineCursor(dsp->display_id, report.xany.window, &HorizScrollCursor);
+              DefineCursor(dsp, report.xany.window, &HorizScrollCursor);
               break;
             case Button2:
               JumpScrollHor(dsp, report.xbutton.x);
-              DefineCursor(dsp->display_id, report.xany.window, &HorizScrollCursor);
+              DefineCursor(dsp, report.xany.window, &HorizScrollCursor);
               break;
             case Button3:
-              DefineCursor(dsp->display_id, report.xany.window, &HorizScrollCursor);
+              DefineCursor(dsp, report.xany.window, &HorizScrollCursor);
               break;
             default: break;
           } /* end switch */
@@ -300,14 +300,14 @@ void getXsignaldata(DspInterface dsp)
         case ButtonPress:
           switch (report.xbutton.button) {
             case Button1:
-              DefineCursor(dsp->display_id, report.xany.window, &ScrollUpCursor);
+              DefineCursor(dsp, report.xany.window, &ScrollUpCursor);
               ScrollUp(dsp);
               break;
             case Button2:
-              DefineCursor(dsp->display_id, report.xany.window, &VertThumbCursor);
+              DefineCursor(dsp, report.xany.window, &VertThumbCursor);
               break;
             case Button3:
-              DefineCursor(dsp->display_id, report.xany.window, &ScrollDownCursor);
+              DefineCursor(dsp, report.xany.window, &ScrollDownCursor);
               ScrollDown(dsp);
               break;
             default: break;
@@ -316,14 +316,14 @@ void getXsignaldata(DspInterface dsp)
         case ButtonRelease:
           switch (report.xbutton.button) {
             case Button1:
-              DefineCursor(dsp->display_id, report.xany.window, &VertScrollCursor);
+              DefineCursor(dsp, report.xany.window, &VertScrollCursor);
               break;
             case Button3:
-              DefineCursor(dsp->display_id, report.xany.window, &VertScrollCursor);
+              DefineCursor(dsp, report.xany.window, &VertScrollCursor);
               break;
             case Button2:
               JumpScrollVer(dsp, report.xbutton.y);
-              DefineCursor(dsp->display_id, report.xany.window, &VertScrollCursor);
+              DefineCursor(dsp, report.xany.window, &VertScrollCursor);
               break;
             default: break;
           } /* end switch */


### PR DESCRIPTION
Removes explicit usage of SIGPOLL by replacing indirect calls to getXsignaldata (via `kill(getpid(),SIGPOLL)`), when there was a deferred signal at XUNLOCK, by a direct call.  This requires the DspInterface be available from XUNLOCK usage sites, so some procedures and macros needed parameters adjusted.

There are also a few places where XLOCK/XUNLOCK calls are superfluous because the procedures they are in are always called with locks already held.