### PR TITLE
Additional Makefiles for FreeBSD amd64, Raspberry Pi

### DIFF
--- a/bin/makefile-freebsd.aarch64-x
+++ b/bin/makefile-freebsd.aarch64-x
@@ -1,4 +1,4 @@
-# Options for FreeBSD, , ARMv7 and X-Window
+# Options for FreeBSD, ARMv7 and X-Windows
 
 CC = clang -m64 $(CLANG_CFLAGS)
 

--- a/bin/makefile-freebsd.aarch64-x
+++ b/bin/makefile-freebsd.aarch64-x
@@ -1,0 +1,27 @@
+# Options for FreeBSD, Intel 386/486 and X Windows
+
+CC = clang -m64 $(CLANG_CFLAGS)
+
+XFILES = $(OBJECTDIR)xmkicon.o \
+	$(OBJECTDIR)xbbt.o \
+	$(OBJECTDIR)dspif.o \
+	$(OBJECTDIR)xinit.o \
+	$(OBJECTDIR)xscroll.o \
+	$(OBJECTDIR)xcursor.o \
+	$(OBJECTDIR)xlspwin.o \
+	$(OBJECTDIR)xrdopt.o \
+	$(OBJECTDIR)xwinman.o
+
+
+XFLAGS = -I/usr/local/include -DXWINDOW -DLOCK_X_UPDATES
+
+# OPTFLAGS is normally -O2.
+OPTFLAGS = -O2 -g
+DFLAGS = $(XFLAGS) -DRELEASE=351
+
+LDFLAGS = -L/usr/local/lib -lX11 -lc -lm
+LDELDFLAGS =  -L/usr/local/lib -lX11 -lc -lm
+
+OBJECTDIR = ../$(RELEASENAME)/
+
+default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex

--- a/bin/makefile-freebsd.aarch64-x
+++ b/bin/makefile-freebsd.aarch64-x
@@ -1,4 +1,4 @@
-# Options for FreeBSD, Intel 386/486 and X Windows
+# Options for FreeBSD, , ARMv7 and X-Window
 
 CC = clang -m64 $(CLANG_CFLAGS)
 

--- a/bin/makefile-freebsd.x86_64-x
+++ b/bin/makefile-freebsd.x86_64-x
@@ -1,4 +1,4 @@
-# Options for FreeBSD, Intel 386/486 and X Windows
+# Options for FreeBSD, Intel x86_64 and X-Window
 
 CC = clang -m64 $(CLANG_CFLAGS)
 

--- a/bin/makefile-freebsd.x86_64-x
+++ b/bin/makefile-freebsd.x86_64-x
@@ -1,0 +1,27 @@
+# Options for FreeBSD, Intel 386/486 and X Windows
+
+CC = clang -m64 $(CLANG_CFLAGS)
+
+XFILES = $(OBJECTDIR)xmkicon.o \
+	$(OBJECTDIR)xbbt.o \
+	$(OBJECTDIR)dspif.o \
+	$(OBJECTDIR)xinit.o \
+	$(OBJECTDIR)xscroll.o \
+	$(OBJECTDIR)xcursor.o \
+	$(OBJECTDIR)xlspwin.o \
+	$(OBJECTDIR)xrdopt.o \
+	$(OBJECTDIR)xwinman.o
+
+
+XFLAGS = -I/usr/local/include -DXWINDOW -DLOCK_X_UPDATES
+
+# OPTFLAGS is normally -O2.
+OPTFLAGS = -O2 -g
+DFLAGS = $(XFLAGS) -DRELEASE=351
+
+LDFLAGS = -L/usr/local/lib -lX11 -lc -lm
+LDELDFLAGS =  -L/usr/local/lib -lX11 -lc -lm
+
+OBJECTDIR = ../$(RELEASENAME)/
+
+default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex

--- a/bin/makefile-init-freebsd.aarch64
+++ b/bin/makefile-init-freebsd.aarch64
@@ -1,4 +1,4 @@
-# Options for FreeBSD, Intel x86_64 and X-Windows
+# Options for FreeBSD, ARMv7 and X-Windows
 
 CC = clang -m64 $(CLANG_CFLAGS)
 
@@ -15,13 +15,13 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 
 XFLAGS = -I/usr/local/include -DXWINDOW -DLOCK_X_UPDATES
 
-# OPTFLAGS is normally -O2.
-OPTFLAGS = -O2 -g
-DFLAGS = $(XFLAGS) -DRELEASE=351
+# OPTFLAGS is normally -O0 for init
+OPTFLAGS = -O0 -g
+DFLAGS = $(XFLAGS) -DRELEASE=351 -DNOVERSION -DINIT
 
 LDFLAGS = -L/usr/local/lib -lX11 -lc -lm
 LDELDFLAGS =  -L/usr/local/lib -lX11 -lc -lm
 
 OBJECTDIR = ../$(RELEASENAME)/
 
-default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
+default	: ../$(OSARCHNAME)/ldeinit

--- a/bin/makefile-init-freebsd.x86_64
+++ b/bin/makefile-init-freebsd.x86_64
@@ -15,13 +15,13 @@ XFILES = $(OBJECTDIR)xmkicon.o \
 
 XFLAGS = -I/usr/local/include -DXWINDOW -DLOCK_X_UPDATES
 
-# OPTFLAGS is normally -O2.
-OPTFLAGS = -O2 -g
-DFLAGS = $(XFLAGS) -DRELEASE=351
+# OPTFLAGS is normally -O0 for init
+OPTFLAGS = -O0 -g
+DFLAGS = $(XFLAGS) -DRELEASE=351 -DNOVERSION -DINIT
 
 LDFLAGS = -L/usr/local/lib -lX11 -lc -lm
 LDELDFLAGS =  -L/usr/local/lib -lX11 -lc -lm
 
 OBJECTDIR = ../$(RELEASENAME)/
 
-default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
+default	: ../$(OSARCHNAME)/ldeinit


### PR DESCRIPTION
Compiled on 12.2-RELEASE on AMD64 and 13.0-RELEASE on a Raspberry Pi 4. Both platforms compile, with warnings and run fine.