### PR TITLE
better release

### DIFF
--- a/bin/release-one
+++ b/bin/release-one
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Make and release maiko for one os / arch
+# Hopefully to be replaced by GitHub Action
+
+if [ ! -x ../../maiko/bin/machinetype ] ; then
+    echo ERROR: Must be run from maiko/bin
+    exit 1
+fi
+
+tag=$1
+if [ -z "$tag" ] ; then
+    tag=maiko-`date +%y%m%d`
+fi
+
+export PATH=.:"$PATH"
+osarch=`osversion`.`machinetype`
+
+
+./makeright x
+./makeright init
+
+cd ../..
+mkdir -p maiko/build
+echo making $tag-$osarch.tgz
+
+tar cfz maiko/build/$tag-$osarch.tgz         \
+    maiko/bin/osversion                      \
+    maiko/bin/machinetype                    \
+    maiko/bin/config.guess                   \
+    maiko/bin/config.sub                     \
+    maiko/$osarch/lde*
+
+if ! command -v gh >/dev/null ; then
+    echo 
+    echo The GitHub Command Line Interface, gh
+    echo does not seem to be installed.
+    echo Please upload  maiko/build/$tag-$osarch.tgz
+    echo to https://github.com/Interlisp/maiko/releases $tag
+    exit 0
+fi
+
+echo uploading 
+cd maiko
+gh release upload --clobber $tag build/$tag-$osarch.tgz

--- a/bin/start-release
+++ b/bin/start-release
@@ -1,0 +1,36 @@
+#!/bin/sh
+# This script is just a placeholder until we get GitHub
+# Actions to do releases 
+
+# Start Maiko release from maiko/bin
+#     startrelease [tag]
+# tag defaults to maiko-YYMMDD
+
+tag=$1
+if [ -z "$tag" ] ; then
+    tag=maiko-`date +%y%m%d`
+fi
+
+if ! command -v gh >/dev/null ; then
+    echo "It seems like 'gh', the GitHub Command Line Interface is"
+    echo "not installed. You can start a release using the"
+    echo "web interface at"
+    echo "https://github.com/Interlisp/maiko/releases/new"
+    echo "Make up a tag (or use  $tag)"
+    echo "and run './release-one tag' (or manually upload if"
+    echo "no 'gh' is installed) on every os/machine you want"
+    echo "this release to work for"
+    exit 0
+fi
+
+# Now for the only thing this script is actually doing
+
+gh release create $tag -p -t $tag -n "See release notes in medley repo"
+
+
+echo "Now run "
+echo ./release-one $tag
+echo "in maiko/bin on every os/machine you want this release"
+echo "to work for. When done, edit the release in your"
+echo "browser and uncheck the prerelease box	"
+


### PR DESCRIPTION
- add start-release.sh and release-one.sh for separate maiko/medley releases
- fix up
- more fixes
- no '.sh', explicit test for 'gh', remove color
- Update release-one to prepare release for platform but give instructions if gh not installed
