### PR TITLE
Replace uses of atoi() with strtol() or stroul() as appropriate

### DIFF
--- a/inc/lispver1.h
+++ b/inc/lispver1.h
@@ -39,7 +39,7 @@
 	NumericStringP(vp, YES, NO);					\
        NO: *vp = 0;							\
        YES:								\
-	if ((*vp)) ver = atoi(vp);					\
+	if ((*vp)) ver = strtol(vp, (char **)NULL, 10);                \
 	else ver = -1;							\
       }									\
       else ver = -1;							\

--- a/inc/lispver2.h
+++ b/inc/lispver2.h
@@ -8,7 +8,7 @@
 									\
 	register char	*lv_cp;						\
 	register char	*lv_vp;						\
-	register int	lv_ver;						\
+	register unsigned lv_ver;					\
 	char		lv_ver_buf[VERSIONLEN];				\
 									\
 	lv_cp = pathname;						\
@@ -48,12 +48,12 @@
 			/*						\
 			 * Convert the remaining field to digit.	\
 			 */						\
-			lv_ver = atoi(lv_vp + 1);				\
-			if (lv_ver == 0) {					\
+			lv_ver = strtoul(lv_vp + 1, (char **)NULL, 10); \
+			if (lv_ver == 0) {				\
 				/* versionless */			\
 				*lv_vp = 0;				\
 			} else {					\
-				sprintf(lv_ver_buf, ".~%d~", lv_ver);		\
+				sprintf(lv_ver_buf, ".~%u~", lv_ver);	\
 				*lv_vp = 0;				\
 				strcat(pathname, lv_ver_buf);		\
 			}						\
@@ -61,7 +61,7 @@
 									\
 		      NO:						\
 			strcpy(lv_ver_buf, lv_vp + 1);			\
-			strcat(lv_ver_buf, "~");				\
+			strcat(lv_ver_buf, "~");			\
 			*lv_vp++ = '.';					\
 			*lv_vp++ = '~';					\
 			*lv_vp = 0;					\

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -385,9 +385,9 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			*(start - 1) = ';';					\
 			*start = '\0';						\
 			*end = '\0';						\
-			/* call ato i to eliminate leading 0s. */		\
-			ver_no = atoi(start + 1);				\
-			sprintf(ver_buf, "%d", ver_no);				\
+			/* call strtoul() to eliminate leading 0s. */		\
+			ver_no = strtoul(start + 1, (char **)NULL, 10);		\
+			sprintf(ver_buf, "%u", ver_no);				\
 			strcat(pathname, ver_buf);				\
 			goto CONT;						\
 										\
@@ -494,7 +494,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 #define	MAXVERSION		999999999
 
-#define	LASTVERSIONARRAY	(-1)
+#define	LASTVERSIONARRAY	((unsigned) -1)
 #define	VERSIONARRAYLENGTH	200
 
 #define NoFileP(varray)						\

--- a/src/dir.c
+++ b/src/dir.c
@@ -329,7 +329,7 @@ void print_finfo(FINFO *fp)
   if (fp != (FINFO *)NULL) {
     do {
       printf("%s -> ", fp->lname);
-      printf("%d\n", fp->version);
+      printf("%u\n", fp->version);
       fp = fp->next;
     } while (fp != (FINFO *)NULL && fp != sp);
 
@@ -685,7 +685,7 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
       if (*fver == '\0')
         nextp->version = 0;
       else
-        nextp->version = atoi(fver);
+        nextp->version = strtoul(fver, (char **)NULL, 10);
       nextp->ino = sbuf.st_ino;
       nextp->prop->length = (unsigned)sbuf.st_size;
       nextp->prop->wdate = (unsigned)ToLispTime(sbuf.st_mtime);
@@ -948,7 +948,7 @@ static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
       if (*fver == '\0')
         nextp->version = 0;
       else
-        nextp->version = atoi(fver);
+        nextp->version = strtoul(fver, (char **)NULL, 10);
       nextp->ino = sbuf.st_ino;
       n++;
     }
@@ -1399,7 +1399,7 @@ static int trim_finfo(FINFO **fp)
            * Versionless is not linked to any versioned
            * file.
            */
-          sprintf(ver, ";%d", mp->version + 1);
+          sprintf(ver, ";%u", mp->version + 1);
           strcat(sp->lname, ver);
           sp->lname_len = strlen(sp->lname);
           pnum = ++num;
@@ -1527,7 +1527,7 @@ static int trim_finfo_highest(FINFO **fp, int highestp)
            * Versionless is not linked to any versioned
            * file.
            */
-          sprintf(ver, ";%d", mp->version + 1);
+          sprintf(ver, ";%u", mp->version + 1);
           strcat(sp->lname, ver);
           sp->lname_len = strlen(sp->lname);
           /*
@@ -1709,7 +1709,7 @@ static int trim_finfo_version(FINFO **fp, int rver)
            * file.
            */
           if (mp->version + 1 == rver) {
-            sprintf(ver, ";%d", rver);
+            sprintf(ver, ";%u", rver);
             strcat(sp->lname, ver);
             sp->lname_len = strlen(sp->lname);
             /*
@@ -2111,7 +2111,7 @@ LispPTR COM_gen_files(register LispPTR *args)
 
     if (*ver != '\0') {
       highestp = 0;
-      version = atoi(ver);
+      version = strtoul(ver, (char **)NULL, 10);
       if (version > 0) strcpy(ver, "*");
     } else {
       version = 0;

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -59,7 +59,7 @@ extern int Dummy_errno;
 
 typedef struct filename_entry {
   char name[MAXPATHLEN]; /* With version, foo.~3~ or foo */
-  int version_no;
+  unsigned version_no;
 } FileName;
 
 typedef struct current_varray {
@@ -2365,7 +2365,7 @@ LispPTR COM_getfreeblock(register LispPTR *args)
 void separate_version(char *name, char *ver, int checkp)
 {
   register char *start, *end, *cp;
-  register int ver_no;
+  register unsigned ver_no;
   size_t len;
   char ver_buf[VERSIONLEN];
 
@@ -2397,10 +2397,10 @@ void separate_version(char *name, char *ver, int checkp)
         *(start - 1) = '\0';
         *end = '\0';
         /*
-         * Use atoi to eliminate leading 0s.
+         * Use strtoul() to eliminate leading 0s.
          */
-        ver_no = atoi(start + 1);
-        sprintf(ver_buf, "%d", ver_no);
+        ver_no = strtoul(start + 1, (char **)NULL, 10);
+        sprintf(ver_buf, "%u", ver_no);
         strcpy(ver, ver_buf);
         return;
       } else {
@@ -3025,7 +3025,7 @@ static int get_version_array(char *dir, char *file, FileName *varray, CurrentVAr
        * separator_version guarantees ver is a numeric
        * string.
        */
-      svarray->version_no = atoi(ver);
+      svarray->version_no = strtoul(ver, (char **)NULL, 10);
     }
     svarray++;
   }
@@ -3119,7 +3119,7 @@ static int get_version_array(char *dir, char *file, FileName *varray, CurrentVAr
            * separator_version guarantees ver is a numeric
            * string.
            */
-          svarray->version_no = atoi(ver);
+          svarray->version_no = strtoul(ver, (char **)NULL, 10);
         }
         svarray++;
       }
@@ -3263,7 +3263,7 @@ static int maintain_version(char *file, FileName *varray, int forcep)
      * is versioned one higher than the existing highest version.
      */
     FindHighestVersion(varray, entry, max_no);
-    sprintf(ver, "%d", max_no + 1);
+    sprintf(ver, "%u", max_no + 1);
 /*
  * The old file should have the same case name as the versionless
  * file.
@@ -3498,7 +3498,7 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
 {
   char name[MAXPATHLEN], vless[MAXPATHLEN], to_file[MAXPATHLEN];
   char ver[VERSIONLEN], vbuf[VERSIONLEN];
-  register int ver_no, max_no;
+  register unsigned ver_no, max_no;
   int highest_p;
   register FileName *entry;
 
@@ -3528,7 +3528,7 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
        * varray and try to find the file with the specified
        * version.
        */
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       FindSpecifiedVersion(varray, entry, ver_no);
       if (entry != NULL) {
         ConcDirAndName(dir, entry->name, afile);
@@ -3552,7 +3552,7 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
       strcpy(afile, vless);
       return (1);
     } else {
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       if (ver_no == 1) {
         /*
          * Version 1 is specified.  The versionless file is
@@ -3586,13 +3586,13 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
          * link missing versionless file.
          */
         FindHighestVersion(varray, entry, max_no);
-        sprintf(vbuf, "%d", max_no + 1);
+        sprintf(vbuf, "%u", max_no + 1);
         ConcNameAndVersion(vless, vbuf, vfile);
         strcpy(afile, vless);
         return (1);
       } else {
         /* A version is specified. */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindHighestVersion(varray, entry, max_no);
         if (ver_no == max_no + 1) {
           /*
@@ -3601,7 +3601,7 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
            * is dealt with as a version of the link
            * missing versionless file.
            */
-          sprintf(vbuf, "%d", ver_no);
+          sprintf(vbuf, "%u", ver_no);
           ConcNameAndVersion(vless, vbuf, vfile);
           strcpy(afile, vless);
           return (1);
@@ -3640,7 +3640,7 @@ static int get_old(char *dir, FileName *varray, char *afile, char *vfile)
          * varray and try to find the file with the specified
          * version.
          */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindSpecifiedVersion(varray, entry, ver_no);
         if (entry != NULL) {
           ConcDirAndName(dir, entry->name, afile);
@@ -3697,7 +3697,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
 {
   char name[MAXPATHLEN], vless[MAXPATHLEN], to_file[MAXPATHLEN];
   char ver[VERSIONLEN], vbuf[VERSIONLEN];
-  register int ver_no, min_no;
+  register unsigned ver_no, min_no;
   int highest_p;
   register FileName *entry;
 
@@ -3727,7 +3727,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
        * varray and try to find the file with the specified
        * version.
        */
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       FindSpecifiedVersion(varray, entry, ver_no);
       if (entry != NULL) {
         ConcDirAndName(dir, entry->name, afile);
@@ -3751,7 +3751,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
       strcpy(afile, vless);
       return (1);
     } else {
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       if (ver_no == 1) {
         /*
          * Version 1 is specified.  The versionless file is
@@ -3788,7 +3788,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
         return (1);
       } else {
         /* A version is specified. */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindHighestVersion(varray, entry, min_no);
         if (ver_no == min_no + 1) {
           /*
@@ -3797,7 +3797,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
            * is dealt with as a version of the link
            * missing versionless file.
            */
-          sprintf(vbuf, "%d", ver_no);
+          sprintf(vbuf, "%u", ver_no);
           ConcNameAndVersion(vless, vbuf, vfile);
           strcpy(afile, vless);
           return (1);
@@ -3836,7 +3836,7 @@ static int get_oldest(char *dir, FileName *varray, char *afile, char *vfile)
          * varray and try to find the file with the specified
          * version.
          */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindSpecifiedVersion(varray, entry, ver_no);
         if (entry != NULL) {
           ConcDirAndName(dir, entry->name, afile);
@@ -3894,7 +3894,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
 {
   char name[MAXPATHLEN], vless[MAXPATHLEN], to_file[MAXPATHLEN];
   char ver[VERSIONLEN], vbuf[VERSIONLEN];
-  register int ver_no, max_no;
+  register unsigned ver_no, max_no;
   int highest_p;
   register FileName *entry;
 
@@ -3942,7 +3942,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
        * the existing highest version.
        */
       FindHighestVersion(varray, entry, max_no);
-      sprintf(vbuf, "%d", max_no + 1);
+      sprintf(vbuf, "%u", max_no + 1);
       /*
        * We will use the file name of the existing highest
        * versioned file as the name of the new file, so that
@@ -3960,7 +3960,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
        * varray and try to find the file with the specified
        * version.
        */
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       FindSpecifiedVersion(varray, entry, ver_no);
       if (entry != NULL) {
         ConcDirAndName(dir, entry->name, afile);
@@ -3998,7 +3998,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
       strcpy(afile, vfile);
       return (1);
     } else {
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       if (ver_no == 1) {
         /*
          * Version 1 is specified.  The versionless file is
@@ -4034,13 +4034,13 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
          * missing versionless file.
          */
         FindHighestVersion(varray, entry, max_no);
-        sprintf(vbuf, "%d", max_no + 2);
+        sprintf(vbuf, "%u", max_no + 2);
         ConcNameAndVersion(vless, vbuf, vfile);
         strcpy(afile, vfile);
         return (1);
       } else {
         /* A version is specified. */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindHighestVersion(varray, entry, max_no);
         if (ver_no == max_no + 1) {
           /*
@@ -4049,7 +4049,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
            * is dealt with as a version of the link
            * missing versionless file.
            */
-          sprintf(vbuf, "%d", ver_no);
+          sprintf(vbuf, "%u", ver_no);
           ConcNameAndVersion(vless, vbuf, vfile);
           strcpy(afile, vless);
           return (1);
@@ -4097,7 +4097,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
          * new file.
          */
         FindHighestVersion(varray, entry, max_no);
-        sprintf(vbuf, "%d", max_no + 1);
+        sprintf(vbuf, "%u", max_no + 1);
         /*
          * We will use the name of the highest versioned file
          * as the name of the new file.
@@ -4114,7 +4114,7 @@ static int get_new(char *dir, FileName *varray, char *afile, char *vfile)
          * varray and try to find the file with the specified
          * version.
          */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindSpecifiedVersion(varray, entry, ver_no);
         if (entry != NULL) {
           ConcDirAndName(dir, entry->name, afile);
@@ -4188,7 +4188,7 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
 {
   char name[MAXPATHLEN], vless[MAXPATHLEN], to_file[MAXPATHLEN];
   char ver[VERSIONLEN], vbuf[VERSIONLEN];
-  register int ver_no, max_no;
+  register unsigned ver_no, max_no;
   int highest_p;
   register FileName *entry;
 
@@ -4240,7 +4240,7 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
        * varray and try to find the file with the specified
        * version.
        */
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       FindSpecifiedVersion(varray, entry, ver_no);
       if (entry != NULL) {
         ConcDirAndName(dir, entry->name, afile);
@@ -4278,7 +4278,7 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
       strcpy(afile, vless);
       return (1);
     } else {
-      ver_no = atoi(ver);
+      ver_no = strtoul(ver, (char **)NULL, 10);
       if (ver_no == 1) {
         /*
          * Version 1 is specified.  The versionless file is
@@ -4313,13 +4313,13 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
          * link missing versionless file.
          */
         FindHighestVersion(varray, entry, max_no);
-        sprintf(vbuf, "%d", max_no + 1);
+        sprintf(vbuf, "%u", max_no + 1);
         ConcNameAndVersion(vless, vbuf, vfile);
         strcpy(afile, vless);
         return (1);
       } else {
         /* A version is specified. */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindHighestVersion(varray, entry, max_no);
         if (ver_no == max_no + 1) {
           /*
@@ -4328,7 +4328,7 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
            * is dealt with as a version of the link
            * missing versionless file.
            */
-          sprintf(vbuf, "%d", ver_no);
+          sprintf(vbuf, "%u", ver_no);
           ConcNameAndVersion(vless, vbuf, vfile);
           strcpy(afile, vless);
           return (1);
@@ -4384,7 +4384,7 @@ static int get_old_new(char *dir, FileName *varray, char *afile, char *vfile)
          * varray and try to find the file with the specified
          * version.
          */
-        ver_no = atoi(ver);
+        ver_no = strtoul(ver, (char **)NULL, 10);
         FindSpecifiedVersion(varray, entry, ver_no);
         if (entry != NULL) {
           ConcDirAndName(dir, entry->name, afile);

--- a/src/main.c
+++ b/src/main.c
@@ -312,6 +312,7 @@ int main(int argc, char *argv[])
   char *envname;
   extern int TIMER_INTERVAL;
   extern fd_set LispReadFds;
+  int tmpint;
 #ifdef MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE
   if (dld_find_executable(argv[0]) == 0) {
     perror("Name of executable not found.");
@@ -377,18 +378,32 @@ int main(int argc, char *argv[])
     /* -t and -m are undocumented and somewhat dangerous... */
 
     if (!strcmp(argv[i], "-t")) { /**** timer interval	****/
-      if (argc > ++i)
-        TIMER_INTERVAL = atoi(argv[i]);
-      else {
+      if (argc > ++i) {
+        errno = 0;
+        tmpint = strtol(argv[i], (char **)NULL, 10);
+        if (errno == 0 && tmpint > 0) {
+          TIMER_INTERVAL = tmpint;
+        } else {
+          fprintf(stderr, "Bad value for -t (integer > 0)\n");
+          exit(1);
+        }
+      } else {
         fprintf(stderr, "Missing argument after -t\n");
         exit(1);
       }
     }
 
     else if (!strcmp(argv[i], "-m")) { /**** sysout size	****/
-      if (argc > ++i)
-        sysout_size = atoi(argv[i]);
-      else {
+      if (argc > ++i) {
+        errno = 0;
+        tmpint = strtol(argv[i], (char **)NULL, 10);
+        if (errno == 0 && tmpint > 0) {
+          sysout_size = tmpint;
+        } else {
+          fprintf(stderr, "Bad value for -m (integer > 0)\n");
+          exit(1);
+        }
+      } else {
         fprintf(stderr, "Missing argument after -m\n");
         exit(1);
       }
@@ -453,9 +468,16 @@ int main(int argc, char *argv[])
     }
     /* diagnostic flag for big vmem write() calls */
     else if (!strcmp(argv[i], "-xpages")) {
-      if (argc > ++i)
-        maxpages = atoi(argv[i]);
-      else {
+      if (argc > ++i) {
+        errno = 0;
+        tmpint = strtol(argv[i], (char **)NULL, 10);
+        if (errno == 0 && tmpint > 0) {
+          maxpages = tmpint;
+        } else {
+          fprintf(stderr, "Bad value for -xpages (integer > 0)\n");
+          exit(1);
+        }
+      } else {
         fprintf(stderr, "Missing argument after -xpages\n");
         exit(1);
       }

--- a/src/setsout.c
+++ b/src/setsout.c
@@ -99,7 +99,9 @@ int main(int argc, char **argv) {
     printf("setsysout version sysout-name\n");
     return (-1);
   }
-  if ((version = atoi(argv[1])) == 0) {
+  errno = 0;
+  version = (int)strtol(argv[1], (char **)NULL, 10);
+  if (errno || version <= 0) {
     printf("version must be an integer > 0.\n");
     return (-1);
   }

--- a/src/timer.c
+++ b/src/timer.c
@@ -18,6 +18,7 @@
 
 #include "version.h"
 
+#include <errno.h>
 #include <fcntl.h>
 #include <setjmp.h>
 #include <signal.h>
@@ -85,7 +86,7 @@ extern DspInterface currentdsp;
  *	to get Alto time.
  */
 
-int TIMEOUT_TIME; /* For file system timeout */
+int TIMEOUT_TIME = 10; /* For file system timeout, seconds, default 10 */
 
 volatile sig_atomic_t IO_Signalled = FALSE;
 
@@ -710,13 +711,12 @@ static void int_file_init() {
   }
 
   /* Set Timeout period */
-  if ((envtime = getenv("LDEFILETIMEOUT")) == NULL) {
-    TIMEOUT_TIME = 10;
-  } else {
-    if ((timeout_time = atoi(envtime)) > 0)
+  envtime = getenv("LDEFILETIMEOUT");
+  if (envtime != NULL) {
+    errno = 0;
+    timeout_time = (int)strtol(envtime, (char **)NULL, 10);
+    if (errno == 0 && timeout_time > 0)
       TIMEOUT_TIME = timeout_time;
-    else
-      TIMEOUT_TIME = 10;
   }
   DBPRINT(("File timeout interrupts enabled\n"));
 }

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -247,14 +247,35 @@ void close_unix_descriptors(void) /* Get ready to shut Maiko down */
 
 int FindUnixPipes(void) {
   char *envtmp;
+  int inttmp;
   struct unixjob cleareduj;
 
   DBPRINT(("Entering FindUnixPipes\n"));
   UnixPipeIn = UnixPipeOut = StartTime = UnixPID = -1;
-  if ((envtmp = getenv("LDEPIPEIN"))) UnixPipeIn = atoi(envtmp);
-  if ((envtmp = getenv("LDEPIPEOUT"))) UnixPipeOut = atoi(envtmp);
-  if ((envtmp = getenv("LDESTARTTIME"))) StartTime = atoi(envtmp);
-  if ((envtmp = getenv("LDEUNIXPID"))) UnixPID = atoi(envtmp);
+  if ((envtmp = getenv("LDEPIPEIN"))) {
+    errno = 0;
+    inttmp = (int)strtol(envtmp, (char **)NULL, 10);
+    if (errno == 0)
+      UnixPipeIn = inttmp;
+  }
+  if ((envtmp = getenv("LDEPIPEOUT"))) {
+    errno = 0;
+    inttmp = (int)strtol(envtmp, (char **)NULL, 10);
+    if (errno == 0)
+      UnixPipeOut = inttmp;
+  }
+  if ((envtmp = getenv("LDESTARTTIME"))) {
+    errno = 0;
+    inttmp = (int)strtol(envtmp, (char **)NULL, 10);
+    if (errno == 0)
+      StartTime = inttmp;
+  }
+  if ((envtmp = getenv("LDEUNIXPID"))) {
+    errno = 0;
+    inttmp = (int)strtol(envtmp, (char **)NULL, 10);
+    if (errno == 0)
+      UnixPID = inttmp;
+  }
 
 /* This is a good place to initialize stuff like the UJ table */
   NPROCS = sysconf(_SC_OPEN_MAX);

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -11,6 +11,7 @@
 
 #include "version.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -287,7 +288,10 @@ void read_Xoption(int *argc, char *argv[])
   */
   if (XrmGetResource(rDB, "ldex.memory", "Ldex.memory", str_type, &value) == True) {
     (void)strncpy(tmp, value.addr, (int)value.size);
-    sysout_size = atoi(tmp);
+    errno = 0;
+    i = (int)strtol(tmp, (char **)NULL, 10);
+    if (errno == 0 && i > 0)
+      sysout_size = i;
   }
 
   if (XrmGetResource(rDB, "ldex.Init", "Ldex.Init", str_type, &value) == True) { for_makeinit = 1; }


### PR DESCRIPTION
As a side-effect of this change, we also resolve a a problem with
signed file version numbers, so that instead of version 2147483647
wrapping to -2147483648 we can go as far as 4294967296 before we
have issues.  Various sprintf() formats get changed from %d to %u.
The DOS version code is left behind as int versions.

Closes Interlisp/medley#455