### PR TITLE
Fix errors preventing the use of -DDTDDEBUG for mkcell.c

### DIFF
--- a/inc/testtooldefs.h
+++ b/inc/testtooldefs.h
@@ -33,6 +33,7 @@ LispPTR *MakeAtom68k(char *string);
 void GETTOPVAL(char *string);
 void all_stack_dump(DLword start, DLword end, DLword silent);
 void dtd_chain(DLword type);
+void check_dtd_chain(DLword type);
 void Trace_FNCall(int numargs, int atomindex, int arg1, LispPTR *tos);
 void Trace_APPLY(int atomindex);
 #endif

--- a/src/mkcell.c
+++ b/src/mkcell.c
@@ -41,6 +41,9 @@
 #include "allocmdsdefs.h"
 #include "commondefs.h"
 #include "gchtfinddefs.h"
+#ifdef DTDDEBUG
+#include "testtooldefs.h"
+#endif
 
 static LispPTR oldoldfree;
 static LispPTR oldfree;

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -1241,8 +1241,6 @@ void dtd_chain(DLword type) {
 
 } /*  dtd_chain end **/
 
-#ifdef DTDDEBUG
-
 void check_dtd_chain(DLword type)
 {
   register LispPTR next, onext;
@@ -1269,8 +1267,6 @@ void check_dtd_chain(DLword type)
     next &= POINTERMASK;
   }
 }
-
-#endif
 
 /************************************************************************/
 /*									*/


### PR DESCRIPTION
Preliminary step prior to likely changing the sanity check that appears to be too aggressive in detecting free-list pointers that are "too big" (now that we're regularly running with 256 MB vmem)