### PR TITLE
Remove code for unsupported Sun display configurations

### DIFF
--- a/bin/compile-flags
+++ b/bin/compile-flags
@@ -128,5 +128,4 @@ bitbltsub.c:#ifdef GETBASE
 testdisplay.c:#ifdef NOTUSED
 uraid.c:#ifdef ETHERINT
 bitblt.c:#ifndef COLOR
-bitbltsub.c:#ifndef prropstyle
 lispmap.h:#ifdef MEDLEY

--- a/inc/bbtsubdefs.h
+++ b/inc/bbtsubdefs.h
@@ -1,36 +1,19 @@
 #ifndef BBTSUBDEFS_H
 #define BBTSUBDEFS_H 1
 
-/***** Don't use PixRect code on 386i for now *****/
-/***** -or on any machine that doesn't support it (HP, e.g.) *****/
-
 /********************************************************/
 /*                                                      */
-/*      prropstyle is DEFINED when we want to use       */
-/*      pixrect versions of the operations in this      */
-/*      file, and UNDEFINED, when we want to use        */
-/*      Don Charnley's bitblt code to do them.          */
+/*      Don Charnley's bitblt code                      */
 /*                                                      */
 /********************************************************/
 #include "lispemul.h" /* for LispPTR, DLword */
-
-#if defined(SUNDISPLAY) && \
-    !defined(NOPIXRECT) && \
-    !defined(NEWBITBLT)
-#define prropstyle 1
-#endif
 
 void bitbltsub(LispPTR *argv);
 LispPTR n_new_cursorin(DLword *baseaddr, int dx, int dy, int w, int h);
 LispPTR bitblt_bitmap(LispPTR *args);
 LispPTR bitshade_bitmap(LispPTR *args);
-#ifndef prropstyle
 void bltchar(LispPTR *args);
 void newbltchar(LispPTR *args);
-#else
-LispPTR bltchar(LispPTR *args);
-LispPTR newbltchar(LispPTR *args);
-#endif
 void ccfuncall(unsigned int atom_index, int argnum, int bytenum);
 void tedit_bltchar(LispPTR *args);
 

--- a/inc/bitblt.h
+++ b/inc/bitblt.h
@@ -54,13 +54,6 @@ extern int DisplayRasterWidth;
 #define ShowCursor { (currentdsp->mouse_visible)(IOPage68K->dlmousex, \
 												  IOPage68K->dlmousey); }
 
-#elif defined(SUNDISPLAY) && defined(OLD_CURSOR)
-extern struct winlock DisplayLockArea;
-#define	HideCursor	\
-	ioctl( LispWindowFd, WINLOCKSCREEN, &DisplayLockArea)
-
-#define ShowCursor \
-	ioctl( LispWindowFd, WINUNLOCKSCREEN, &DisplayLockArea)
 #else
 extern DLword *EmCursorX68K,*EmCursorY68K;
 #define	HideCursor	{ taking_mouse_down();}

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -1130,7 +1130,6 @@ bad_arg:
 /*                                                                      */
 /*                                                                      */
 /************************************************************************/
-#ifndef prropstyle
 /********************************************************/
 /*             Non-PIXRECT version of the code          */
 /********************************************************/
@@ -1222,98 +1221,6 @@ void bltchar(LispPTR *args)
   UNLOCKSCREEN;
 }
 
-#else
-/* prropstyle */
-
-LispPTR bltchar(LispPTR *args)
-/*      args[0] :       PILOTBBT
- *      args[1] :       DISPLAYDATA
- *      args[2] :       CHAR8CODE
- *      args[3] :       CURX
- *      args[4] :       LEFT
- *      args[5] :       RIGHT
- */
-{
-  register PILOTBBT *pbt;
-  register DISPLAYDATA *dspdata;
-  int x, y, destbpl, srcebpl, srcebit, distance;
-  int base;
-  register int displayflg;
-  unsigned int pix_op;
-  DLword *dstbase;
-
-  pbt = (PILOTBBT *)Addr68k_from_LADDR(((BLTC *)args)->pilotbbt);
-  dspdata = (DISPLAYDATA *)Addr68k_from_LADDR(((BLTC *)args)->displaydata);
-
-  (mpr_d(SrcePixRect))->md_image =
-      (short *)Addr68k_from_LADDR(VAG2(pbt->pbtsourcehi, pbt->pbtsourcelo));
-
-  dstbase = (mpr_d(DestPixRect))->md_image =
-      (short *)Addr68k_from_LADDR(VAG2(pbt->pbtdesthi, pbt->pbtdestlo));
-
-  SrcePixRect->pr_width = srcebpl = abs(pbt->pbtsourcebpl);
-  DestPixRect->pr_width = destbpl = abs(pbt->pbtdestbpl);
-  SrcePixRect->pr_height = DestPixRect->pr_height = pbt->pbtheight;
-
-  mpr_mdlinebytes(DestPixRect) = (destbpl + 7) >> 3;
-  mpr_mdlinebytes(SrcePixRect) = (srcebpl + 7) >> 3;
-
-  base = GETWORD(Addr68k_from_LADDR(dspdata->ddoffsetscache + ((BLTC *)args)->char8code));
-  srcebit = base + ((BLTC *)args)->left - ((BLTC *)args)->curx;
-
-#ifdef REALCURSOR
-  /* if displayflg != 0 then source or destination is DisplayBitMap
-   * Now we consider about only destination
-   */
-  displayflg = old_cursorin(pbt->pbtdesthi, pbt->pbtdestlo, ((BLTC *)args)->left, (((BLTC *)args)->right - ((BLTC *)args)->left),
-                            pbt->pbtheight, y, pbt->pbtbackward);
-#endif /* REALCURSOR */
-
-  /**** for DEBUG DEBUG DEBUG DEBUG DEBUG DEBUG DEBUG *****/
-  /*      displayflg = T;                                         */
-  /**** for DEBUG DEBUG DEBUG DEBUG DEBUG DEBUG DEBUG *****/
-
-  pix_op = PixOperation(pbt->pbtsourcetype, pbt->pbtoperation);
-
-  LOCKSCREEN;
-
-#ifdef REALCURSOR
-  if (displayflg) HideCursor;
-#endif /* REALCURSOR */
-
-  if (pr_rop(DestPixRect, ((BLTC *)args)->left, 0, (((BLTC *)args)->right - ((BLTC *)args)->left), pbt->pbtheight, pix_op,
-             SrcePixRect, srcebit, 0) != 0)
-    error("pilotbitblt: pr_rop failed\n");
-
-#ifdef DISPLAYBUFFER
-#ifdef COLOR
-  if (MonoOrColor == MONO_SCREEN)
-#endif /* COLOR */
-
-    if (in_display_segment(dstbase)) {
-      /*          DBPRINT(("bltchar pix:  x %x, y %d, w %d, h %d.\n", ((BLTC *)args)->left, dstbase,
-       * (((BLTC *)args)->right - ((BLTC *)args)->left),pbt->pbtheight));
-      */
-      flush_display_lineregion(((BLTC *)args)->left, dstbase, (((BLTC *)args)->right - ((BLTC *)args)->left), pbt->pbtheight);
-    }
-#endif
-
-#ifdef XWINDOW
-  if (in_display_segment(dstbase))
-    flush_display_lineregion(((BLTC *)args)->left, dstbase, (((BLTC *)args)->right - ((BLTC *)args)->left), pbt->pbtheight);
-#endif /* XWINDOW */
-
-#ifdef DOS
-  if (in_display_segment(dstbase)) flush_display_lineregion(dx, dstbase, w, h);
-#endif /* DOS */
-
-#ifdef REALCURSOR
-  if (displayflg) ShowCursor;
-#endif /* REALCURSOR */
-
-  ScreenLocked = NIL;
-}
-#endif
 
 /************************************************************************/
 /*                                                                      */
@@ -1400,7 +1307,6 @@ LispPTR BLTCHAR_index;       /* Atom # for \PUNTBLTCHAR punt fn */
 LispPTR TEDIT_BLTCHAR_index; /* if NIL ,TEDIT is not yet loaded */
 
 
-#ifndef prropstyle
 
 /************************************************************************/
 /*                                                                      */
@@ -1529,115 +1435,6 @@ void newbltchar(LispPTR *args) {
 
 } /* end of newbltchar */
 
-#else /* prropstyle */
-
-/************************************************************************/
-/*                                                                      */
-/*                          n e w b l t c h a r                                 */
-/*                           (PIXRECT version)                          */
-/*                                                                      */
-/************************************************************************/
-
-LispPTR newbltchar(LispPTR *args) {
-  register DISPLAYDATA *displaydata68k;
-
-  register int right, left, curx;
-  register PILOTBBT *pbt;
-  register int lmargin, rmargin, xoff;
-  int displayflg; /* T if cursor needs to be taken down */
-  displaydata68k = (DISPLAYDATA *)Addr68k_from_LADDR(((BLTARG *)args)->displaydata);
-
-  if ((displaydata68k->ddcharset & 0xFFFF) != ((BLTARG *)args)->charset) {
-    /* Currently, this has BUG, so I can't call it */
-    /*if(changecharset_display(displaydata68k,((BLTARG *)args)->charset) ==-1)*/
-    { PUNT_TO_BLTCHAR; }
-  }
-
-  if (displaydata68k->ddslowprintingcase) { PUNT_TO_BLTCHAR; /** \SLOWBLTCHAR--return;**/ }
-
-  FGetNum(displaydata68k->ddxposition, curx);
-  FGetNum(displaydata68k->ddrightmargin, rmargin);
-  FGetNum(displaydata68k->ddleftmargin, lmargin);
-  FGetNum(displaydata68k->ddxoffset, xoff);
-
-  right =
-      curx +
-      GETWORD((DLword *)Addr68k_from_LADDR(displaydata68k->ddcharimagewidths + ((BLTARG *)args)->char8code));
-
-  if ((right > rmargin) && (curx > lmargin)) PUNT_TO_BLTCHAR;
-  if (((BLTARG *)args)->displaystream != *TOPWDS68k) PUNT_TO_BLTCHAR;
-  {
-    register int newpos;
-    newpos = curx +
-             GETWORD((DLword *)Addr68k_from_LADDR(displaydata68k->ddwidthscache + ((BLTARG *)args)->char8code));
-
-    if ((0 <= newpos) && (newpos < 65536))
-      (displaydata68k->ddxposition) = (LispPTR)(S_POSITIVE | newpos);
-    else if (-65537 < newpos)
-      (displaydata68k->ddxposition) = (LispPTR)(S_NEGATIVE | (0xffff & newpos));
-    else {
-      PUNT_TO_BLTCHAR;
-    }
-  }
-
-  curx += xoff;
-  right += xoff;
-  if (right > (int)(displaydata68k->ddclippingright)) right = displaydata68k->ddclippingright;
-
-  if (curx > (int)(displaydata68k->ddclippingleft))
-    left = curx;
-  else
-    left = displaydata68k->ddclippingleft;
-
-  if (left < right) {
-    pbt = (PILOTBBT *)Addr68k_from_LADDR(displaydata68k->ddpilotbbt);
-    if (pbt->pbtheight != 0) {
-      /****** OLD bltchar *****/
-      register int destbpl, srcebpl, sourcebit;
-      DLword *dstbase;
-      int base, y;
-
-      (mpr_d(SrcePixRect))->md_image =
-          (short *)Addr68k_from_LADDR(VAG2(pbt->pbtsourcehi, pbt->pbtsourcelo));
-
-      dstbase = (mpr_d(DestPixRect))->md_image =
-          (short *)Addr68k_from_LADDR(VAG2(pbt->pbtdesthi, pbt->pbtdestlo));
-
-      SrcePixRect->pr_width = srcebpl = abs(pbt->pbtsourcebpl);
-      DestPixRect->pr_width = destbpl = abs(pbt->pbtdestbpl);
-      SrcePixRect->pr_height = DestPixRect->pr_height = pbt->pbtheight;
-
-      mpr_mdlinebytes(DestPixRect) = (destbpl + 7) >> 3;
-      mpr_mdlinebytes(SrcePixRect) = (srcebpl + 7) >> 3;
-
-      base = GETBASE(Addr68k_from_LADDR(displaydata68k->ddoffsetscache), ((BLTARG *)args)->char8code);
-      sourcebit = base + left - curx;
-
-      LOCKSCREEN;
-
-
-#ifdef XWINDOW
-      if (pr_rop(DestPixRect, left, 0, (right - left), pbt->pbtheight,
-                 PixOperation(pbt->pbtsourcetype, pbt->pbtoperation), SrcePixRect, sourcebit,
-                 0) != 0)
-        error("pilotbitblt: pr_rop failed\n");
-
-      if (in_display_segment(dstbase))
-        flush_display_lineregion(left, dstbase, (right - left), pbt->pbtheight);
-#endif /* XWINDOW */
-
-#ifdef DOS
-      if (in_display_segment(dstbase)) flush_display_lineregion(dx, dstbase, w, h);
-      if (displayflg) ShowCursor;
-#endif /* DOS */
-
-      ScreenLocked = NIL;
-
-      /****** OLD bltchar *****/
-    }
-  }
-} /* newbltchar */
-#endif
 
 /******************************************************************/
 #ifndef BYTESWAP
@@ -1935,7 +1732,6 @@ void ccfuncall(register unsigned int atom_index, register int argnum, register i
 /*                                                              */
 /****************************************************************/
 
-#ifndef prropstyle
 /***************************/
 /*   Non-PIXRECT version   */
 /***************************/
@@ -1993,67 +1789,6 @@ void tedit_bltchar(LispPTR *args)
 #undef backwardflg
 
 } /* end tedit_bltchar */
-#else
-
-/* pr_op style */
-/**********************/
-/*   PIXRECT version  */
-/**********************/
-
-void tedit_bltchar(LispPTR *args)
-{
-  register DISPLAYDATA *displaydata68k;
-  register int left, right;
-  register PILOTBBT *pbt;
-  register int imagewidth, newx;
-  register displayflg;
-
-  displaydata68k = (DISPLAYDATA *)Addr68k_from_LADDR(((TBLTARG *)args)->displaydata);
-  if (displaydata68k->ddcharset != ((TBLTARG *)args)->charset) {
-    /**if(changecharset_display(displaydata68k, ((TBLTARG *)args)->charset)== -1)**/
-    { PUNT_TO_TEDIT_BLTCHAR; }
-  }
-  imagewidth = *((DLword *)Addr68k_from_LADDR(displaydata68k->ddcharimagewidths + ((TBLTARG *)args)->char8code));
-  newx = ((TBLTARG *)args)->current_x + imagewidth;
-  left = IMAX(0, ((TBLTARG *)args)->current_x);
-  right = IMIN(newx, ((TBLTARG *)args)->clipright);
-  LOCKSCREEN;
-
-  if (left < right) {
-    pbt = (PILOTBBT *)Addr68k_from_LADDR(displaydata68k->ddpilotbbt);
-    if (pbt->pbtheight) {
-      (mpr_d(SrcePixRect))->md_image =
-          (short *)Addr68k_from_LADDR(VAG2(pbt->pbtsourcehi, pbt->pbtsourcelo));
-
-      (mpr_d(DestPixRect))->md_image =
-          (short *)Addr68k_from_LADDR(VAG2(pbt->pbtdesthi, pbt->pbtdestlo));
-      {
-        register int srcebpl, destbpl;
-        SrcePixRect->pr_width = srcebpl = abs(pbt->pbtsourcebpl);
-        DestPixRect->pr_width = destbpl = abs(pbt->pbtdestbpl);
-        SrcePixRect->pr_height = DestPixRect->pr_height = pbt->pbtheight;
-
-        mpr_mdlinebytes(DestPixRect) = (destbpl + 7) >> 3;
-        mpr_mdlinebytes(SrcePixRect) = (srcebpl + 7) >> 3;
-      }
-
-      pbt->pbtwidth = IMIN(imagewidth, (right - left));
-      pbt->pbtsourcebit =
-          GETBASE(Addr68k_from_LADDR(displaydata68k->ddoffsetscache), ((TBLTARG *)args)->char8code);
-
-      if (pr_rop(DestPixRect, left, 0, pbt->pbtwidth, pbt->pbtheight,
-                 PixOperation(pbt->pbtsourcetype, pbt->pbtoperation), SrcePixRect,
-                 pbt->pbtsourcebit, 0) != 0)
-        error("pilotbitblt: pr_rop failed\n");
-
-    } /* if pbt->pbtheight */
-  }   /* if left<right */
-
-  UNLOCKSCREEN;
-
-} /* end tedit_bltchar */
-
-#endif
 
 #if defined(REALCURSOR) || defined(SUNDISPLAY)
 #ifndef COLOR

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -37,12 +37,6 @@
 #include "xdefs.h"
 #endif /* XWINDOW */
 
-#ifdef SUNDISPLAY
-#ifndef NOPIXRECT
-#include <sunwindow/window_hs.h>
-#include <sunwindow/win_ioctl.h>
-#endif /* NOPIXRECT */
-#endif /* SUNDISPLAY */
 
 #include "lispemul.h"
 #include "lspglob.h"
@@ -87,10 +81,8 @@ extern int  kbd_for_makeinit;
   };
 #endif
 
-#if !defined(SUNDISPLAY)
 #include "devif.h"
 extern DspInterface currentdsp;
-#endif /* SUNDISPLAY */
 
 #ifdef COLOR
 extern int MonoOrColor;
@@ -1623,41 +1615,6 @@ LispPTR newbltchar(LispPTR *args) {
 
       LOCKSCREEN;
 
-#ifdef SUNDISPLAY
-      if (displayflg = old_cursorin(pbt->pbtdesthi, pbt->pbtdestlo, left, (right - left),
-                                    pbt->pbtheight, y, pbt->pbtbackward)) {
-        HideCursor;
-        if (pr_rop(DestPixRect, left, 0, (right - left), pbt->pbtheight,
-                   PixOperation(pbt->pbtsourcetype, pbt->pbtoperation), SrcePixRect, sourcebit,
-                   0) != 0)
-          error("pilotbitblt: pr_rop failed\n");
-/* Save SHOWCURSOR 'til after paint to screen */
-#ifndef DISPLAYBUFFER
-        ShowCursor;
-#endif
-      } /* display case */
-      else {
-        if (pr_rop(DestPixRect, left, 0, (right - left), pbt->pbtheight,
-                   PixOperation(pbt->pbtsourcetype, pbt->pbtoperation), SrcePixRect, sourcebit,
-                   0) != 0)
-          error("pilotbitblt: pr_rop failed\n");
-
-      } /* else */
-
-#ifdef DISPLAYBUFFER
-#ifdef COLOR
-      if (MonoOrColor == MONO_SCREEN)
-#endif /* COLOR */
-
-        if (in_display_segment(dstbase)) {
-          /*               DBPRINT(("newbltchar:  x %d, y 0x%x, w %d, h %d.\n", left, dstbase,
-           * (right - left), pbt->pbtheight)); */
-
-          flush_display_lineregion(left, dstbase, (right - left), pbt->pbtheight);
-          if (displayflg) ShowCursor; /* because hide is done earlier */
-        }
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
       if (pr_rop(DestPixRect, left, 0, (right - left), pbt->pbtheight,

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -12,16 +12,6 @@
 
 #include <stdio.h>
 
-#ifdef SUNDISPLAY
-#include <sunwindow/window_hs.h>
-#include <sunwindow/win_ioctl.h>
-
-#include <suntool/sunview.h>
-#include <sunwindow/cms_mono.h>
-#include <suntool/canvas.h>
-#include <sys/ioctl.h>
-#include <signal.h>
-#endif
 
 #ifdef XWINDOW
 #define DISPLAYBUFFER
@@ -127,25 +117,14 @@ LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl,int tos)
   num_gray = ((TEXTUREBBT *)pbt)->pbtgrayheightlessone + 1;
   curr_gray_line = ((TEXTUREBBT *)pbt)->pbtgrayoffset;
 
-#ifdef SUNDISPLAY
-  if (displayflg) HideCursor;
-#elif DOS
+#if   DOS
   if (displayflg) (currentdsp->mouse_invisible)(currentdsp, IOPage68K);
   ;
 #endif /* SUNDISPLAY / DOS */
 
   new_bitblt_code
 
-#ifdef SUNDISPLAY
-#ifdef DISPLAYBUFFER
-#ifdef COLOR
-      if (MonoOrColor == MONO_SCREEN)
-#endif /* COLOR */
-
-          if (in_display_segment(dstbase)) flush_display_lineregion(dx, dstbase, w, h);
-#endif
-  if (displayflg) ShowCursor;
-#elif DOS
+#if   DOS
       flush_display_lineregion(dx, dstbase, w, h);
   if (displayflg) (currentdsp->mouse_visible)(IOPage68K->dlmousex, IOPage68K->dlmousey);
 #endif /* SUNDISPLAY / DOS */

--- a/src/draw.c
+++ b/src/draw.c
@@ -20,11 +20,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#ifdef SUNDISPLAY
-#include <sys/ioctl.h>
-#include <sunwindow/window_hs.h>
-#include <sunwindow/win_ioctl.h>
-#endif
 
 #include "lispemul.h"
 #include "lspglob.h"
@@ -133,17 +128,6 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
   if (MonoOrColor == MONO_SCREEN)
 #endif /* COLOR */
 
-#ifdef SUNDISPLAY
-#ifndef DISPLAYBUFFER
-    HideCursor; /** Figure out how to be smart later **/
-#else           /* DISPLAYBUFFER */
-#ifndef OLD_CURSOR
-    HideCursor;
-#endif /* OLD_CURSOR */
-
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
   delta &= 0xFFFF;
   op &= 3;
@@ -277,17 +261,6 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
   if (MonoOrColor == MONO_SCREEN)
 #endif /* COLOR */
 
-#ifdef SUNDISPLAY
-#ifndef DISPLAYBUFFER
-    ShowCursor; /** figure how to be smart later **/
-#else
-#ifndef OLD_CURSOR
-    ShowCursor;
-#endif /* OLD_CURSOR */
-
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
 #ifdef DISPLAYBUFFER
 #ifdef COLOR
@@ -304,9 +277,6 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
         ((int)(temp_e = (DLword *)(dataptr - DisplayRegion68k)) >= 0) &&
         ((DLword *)dataptr < DisplayRegion68k_end_addr)) {
       int start_x, start_y, end_x, end_y, w, h;
-#if defined(SUNDISPLAY) && defined(OLD_CURSOR)
-      int displayflg;
-#endif
 
       start_y = (int)temp_s / DisplayRasterWidth;
       start_x = ((int)temp_s % DisplayRasterWidth) * BITSPER_DLWORD;
@@ -320,18 +290,6 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
       if (start_x > end_x) start_x = end_x;
       if (start_y > end_y) start_y = end_y;
 
-#if defined(SUNDISPLAY) && !defined(BYTESWAP)
-#ifdef OLD_CURSOR
-      if ((displayflg = n_new_cursorin_CG6(start_x, start_y, w, h))) HideCursor;
-#endif /* OLD_CURSOR */
-
-      pr_rop(ColorDisplayPixrect, start_x, start_y, w, h, PIX_SRC, DisplayRegionPixrect, start_x,
-             start_y);
-#ifdef OLD_CURSOR
-      if (displayflg) ShowCursor;
-#endif /* OLD_CURSOR */
-
-#endif /* SUNDISPLAY */
 
 #if defined(XWINDOW) || defined(BYTESWAP)
       flush_display_region(start_x, start_y, w, h);

--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -12,9 +12,6 @@
 #include "version.h"
 
 #include <stdio.h>
-#ifdef SUNDISPLAY
-#include <sunwindow/window_hs.h>
-#endif
 
 #include "lispemul.h"
 #include "lsptypes.h"
@@ -68,9 +65,7 @@ void DSP_showdisplay(LispPTR *args)
 LispPTR DSP_VideoColor(LispPTR *args) /* args[0] :	black flag	*/
 {
   int invert;
-#ifdef SUNDISPLAY
-  return NIL;
-#elif defined(XWINDOW)
+#if   defined(XWINDOW)
   invert = args[0] & 0xFFFF;
   lisp_Xvideocolor(invert);
   if (invert)
@@ -99,50 +94,7 @@ void DSP_Cursor(LispPTR *args, int argnum)
   extern int ScreenLocked;
   extern DLword *EmCursorX68K, *EmCursorY68K;
   extern int LastCursorX, LastCursorY;
-#if defined(SUNDISPLAY) && !defined(OLD_CURSOR)
-  static int Init = T;
-#endif
 
-#ifdef SUNDISPLAY
-  if (argnum == 2) {
-    CurrentCursor.cur_xhot = args[0] & 0xffff;
-    CurrentCursor.cur_yhot = args[1] & 0xffff;
-  };
-
-#ifdef OLD_CURSOR
-  win_setcursor(LispWindowFd, &CurrentCursor);
-#else
-#ifndef INIT
-  ScreenLocked = T;
-  if (!Init) {
-    taking_mouse_down();
-    taking_mouse_up(*EmCursorX68K, *EmCursorY68K);
-  } else {
-    Init = NIL;
-    cursor_hidden_bitmap(0, 0);
-    taking_mouse_up(0, 0);
-    *EmCursorX68K = LastCursorX = 0;
-    *EmCursorY68K = LastCursorY = 0;
-  }
-
-  ScreenLocked = NIL;
-#else
-  /* Init specific lde only */
-  ScreenLocked = T;
-  if (!Init) {
-    taking_mouse_down();
-    taking_mouse_up(0, 0);
-  } else {
-    Init = NIL;
-    cursor_hidden_bitmap(0, 0);
-    taking_mouse_up(0, 0);
-  }
-
-  ScreenLocked = NIL;
-#endif /* INIT */
-
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   /* For X-Windows, set the cursor to the given location. */
@@ -161,32 +113,6 @@ void DSP_Cursor(LispPTR *args, int argnum)
   */
 void DSP_SetMousePos(register LispPTR *args)
 {
-#ifdef SUNDISPLAY
-#ifdef OLD_CURSOR
-  register int x, y;
-  x = GetSmalldata(args[0]);
-  y = GetSmalldata(args[1]); /* debug */
-  win_setmouseposition(LispWindowFd, GetSmalldata(args[0]), GetSmalldata(args[1]));
-#else
-  extern int ScreenLocked;
-  extern DLword *EmCursorX68K, *EmCursorY68K, *EmMouseX68K, *EmMouseY68K;
-  register int x, y;
-  ScreenLocked = T;
-  x = GetSmalldata(args[0]);
-  y = GetSmalldata(args[1]);
-  /* for Suntool's invisible cursor */
-  win_setmouseposition(LispWindowFd, x, y);
-  /* for REAL cursor image */
-  taking_mouse_down();
-  taking_mouse_up(x, y);
-
-#ifndef INIT
-  *EmMouseX68K = x;
-  *EmMouseY68K = y;
-#endif
-  ScreenLocked = NIL;
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   if (Mouse_Included)
@@ -251,25 +177,6 @@ void flip_cursor() {
 
 #endif
 
-#ifdef SUNDISPLAY
-#ifdef OLD_CURSOR
-
-  win_setcursor(LispWindowFd, &CurrentCursor);
-#else
-  ScreenLocked = T;
-  taking_mouse_down();
-#ifndef INIT
-  taking_mouse_up(*EmCursorX68K, *EmCursorY68K);
-#else
-  if (!for_makeinit)
-    taking_mouse_up(*EmCursorX68K, *EmCursorY68K);
-  else
-    taking_mouse_up(0, 0);
-#endif /* INIT */
-
-  ScreenLocked = NIL;
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   /* JDS 011213: 15- cur y, as function does same! */

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -18,20 +18,6 @@
 #include <stdio.h>
 #include <unistd.h>
 
-#ifdef SUNDISPLAY
-#ifndef NOPIXRECT
-#include <sunwindow/window_hs.h>
-#include <sunwindow/cms.h>
-#include <sunwindow/win_ioctl.h>
-#include <sys/ioctl.h>
-#include <sys/mman.h>
-#include <pixrect/pixrect_hs.h>
-#include <sun/fbio.h>
-#include <sys/ioctl.h>
-#include <sys/file.h>
-#include <pixrect/pr_planegroups.h>
-#endif /* NOPIXRECT */
-#endif /* SUNDISPLAY */
 
 #ifdef OS4
 #include <vfork.h>
@@ -76,21 +62,6 @@ extern DspInterface currentdsp;
 #define FBTYPE_SUNFAST_COLOR 12
 #endif
 
-#ifdef SUNDISPLAY
-struct screen LispScreen;
-#ifndef NOPIXRECT
-struct pixrect *CursorBitMap, *InvisibleCursorBitMap;
-struct pixrect *SrcePixRect, *DestPixRect;
-#ifdef DISPLAYBUFFER
-int black = 0, white = -1;
-struct pixrect *ColorDisplayPixrect, *DisplayRegionPixrect;
-#define COPY_PIXRECT_TO_COLOR (PIX_SRC /*| PIX_DONTCLIP */)
-#ifdef DEBUG
-int oldred[2], oldgreen[2], oldblue[2];
-#endif /* DEBUG */
-#endif /* DISPLAYBUFFER */
-#endif /* NOPIXRECT */
-#endif /* SUNDISPLAY */
 
 int LispWindowFd = -1;
 int FrameBufferFd = -1;
@@ -107,10 +78,6 @@ DLword *DisplayRegion68k_end_addr;
 /* some functions use this variable when undef DISPLAYBUFFER */
 DLword *DISP_MAX_Address;
 
-#ifdef SUNDISPLAY
-struct cursor CurrentCursor, InvisibleCursor;
-struct winlock DisplayLockArea;
-#endif /* SUNDISPLAY */
 
 extern DLword *EmCursorBitMap68K;
 extern IFPAGE *InterfacePage;
@@ -127,13 +94,6 @@ DLword *DisplayRegion68k_end_addr;
 extern int *Xdisplay; /* DAANGER -jarl nilsson 27-apr-92 */
 #endif                /* XWINDOW */
 
-#ifdef SUNDISPLAY
-/* For SunOS4.1 Window Security Feature. */
-int Win_security_p;
-#include <sys/wait.h>
-#define SV_ACQUIRE "/bin/sunview1/sv_acquire"
-#define SV_RELEASE "/bin/sunview1/sv_release"
-#endif /* SUNDISPLAY */
 
 /************************************************************************/
 /*									*/
@@ -144,30 +104,6 @@ int Win_security_p;
 /************************************************************************/
 
 void init_cursor() {
-#ifdef SUNDISPLAY
-#ifndef NOPIXRECT
-  CursorBitMap = mem_create(CURSORWIDTH, CURSORHEIGHT, 1);
-  mpr_mdlinebytes(CursorBitMap) = CURSORWIDTH >> 3; /* 2(byte) */
-#endif                                              /* NOPIXRECT */
-
-  CurrentCursor.cur_xhot = 0;
-  CurrentCursor.cur_yhot = 0;
-  CurrentCursor.cur_shape = CursorBitMap;
-  CurrentCursor.cur_function = PIX_SRC | PIX_DST;
-
-  /*  Invisible Cursor */
-
-#ifndef NOPIXRECT
-  InvisibleCursorBitMap = mem_create(0, 0, 1);
-#endif /* NOPIXRECT */
-
-  InvisibleCursor.cur_xhot = 0;
-  InvisibleCursor.cur_yhot = 0;
-  InvisibleCursor.cur_shape = InvisibleCursorBitMap;
-  InvisibleCursor.cur_function = /*PIX_SRC |*/ PIX_DST;
-  win_setcursor(LispWindowFd, &InvisibleCursor);
-  win_setmouseposition(LispWindowFd, 0, 0);
-#endif /* SUNDISPLAY */
 }
 
 /************************************************************************/
@@ -178,18 +114,6 @@ void init_cursor() {
 /*									*/
 /************************************************************************/
 void set_cursor() {
-#ifdef SUNDISPLAY
-#ifdef OLD_CURSOR
-  (mpr_d(CursorBitMap))->md_image = (short *)(IOPage->dlcursorbitmap);
-  /* BitmapBase of CurrentCursor
-   * is set to IOPage->dlcursorbitmap
-   */
-  if (win_setcursor(LispWindowFd, &CurrentCursor) == -1) perror("SET Cursor");
-  if (win_setmouseposition(LispWindowFd, 0, 0) == -1) perror("SET Mouse POS");
-#else
-  if (win_setcursor(LispWindowFd, &InvisibleCursor) == -1) perror("SET Cursor:");
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   Init_XCursor();
@@ -208,22 +132,6 @@ void set_cursor() {
 
 #ifndef COLOR
 void clear_display() {
-#ifdef SUNDISPLAY
-#ifndef DISPLAYBUFFER
-  register short *word;
-  register int w, h;
-  word = (short *)DisplayRegion68k;
-  for (h = displayheight; (h--);) {
-    for (w = DisplayRasterWidth; (w--);) { *word++ = 0; }
-  }
-#else
-  pr_rop(ColorDisplayPixrect, 0, 0, displaywidth, displayheight, PIX_CLR, ColorDisplayPixrect, 0,
-         0);
-/* Original images are still kept in SYSOUT(DisplayRegion)  */
-/*  clear_CG6; */
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
 #ifdef DOS
   TPRINT(("Enter Clear_display\n"));
@@ -261,82 +169,11 @@ void clear_display() {
 
 void init_display2(DLword *display_addr, int display_max)
 {
-#ifdef SUNDISPLAY
-#ifndef DISPLAYBUFFER
-  int mmapstat;
-#endif
-  int fbgattr_result;
-  struct fbtype my_screen;
-  char groups[PIXPG_OVERLAY + 1];
-  struct fbgattr FBattr;
-  struct pixrect *ColorFb;
-#endif /* SUNDISPLAY */
 
-#ifdef SUNDISPLAY
 
-  /* For SunOS4.1 Window Security Feature. */
-
-  union wait status;
-
-  /* Window Security is available? */
-  if (!access(SV_ACQUIRE, F_OK))
-    Win_security_p = 1;
-  else
-    Win_security_p = 0;
-
-  if (Win_security_p) {
-    switch (vfork()) {
-      case -1: /* Error */ (void)fprintf(stderr, "init_display: Fork failed.\n"); exit(1);
-
-      case 0: /* Child */
-        (void)execl(SV_ACQUIRE, "sv_acquire", "0", "256", "250", 0);
-        /* should not return */
-        (void)fprintf(stderr, "init_display: exec for sv_acquire failed\n");
-        exit(1);
-
-      default: /* Parent */
-        /* do nothing */
-        break;
-    }
-    (void)wait(&status); /* child dies after changing 6 */
-
-    if (status.w_retcode != 0) {
-      (void)fprintf(stderr, "init_display: failed to set ownership of win devices\n");
-      exit(1);
-    }
-  }
-
-#endif /* SUNDISPLAY */
-
-#ifdef SUNDISPLAY
-  if ((LispWindowFd = win_screennew(&LispScreen)) == -1) {
-    perror("init_display: can't create LispWindow\n");
-    exit(-1);
-  } else {
-#ifdef KBINT
-/* int_io_open(LispWindowFd);  JDS 4/27/94 move to initkbd, to try preventing the
- * move-mouse-never-get-kbd bug */
-#endif
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
-  }
-#endif /* SUNDISPLAY */
 
   DisplayRegion68k = (DLword *)display_addr;
 
-#ifdef SUNDISPLAY
-  if ((FrameBufferFd = open(LispScreen.scr_fbname, 2)) == -1) {
-    perror("init_display: can't open FrameBuffer\n");
-    exit(-1);
-  }
-
-  /* initialize Display parameters */
-  if (ioctl(FrameBufferFd, FBIOGTYPE, &my_screen) == -1) {
-    perror("init_display: can't find screen parameters\n");
-    exit(-1);
-  }
-  displaywidth = my_screen.fb_width;
-  displayheight = my_screen.fb_height;
-#endif /* SUNDISPLAY */
 
 #if (defined(XWINDOW) || defined(DOS))
   (currentdsp->device.enter)(currentdsp);
@@ -351,146 +188,7 @@ void init_display2(DLword *display_addr, int display_max)
   DBPRINT(("FBIOGTYPE w x h = %d x %d\n", displaywidth, displayheight));
 
   DBPRINT(("FBIOGTYPE w x h = %d x %d\n", displaywidth, displayheight));
-#ifdef SUNDISPLAY
-  DBPRINT(("   (real) type  = %d\n", my_screen.fb_type));
-  DBPRINT(("   (real) bpp   = %d\n", my_screen.fb_depth));
-#endif /* SUNDISPLAY */
 
-#ifdef SUNDISPLAY
-  /** now attempt to use the FBIOGATTR call for more information **/
-
-  fbgattr_result = ioctl(FrameBufferFd, FBIOGATTR, &FBattr);
-  if (fbgattr_result >= 0) {
-    DBPRINT(("FBIOGATTR realtype = %d\n", FBattr.real_type));
-    DBPRINT(("   (real) size = %d x %d\n", FBattr.fbtype.fb_width, FBattr.fbtype.fb_height));
-    DBPRINT(("   (real) type = %d\n", FBattr.fbtype.fb_type));
-    DBPRINT(("   (real) bpp  = %d\n", FBattr.fbtype.fb_depth));
-    DBPRINT(("          emuls= %d %d %d %d\n", FBattr.emu_types[0], FBattr.emu_types[1],
-             FBattr.emu_types[2], FBattr.emu_types[3]));
-  } else { /* fill in defaults */
-    FBattr.real_type = my_screen.fb_type;
-  }
-  DBPRINT(("init_display: FBIOGATTR_result = %d\n", fbgattr_result));
-/* probe for DISPLAY type */
-/**********************************************************************
- *	         FB-TYPE       REAL-TYPE
- * 	BW2      2             x
- *	CG2      3             3
- *	CG3      8             6
- *	CG4      2             8
- *	CG6      8             12
- *	CG8      6             7
- *	CG9(GP1) 4             4    ;gpconfig -f -b
- *	CG9(GP1) 2            13    ;gpconfig gpone0 -f -b cgtwo0
- *	                            ;We assume This config for GXP model
- ***********************************************************************/
-/* Medley supports real (or emulated) BW2, so check for that first */
-#ifndef DISPLAYBUFFER
-
-  if ((my_screen.fb_type == FBTYPE_SUN2BW)        /* real or emulated bwtwo */
-      || (my_screen.fb_type == FBTYPE_SUN3COLOR)) /* Sun 3 color? */
-    switch (FBattr.real_type) {
-      case FBTYPE_SUN2BW: DisplayType = SUN2BW; break;
-
-      case FBTYPE_MEMCOLOR: /* memory 24-bit (CG8) */
-      {
-        DisplayType = SUNMEMCOLOR;
-        ColorFb = pr_open("/dev/fb");
-        pr_available_plane_groups(ColorFb, sizeof(groups), groups);
-        if (groups[PIXPG_OVERLAY] && groups[PIXPG_OVERLAY_ENABLE]) {
-          pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-          pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_SET, 0, 0, 0);
-          pr_set_plane_group(ColorFb, PIXPG_OVERLAY);
-        }
-      } break;
-
-      case FBTYPE_SUN4COLOR:    /* cg4 */
-      case FBTYPE_SUNROP_COLOR: /* cg9(GXP) */
-      {                         /* need to clear overlay plane */
-        DisplayType = SUN4COLOR;
-        ColorFb = pr_open("/dev/fb");
-        pr_available_plane_groups(ColorFb, sizeof(groups), groups);
-        if (groups[PIXPG_OVERLAY] && groups[PIXPG_OVERLAY_ENABLE]) {
-          pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-          pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_SET, 0, 0, 0);
-          pr_set_plane_group(ColorFb, PIXPG_OVERLAY);
-        }
-        break;
-      }
-
-      default:
-        printf("initdisplay: Unsupported FBreal_type %d\n", FBattr.real_type);
-        DisplayType = (my_screen.fb_type) << 3;
-        /* should be able to proceed, since its an emulated bwtwo */
-    }
-  else {                       /* not currently a SUN2BW, perhaps can emulate it? */
-    if (fbgattr_result >= 0) { /* got gattrs, can try sattr */
-#ifdef DEBUG
-      error("fb bwtwo emulation not implemented, q to proceed\n");
-#endif /* DEBUG */
-    } else {
-      error("Not cgfour or bwtwo, q to attempt to proceed");
-    }
-    printf("initdisplay: Unsupported FBreal_type %d\n", FBattr.real_type);
-    DisplayType = (my_screen.fb_type) << 3;
-    /* try to muddle on */
-  }
-#else /* DISPLAYBUFFER is defined, then: */
-  DisplayRegion68k_end_addr = DisplayRegion68k + DisplayRasterWidth * displayheight;
-  if (my_screen.fb_type == FBTYPE_SUN2BW) /* real or emulated bwtwo */
-    switch (FBattr.real_type) {
-      case FBTYPE_SUN4COLOR: { /* need to clear overlay plane */
-        DisplayType = SUN4COLOR;
-        ColorFb = pr_open("/dev/fb");
-        pr_available_plane_groups(ColorFb, sizeof(groups), groups);
-        if (groups[PIXPG_OVERLAY] && groups[PIXPG_OVERLAY_ENABLE]) {
-          pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-          pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_CLR, 0, 0, 0);
-          pr_set_plane_group(ColorFb, PIXPG_8BIT_COLOR);
-        }
-        ColorDisplayPixrect = ColorFb;
-        break;
-      }
-
-      default: ColorDisplayPixrect = pr_open("/dev/fb"); break;
-    }
-
-  else if (my_screen.fb_type == FBTYPE_SUN4COLOR) { /* cg3 or cg6 */
-    switch (FBattr.real_type) {
-      case FBTYPE_SUN3COLOR: /* cg3 */
-                             /*	DisplayType = SUN3COLOR; */
-        DisplayType = (FBattr.real_type) << 3;
-        break;
-      case FBTYPE_SUNFAST_COLOR: /* cg6 */
-                                 /*	DisplayType = SUNFASTCOLOR; */
-        DisplayType = (FBattr.real_type) << 3;
-        break;
-      default: /* unknown display */ DisplayType = (FBattr.real_type) << 3; break;
-    } /* end switch */
-    ColorDisplayPixrect = pr_open("/dev/fb");
-  } /* end else if() */
-
-  else
-    ColorDisplayPixrect = pr_open("/dev/fb");
-  DisplayRegionPixrect = mem_point(displaywidth, displayheight, 1, display_addr);
-
-#ifdef DEBUG
-  pr_getcolormap(ColorDisplayPixrect, 0, 2, oldred, oldgreen, oldblue);
-#endif /* DEBUG */
-  DBPRINT(("Color map for color pixrect:\n  0:  R: %d, G: %d, B: %d\n  1:  R: %d, G: %d, B: %d\n",
-           oldred[0], oldgreen[0], oldblue[0], oldred[1], oldgreen[1], oldblue[1]));
-  DBPRINT(("Color depth = %d.\n", ColorDisplayPixrect->pr_depth));
-  pr_putcolormap(ColorDisplayPixrect, 1, 1, &black, &black, &black);
-  pr_putcolormap(ColorDisplayPixrect, 0, 1, &white, &white, &white);
-  pr_putcolormap(ColorDisplayPixrect, 255, 1, &black, &black, &black);
-  pr_putcolormap(ColorDisplayPixrect, (1 << ColorDisplayPixrect->pr_depth) - 1, 1, &black, &black,
-                 &black);
-#endif
-
-  DisplayLockArea.wl_rect.r_width = displaywidth;
-  DisplayLockArea.wl_rect.r_height = displayheight;
-
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   DisplayType = SUN2BW;
@@ -504,25 +202,6 @@ void init_display2(DLword *display_addr, int display_max)
   DBPRINT(("        length : 0x%x\n", DisplayByteSize));
   DBPRINT(("        pg size: 0x%x\n", getpagesize()));
 
-#ifdef SUNDISPLAY
-#ifndef DISPLAYBUFFER
-  mmapstat = (int)mmap(DisplayRegion68k, DisplayByteSize, PROT_READ | PROT_WRITE,
-#ifdef OS4
-                       MAP_FIXED |
-#endif
-                           MAP_SHARED,
-                       FrameBufferFd, 0);
-
-  DBPRINT(("after mmap: 0x%x\n", mmapstat));
-
-  if (mmapstat == -1) {
-    perror("init_display: ERROR at mmap system call\n");
-    exit(0);
-  }
-#endif /* ifndef DISPLAYBUFFER */
-
-  DBPRINT(("after mem_point\n"));
-#endif /* SUNDISPLAY */
 
 #ifdef DOS
   (currentdsp->cleardisplay)(currentdsp);
@@ -532,11 +211,6 @@ void init_display2(DLword *display_addr, int display_max)
 
   DBPRINT(("after clear_display()\n"));
 
-#if defined(SUNDISPLAY) && !defined(NOPIXRECT)
-  /* initialize pixrect used in pilotbitblt */
-  SrcePixRect = mem_point(0, 0, 1, NULL);
-  DestPixRect = mem_point(0, 0, 1, NULL);
-#endif
 
   DBPRINT(("exiting init_display\n"));
 }
@@ -549,45 +223,12 @@ void init_display2(DLword *display_addr, int display_max)
 /*									*/
 /************************************************************************/
 void display_before_exit() {
-#ifdef SUNDISPLAY
-  union wait status;
-#endif /* SUNDISPLAY */
 
 #ifdef TRUECOLOR
   truecolor_before_exit();
 #endif /* TRUECOLOR */
 
   clear_display();
-#ifdef SUNDISPLAY
-  /*    win_remove( LispWindowFd ); */
-  win_screendestroy(LispWindowFd);
-#ifdef KBINT
-  int_io_close(LispWindowFd);
-#endif
-  close(LispWindowFd);
-
-  if (Win_security_p) {
-    switch (vfork()) {
-      case -1: /* Error */ (void)fprintf(stderr, "display_before_exit: Fork failed.\n"); exit(1);
-
-      case 0: /* Child */
-        (void)execl(SV_RELEASE, "sv_release", 0);
-        /* should not return */
-        (void)fprintf(stderr, "display_before_exit: exec for sv_release failed\n");
-        exit(1);
-
-      default: /* Parent */
-        /* do nothing */
-        break;
-    }
-    (void)wait(&status);
-    if (status.w_retcode != 0) {
-      (void)fprintf(stderr, "display_before_raid: failed to set ownership of win devices\n");
-      exit(1);
-    }
-  }
-
-#endif /* SUNDISPLAY */
 
 #if defined(XWINDOW) || defined(DOS)
   (currentdsp->device.exit)(currentdsp);
@@ -625,12 +266,6 @@ in_display_segment(baseaddr)
 /************************************************************************/
 
 void flush_display_buffer() {
-#ifdef SUNDISPLAY
-#ifdef DISPLAYBUFFER
-  pr_rop(ColorDisplayPixrect, 0, 0, displaywidth, displayheight, COPY_PIXRECT_TO_COLOR,
-         DisplayRegionPixrect, 0, 0);
-#endif /* DISPLAYBUFFER */
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   (currentdsp->bitblt_to_screen)(currentdsp, DisplayRegion68k, currentdsp->Visible.x,
@@ -662,13 +297,6 @@ void flush_display_buffer() {
 
 void flush_display_region(int x, int y, int w, int h)
 {
-#ifdef SUNDISPLAY
-#ifdef DISPLAYBUFFER
-
-  pr_rop(ColorDisplayPixrect, x, y, w, h, COPY_PIXRECT_TO_COLOR, DisplayRegionPixrect, x, y);
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
 #if (defined(XWINDOW) || defined(DOS))
   TPRINT(("Enter flush_display_region x=%d, y=%d, w=%d, h=%d\n", x, y, w, h));
@@ -712,13 +340,6 @@ void flush_display_lineregion(UNSIGNED x, DLword *ybase, UNSIGNED w, UNSIGNED h)
 {
   int y;
   y = ((DLword *)ybase - DisplayRegion68k) / DLWORD_PERLINE;
-#ifdef SUNDISPLAY
-#ifdef DISPLAYBUFFER
-
-  pr_rop(ColorDisplayPixrect, x, y, w, h, COPY_PIXRECT_TO_COLOR, DisplayRegionPixrect, x, y);
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
 #if (defined(XWINDOW) || defined(DOS))
   TPRINT(("Enter flush_display_lineregion x=%d, y=%d, w=%d, h=%d\n", x, y, w, h));
@@ -751,9 +372,7 @@ void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, UNSIGNED w, UNSI
   y = baseoffset / DLWORD_PERLINE;
   x = bitoffset + (BITSPERWORD * (baseoffset - (DLWORD_PERLINE * y)));
 
-#if (defined(SUNDISPLAY) && defined(DISPLAYBUFFER))
-  pr_rop(ColorDisplayPixrect, x, y, w, h, COPY_PIXRECT_TO_COLOR, DisplayRegionPixrect, x, y);
-#elif (defined(XWINDOW) || defined(DOS))
+#if   (defined(XWINDOW) || defined(DOS))
   TPRINT(("Enter flush_display_ptrregion\n x=%d, y=%d, w=%d, h=%d\n", x, y, w, h));
   (currentdsp->bitblt_to_screen)(currentdsp, DisplayRegion68k, x, y, w, h);
   TPRINT(("Exit flush_display_ptrregion\n"));

--- a/src/kbdsubrs.c
+++ b/src/kbdsubrs.c
@@ -22,11 +22,6 @@
 #include <sys/select.h>
 #endif /* DOS */
 
-#ifdef SUNDISPLAY
-#include <sundev/kbd.h>
-#include <sundev/kbio.h>
-#include <sunwindow/window_hs.h>
-#endif /* SUNDISPLAY */
 
 #include "lispemul.h"
 
@@ -55,9 +50,6 @@ extern DspInterface currentdsp;
  *
  ****************************************************/
 
-#ifdef SUNDISPLAY
-extern struct screen LispScreen;
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
 #include <X11/Xlib.h>
@@ -72,17 +64,13 @@ void KB_enable(LispPTR *args) /* args[0] :	ON/OFF flag
                                      */
 {
   if (args[0] == ATOM_T) {
-#ifdef SUNDISPLAY
-    FD_SET(LispWindowFd, &LispReadFds);
-#elif XWINDOW
+#if   XWINDOW
     enable_Xkeyboard(currentdsp);
 #elif DOS
     (currentkbd->device.enter)(currentkbd);
 #endif /* DOS */
   } else if (args[0] == NIL) {
-#ifdef SUNDISPLAY
-    FD_CLR(LispWindowFd, &LispReadFds);
-#elif XWINDOW
+#if   XWINDOW
     disable_Xkeyboard(currentdsp);
 #elif DOS
     (currentkbd->device.exit)(currentkbd);
@@ -116,28 +104,7 @@ void KB_beep(LispPTR *args) /* args[0] :	ON/OFF flag
                                    * args[1] :	frequency
                                    */
 {
-#ifdef SUNDISPLAY
-  int keycommand;
-
-  /*	belltime.tv_usec = args[1] & 0xffff;
-          win_bell(LispWindowFd, belltime, 0);
-  */
-  if ((LispKbdFd = open(LispScreen.scr_kbdname, O_RDWR)) == -1)
-    fprintf(stderr, "can't open %s, errno=%d\n", LispScreen.scr_kbdname, errno);
-
-  if (args[0] == ATOM_T) {
-    keycommand = KBD_CMD_BELL; /* Turn on the bell */
-    if (ioctl(LispKbdFd, KIOCCMD, &keycommand) == -1)
-      fprintf(stderr, "Error at ioctl errno =%d\n", errno);
-  } else {
-    keycommand = KBD_CMD_NOBELL; /* Turn off the bell */
-    if (ioctl(LispKbdFd, KIOCCMD, &keycommand) == -1)
-      fprintf(stderr, "Error at ioctl errno =%d\n", errno);
-  }
-
-  close(LispKbdFd);
-
-#elif XWINDOW
+#if   XWINDOW
   if (args[0] == ATOM_T) beep_Xkeyboard(currentdsp);
 #elif DOS
   if (args[0] == ATOM_T) {

--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -12,15 +12,6 @@
 
 #include <stdio.h>
 
-#if defined(COLOR) && !defined(NOPIXRECT)
-#include <sunwindow/window_hs.h>
-#include <sunwindow/cms.h>
-#include <sunwindow/win_ioctl.h>
-#include <pixrect/pixrect_hs.h>
-#include <sun/fbio.h>
-#include <pixrect/pr_planegroups.h>
-#include <sys/mman.h>
-#endif /* COLOR && !NOPIXRECT */
 
 #include <sys/ioctl.h>
 #include <sys/types.h>

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -482,9 +482,6 @@ extern struct cursor CurrentCursor;
 void flip_cursorbar(int n)
 {
   GETWORD(EmCursorBitMap68K + n) = ~(GETWORD(EmCursorBitMap68K + n));
-#ifdef SUNDISPLAY
-  win_setcursor(LispWindowFd, &CurrentCursor);
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   /* JDS 011213 When using current_hot_y, remember fn does 15-it! */

--- a/src/main.c
+++ b/src/main.c
@@ -517,9 +517,6 @@ int main(int argc, char *argv[])
 
   /* Get OS message to ~/lisp.log and print the message to prompt window */
   if (!for_makeinit) {
-#ifdef SUNDISPLAY
-    mess_init();
-#endif /* SUNDISPLAY */
 
     init_keyboard(0); /* can't turn on the keyboard yet or you will die
                          in makeinit.  Pilotbitblt will turn it on if

--- a/src/misc7.c
+++ b/src/misc7.c
@@ -32,15 +32,6 @@
 #include "bbtsubdefs.h"
 #include "initdspdefs.h"
 
-#ifdef SUNDISPLAY
-#include <sunwindow/window_hs.h>
-#include <sunwindow/win_ioctl.h>
-
-#include <suntool/sunview.h>
-#include <signal.h>
-#include <sunwindow/cms_mono.h>
-#include <suntool/canvas.h>
-#endif
 
 /*************************************************/
 /*  Possible operation fields for FBITMAPBIT     */
@@ -78,9 +69,6 @@ LispPTR N_OP_misc7(LispPTR arg1, LispPTR arg2, LispPTR arg3, LispPTR arg4, LispP
   DBPRINT(("MISC7 args OK.\n"));
 
   displayflg = n_new_cursorin(base, x, (heightminus1 - y), 1, 1);
-#ifdef SUNDISPLAY
-  if (displayflg) HideCursor;
-#endif /* SUNDISPLAY */
 
 /* Bitmaps use a positive integer coordinate system with the lower left
    corner pixel at coordinate (0, 0). Storage is allocated in 16-bit words
@@ -100,15 +88,6 @@ LispPTR N_OP_misc7(LispPTR arg1, LispPTR arg2, LispPTR arg3, LispPTR arg4, LispP
   default: GETWORDBASEWORD(base, offset) = bmdata | bmmask;
   };
 
-#ifdef SUNDISPLAY
-#ifdef DISPLAYBUFFER
-  if (in_display_segment(base)) {
-    /* NB: base + offset doesn't need WORDPTR() wrapper */
-    flush_display_ptrregion(base + offset, 0, 16, 1);
-  }
-#endif
-  if (displayflg) ShowCursor;
-#endif /* SUNDISPLAY */
 
 #ifdef XWINDOW
   if (in_display_segment(base)) {

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -135,17 +135,10 @@ v filename              Save the virtual memory on the filename(Not Bootable)
 
 */
 /************************************************************************/
-#ifndef NOPIXRECT
-extern int black, white;
-extern struct pixrect *ColorDisplayPixrect, *DisplayRegionPixrect;
-#endif /* NOPIXRECT */
 
 extern int DisplayRasterWidth;
 extern unsigned int LispWindowFd, LispKbdFd;
 extern fd_set LispReadFds;
-#ifndef NOPIXRECT
-extern struct pixrect *CursorBitMap, *InvisibleCursorBitMap;
-#endif /* NOPIXRECT */
 extern struct cursor CurrentCursor, InvisibleCursor;
 extern struct screen LispScreen;
 extern int displaywidth, displayheight;

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -35,20 +35,6 @@
 #include <sys/select.h>
 #endif /* DOS */
 
-#ifdef SUNDISPLAY
-#include <sundev/kbd.h>
-#include <sundev/kbio.h>
-#include <errno.h>
-#ifndef NOPIXRECT
-#include <sunwindow/window_hs.h>
-#include <sunwindow/win_ioctl.h>
-#include <pixrect/pixrect_hs.h>
-#include <sunwindow/win_cursor.h>
-#include <sunwindow/cms.h>
-#include <sys/mman.h>
-extern int Win_security_p;
-#endif /* NOPIXRECT */
-#endif /* SUNDISPLAY */
 
 #ifdef OS5
 #include <stropts.h>
@@ -861,17 +847,8 @@ LispPTR uraid_commands() {
 extern struct pixrect *ColorDisplayPixrect, *DisplayRegionPixrect;
 #endif
 
-#ifdef SUNDISPLAY
-#define SV_ACQUIRE "/bin/sunview1/sv_acquire"
-#define SV_RELEASE "/bin/sunview1/sv_release"
-#endif /* SUNDISPLAY */
 
 int device_before_raid() {
-#ifdef SUNDISPLAY
-  int size;
-  int keytrans;
-  union wait status;
-#endif /* SUNDISPLAY */
 #ifdef XWINDOW
   sigset_t signals;
 #endif
@@ -885,12 +862,6 @@ int device_before_raid() {
   sigprocmask(SIG_UNBLOCK, &signals, NULL);
 #endif
 
-#ifdef SUNDISPLAY
-  win_setcursor(LispWindowFd, &InvisibleCursor);
-#ifdef KBINT
-  int_io_close(LispWindowFd);
-#endif
-#endif /* SUNDISPLAY */
 
 #ifdef MAIKO_ENABLE_ETHERNET
 #ifdef ETHERINT
@@ -903,96 +874,6 @@ int device_before_raid() {
   int_io_close(RS232C_Fd);
 #endif
 
-#ifdef SUNDISPLAY
-  mess_reset(); /* turn off console-msg handling */
-
-#ifdef FX_AR_124
-  /* For AR 124. Type4 driver bug?? by m.matsuda */
-  {
-    long i;
-    for (i = 0; i < 900000; i++)
-      ;
-  }
-#endif /*  FX_AR_124 */
-
-  if ((LispKbdFd = open(LispScreen.scr_kbdname, O_RDWR)) == -1) {
-    fprintf(stderr, "can't open %s\n", LispScreen.scr_kbdname);
-    return (-1);
-  }
-
-  keytrans = TR_EVENT; /* keyboard encodes key */
-  if (ioctl(LispKbdFd, KIOCTRANS, &keytrans) == -1) {
-    fprintf(stderr, "Error at ioctl errno =%d\n", errno);
-    return (-1);
-  }
-  close(LispKbdFd);
-  close(LispWindowFd);
-
-#ifdef TRUECOLOR
-  truecolor_before_raid();
-#endif /* TRUECOLOR */
-
-#ifndef DISPLAYBUFFER
-  size = ((displaywidth * displayheight / 8 + (getpagesize() - 1)) & -getpagesize());
-
-  if ((HideDisp68k = malloc(size)) == 0) {
-    printf("can't malloc hide space\n");
-    return (-1);
-  }
-
-  copy_region(DisplayRegion68k, HideDisp68k, DisplayRasterWidth, displayheight);
-#endif /* DISPLAYBUFFER */
-
-#ifdef COLOR
-  save_colormap();
-
-#ifndef DISPLAYBUFFER
-  if (Inited_Color) {
-#else
-  if (MonoOrColor == COLOR_SCREEN) {
-#endif /* DISPLAYBUFFER */
-
-    /* save color image */
-    size =
-        ((displaywidth * displayheight + (getpagesize() - 1)) & -getpagesize()); /* 8 bit depth */
-    if ((HideColorDisp68k = malloc(size)) == 0) {
-      printf("can't malloc hide space\n");
-      return (-1);
-    }
-    copy_region(ColorDisplayRegion68k, HideColorDisp68k, DisplayRasterWidth * 8, displayheight);
-  }    /* end if(MonoOrColor) */
-#endif /* COLOR */
-
-  clear_display();
-
-#ifdef DISPLAYBUFFER
-  pr_close(ColorDisplayPixrect);
-  close(FrameBufferFd);
-#endif
-
-  if (Win_security_p) {
-    switch (vfork()) {
-      case -1: /* Error */ (void)fprintf(stderr, "display_before_exit: Fork failed.\n"); exit(1);
-
-      case 0: /* Child */
-        (void)execl(SV_RELEASE, "sv_release", NULL);
-        /* should not return */
-        (void)fprintf(stderr, "display_before_exit: exec for sv_release failed\n");
-        exit(1);
-
-      default: /* Parent */
-        /* do nothing */
-        break;
-    }
-    (void)wait(&status); /* child dies after changing 16 */
-
-    if (status.w_retcode != 0) {
-      (void)fprintf(stderr, "device_before_raid: failed to set ownership of win devices\n");
-      exit(1);
-    }
-  }
-
-#endif /* SUNDISPLAY */
 
 #if defined(XWINDOW) || defined(DOS)
   (currentdsp->cleardisplay)(currentdsp);
@@ -1103,9 +984,6 @@ int device_after_raid() {
 
   int_init();
 
-#ifdef SUNDISPLAY
-  FD_SET(LispWindowFd, &LispReadFds);
-#endif /* SUNDISPLAY */
 
 #ifdef MAIKO_ENABLE_ETHERNET
   FD_SET(ether_fd, &LispReadFds);
@@ -1145,107 +1023,6 @@ int device_after_raid() {
 
 static int re_init_display(int lisp_display_addr, int display_max)
 {
-#ifdef SUNDISPLAY
-  int mmapstat, size;
-  struct pixrect *ColorFb;
-  extern struct pixrect *ColorDisplayPixrect, *DisplayRegionPixrect;
-  extern int DisplayType;
-
-  union wait status;
-
-  if (Win_security_p) {
-    switch (vfork()) {
-      case -1: /* Error */ (void)fprintf(stderr, "re_init_display: Fork failed.\n"); exit(1);
-
-      case 0: /* Child */
-        (void)execl(SV_ACQUIRE, "sv_acquire", "0", "256", "250", NULL);
-        /* should not return */
-        (void)fprintf(stderr, "re_init_display: exec for sv_acquire failed\n");
-        exit(1);
-
-      default: /* Parent */
-        /* do nothing */
-        break;
-    }
-    (void)wait(&status); /* child dies after changing 6 */
-
-    if (status.w_retcode != 0) {
-      (void)fprintf(stderr, "re_init_display: failed to set ownership of win devices\n");
-      exit(1);
-    }
-  }
-
-  mess_init();
-  if ((LispWindowFd = win_screennew(&LispScreen)) == -1) {
-    fprintf(stderr, "init_display: can't create LispWindow\n");
-    return (-1);
-  } else {
-#ifdef KBINT
-    int_io_open(LispWindowFd);
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
-
-#ifdef FX_AR_124
-    /* For AR 124. Type4 driver bug?? by m.matsuda */
-    {
-      long i;
-      for (i = 0; i < 900000; i++)
-        ;
-    }
-#endif /* FX_AR_124 */
-
-#endif
-  }
-
-#ifndef DISPLAYBUFFER
-  /* for CGFOUR dev */
-  if (DisplayType == SUN4COLOR) {
-    ColorFb = pr_open("/dev/fb");
-    pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-    pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_SET, 0, 0, 0);
-    pr_set_plane_group(ColorFb, PIXPG_OVERLAY);
-  }
-#else  /* DISPLAYBUFFER is T */
-/*  ColorDisplayPixrect = pr_open("/dev/fb");
-    pr_putcolormap(ColorDisplayPixrect, 1, 1, &black, &black, &black);
-    pr_putcolormap(ColorDisplayPixrect, 0, 1, &white, &white, &white);
-    pr_putcolormap(ColorDisplayPixrect, 255, 1, &black, &black, &black);
-    pr_putcolormap(ColorDisplayPixrect,
-                   (1<<ColorDisplayPixrect->pr_depth)-1, 1,
-                   &black, &black, &black);
-***/
-#endif /* DISPLAYBUFFER */
-
-  init_cursor();
-
-#ifndef DISPLAYBUFFER
-  size = ((displaywidth * displayheight / 8 + (getpagesize() - 1)) & -getpagesize());
-  mmapstat = (int)mmap(DisplayRegion68k, size, PROT_READ | PROT_WRITE,
-#ifdef OS4
-                       MAP_FIXED |
-#endif /* OS4 */
-
-                           MAP_SHARED,
-                       FrameBufferFd, 0);
-
-  if (mmapstat == -1) {
-    fprintf(stderr, "re_init_display: ERROR at mmap system call\n");
-    fprintf(stderr, "errno = %d\n\n", errno);
-    return (0);
-  }
-
-  copy_region(HideDisp68k, DisplayRegion68k, DisplayRasterWidth, displayheight);
-
-  free(HideDisp68k);
-#endif /* DISPLAYBUFFER */
-
-#ifdef DISPLAYBUFFER
-  ColorDisplayPixrect = pr_open("/dev/fb");
-  flush_display_buffer();
-/*     refresh_CG6; */
-
-#endif /* DISPLAYBUFFER */
-
-#endif /* SUNDISPLAY */
 
   return (0);
 }
@@ -1254,163 +1031,6 @@ static int re_init_display(int lisp_display_addr, int display_max)
 
 static int re_init_display(int lisp_display_addr, int display_max)
 {
-#ifdef SUNDISPLAY
-  int mmapstat, size;
-  struct pixrect *ColorFb;
-  struct pixrect *color_source;
-  extern int DisplayType;
-  union wait status;
-
-  if (Win_security_p) {
-    switch (vfork()) {
-      case -1: /* Error */ (void)fprintf(stderr, "re_init_display: Fork failed.\n"); exit(1);
-
-      case 0: /* Child */
-        (void)execl(SV_ACQUIRE, "sv_acquire", "0", "256", "250", NULL);
-        /* should not return */
-        (void)fprintf(stderr, "re_init_display: exec for sv_acquire failed\n");
-        exit(1);
-
-      default: /* Parent */
-        /* do nothing */
-        break;
-    }
-    (void)wait(&status); /* child dies after changing 6 */
-
-    if (status.w_retcode != 0) {
-      (void)fprintf(stderr, "re_init_display: failed to set ownership of win devices\n");
-      exit(1);
-    }
-  }
-
-  mess_init();
-  if ((LispWindowFd = win_screennew(&LispScreen)) == -1) {
-    fprintf(stderr, "init_display: can't create LispWindow\n");
-    return (-1);
-  } else {
-#ifdef KBINT
-    int_io_open(LispWindowFd);
-    fcntl(LispWindowFd, F_SETFL, fcntl(LispWindowFd, F_GETFL, 0) | O_NONBLOCK);
-#endif
-  }
-
-#ifdef DISPLAYBUFFER
-  if ((FrameBufferFd = open(LispScreen.scr_fbname, 2)) == -1) {
-    perror("init_display: can't open FrameBuffer\n");
-    exit(-1);
-  }
-#endif /* DISPLAYBUFFER */
-
-  restore_colormap();
-
-  if (MonoOrColor == MONO_SCREEN) {
-#ifndef DISPLAYBUFFER
-    /* for CGFOUR dev */
-    if (DisplayType == SUN4COLOR) {
-      ColorFb = pr_open("/dev/fb");
-      pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-      pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_SET, 0, 0, 0);
-      pr_set_plane_group(ColorFb, PIXPG_OVERLAY);
-    }
-#else  /* DISPLAYBUFFER is T */
-/*  ColorDisplayPixrect = pr_open("/dev/fb");
-    pr_putcolormap(ColorDisplayPixrect, 1, 1, &black, &black, &black);
-    pr_putcolormap(ColorDisplayPixrect, 0, 1, &white, &white, &white);
-    pr_putcolormap(ColorDisplayPixrect, 255, 1, &black, &black, &black);
-    pr_putcolormap(ColorDisplayPixrect,
-                   (1<<ColorDisplayPixrect->pr_depth)-1, 1,
-                   &black, &black, &black);
-***/
-#endif /* DISPLAYBUFFER */
-
-    init_cursor();
-
-#ifndef DISPLAYBUFFER
-    size = ((displaywidth * displayheight / 8 + (getpagesize() - 1)) & -getpagesize());
-
-    mmapstat = (int)mmap(DisplayRegion68k, size, PROT_READ | PROT_WRITE,
-#ifdef OS4
-                         MAP_FIXED |
-#endif /* OS4 */
-
-                             MAP_SHARED,
-                         FrameBufferFd, 0);
-    if (Inited_Color)
-      mmapstat = (int)mmap(ColorDisplayRegion68k, Dispcolorsize, PROT_READ | PROT_WRITE,
-#ifdef OS4
-                           MAP_FIXED |
-#endif /* OS4 */
-
-                               MAP_SHARED,
-                           FrameBufferFd, 0x40000);
-
-    if (mmapstat == -1) {
-      fprintf(stderr, "re_init_display: ERROR at mmap system call\n");
-      fprintf(stderr, "errno = %d\n\n", errno);
-      return (0);
-    }
-    /* restore mono image */
-    copy_region(HideDisp68k, DisplayRegion68k, DisplayRasterWidth, displayheight);
-
-    free(HideDisp68k);
-
-    if (Inited_Color) { /* restore color image */
-      copy_region(HideColorDisp68k, ColorDisplayRegion68k, DisplayRasterWidth * 8, displayheight);
-      free(HideColorDisp68k);
-    } /* end if( Inited_Color ) */
-#endif /* DISPLAYBUFFER */
-
-#ifdef DISPLAYBUFFER
-    ColorDisplayPixrect = pr_open("/dev/fb");
-    flush_display_buffer();
-/*     refresh_CG6; */
-#endif /* DISPLAYBUFFER */
-
-  } else { /* MonoOrColor is COLOR_SCREEN */
-    ColorFb = pr_open("/dev/fb");
-#ifdef DISPLAYBUFFER
-    ColorDisplayPixrect = ColorFb;
-#endif /* DISPLAYBUFFER */
-
-    color_source = mem_point(displaywidth, displayheight, 8, ColorDisplayRegion68k);
-    pr_rop(ColorFb, 0, 0, displaywidth, displayheight, PIX_SRC, color_source, 0, 0);
-#ifndef DISPLAYBUFFER
-    pr_set_plane_group(ColorFb, PIXPG_OVERLAY_ENABLE);
-    pr_rop(ColorFb, 0, 0, ColorFb->pr_width, ColorFb->pr_height, PIX_CLR, 0, 0, 0);
-#endif /* DISPLAYBUFFER */
-
-    pr_set_plane_group(ColorFb, PIXPG_8BIT_COLOR);
-    init_cursor();
-    mmapstat = (int)mmap(ColorDisplayRegion68k, Dispcolorsize, PROT_READ | PROT_WRITE,
-#ifdef OS4
-                         MAP_FIXED |
-#endif
-                             MAP_SHARED,
-                         FrameBufferFd, 0x40000);
-    if (mmapstat == -1) {
-      perror("cgfour_init_color_display: ERROR at mmap system call\n");
-      error(
-          "cgfour_init_color_display: ERROR at mmap system call\n You may be able to continue by "
-          "typing 'q'");
-      /*                  printf("MMAP FAIL:BMBASE=0x%x\nNATIVE:= 0x%x\nLISPBASEN:= 0x%x\n",
-                              color_bitmapbase,ColorDisplayRegion68k,Lisp_world);
-      */
-      return (NIL);
-    } /* end if(mmapstat) */
-
-#ifndef DISPLAYBUFFER
-    /* restore mono image */
-    copy_region(HideDisp68k, DisplayRegion68k, DisplayRasterWidth, displayheight);
-
-    free(HideDisp68k);
-#endif /* DISPLAYBUFFER */
-
-    /* restore coloe image */
-    copy_region(HideColorDisp68k, ColorDisplayRegion68k, DisplayRasterWidth * 8, displayheight);
-
-    free(HideColorDisp68k);
-  } /* end if(MonoOrColor) */
-#endif /* SUNDISPLAY */
 
   return (0);
 }

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -36,9 +36,6 @@
 #define alarm(x) 1
 #endif /* DOS */
 
-#if defined(SUNDISPLAY) && defined(OLD_CURSOR)
-#include <sunwindow/win_cursor.h>
-#endif
 
 #include "hdw_conf.h"
 #include "lispemul.h"
@@ -316,9 +313,6 @@ LispPTR vmem_save(char *sysout_file_name)
   register int i;
   char tempname[MAXPATHLEN];
   register int rval;
-#ifdef SUNDISPLAY
-  /* DLword *bmptr; */
-#endif
 #ifndef DOS
   extern int ScreenLocked;
   extern DLword *EmCursorX68K;
@@ -329,17 +323,7 @@ LispPTR vmem_save(char *sysout_file_name)
 
 /* remove cursor image from screen */
 
-#ifdef SUNDISPLAY
-#ifdef OLD_CURSOR
-  win_setcursor(LispWindowFd, &InvisibleCursor);
-#else
-  ScreenLocked = T;
-  taking_mouse_down();
-/*	bmptr = EmCursorBitMap68K;
-    EmCursorBitMap68K= NullCursor;*/
-#endif /* OLD_CURSOR */
-
-#elif DOS
+#if   DOS
   /*  For DOS, must also take the mouse cursor away (it's  */
   /*  written into the display-region bitmap).	     */
   currentdsp->device.locked++;
@@ -512,17 +496,7 @@ LispPTR vmem_save(char *sysout_file_name)
   }
 
 /* restore cursor image to screen */
-#ifdef SUNDISPLAY
-#ifdef OLD_CURSOR
-  win_setcursor(LispWindowFd, &CurrentCursor);
-#else
-  ScreenLocked = T;
-  /*EmCursorBitMap68K = bmptr ;*/
-  taking_mouse_up(*EmCursorX68K, *EmCursorY68K);
-  ScreenLocked = NIL;
-#endif /* OLD_CURSOR */
-
-#elif DOS
+#if   DOS
   /* Must also put the mouse back. */
   (currentdsp->mouse_visible)(IOPage68K->dlmousex, IOPage68K->dlmousey);
   currentdsp->device.locked--;


### PR DESCRIPTION
Initial cleanup removing all code that was #ifdef'd for SUNDISPLAY.
Other SunWindows dependent code may also be removable in the future.