### PR TITLE
Fix various bugprone warnings

### DIFF
--- a/inc/my.h
+++ b/inc/my.h
@@ -71,7 +71,7 @@
 	}
 
 static inline LispPTR
-aref_switch(int type, LispPTR tos, LispPTR baseL, int index)
+aref_switch(unsigned type, LispPTR tos, LispPTR baseL, int index)
 {								  
   LispPTR result;
   DLword *wordp;

--- a/src/array3.c
+++ b/src/array3.c
@@ -33,7 +33,7 @@
 /***	N_OP_aref1   -- op 266   (array index)   ***/
 LispPTR N_OP_aref1(register LispPTR arrayarg, register LispPTR inx) {
   register LispPTR baseL;
-  register int type, index;
+  register int index;
   register OneDArray *arrayblk;
 
   /*  verify array  */
@@ -45,12 +45,9 @@ LispPTR N_OP_aref1(register LispPTR arrayarg, register LispPTR inx) {
   if (index >= arrayblk->totalsize) ERROR_EXIT(inx);
   index += arrayblk->offset;
 
-  /*  setup typenumber  */
-  type = 0xFF & arrayblk->typenumber;
-
   /*  setup base  */
   baseL = arrayblk->base;
 
   /*  disp on type  */
-  return (aref_switch(type, inx, baseL, index));
+  return (aref_switch(arrayblk->typenumber, inx, baseL, index));
 } /*  end N_OP_aref1()  */

--- a/src/array4.c
+++ b/src/array4.c
@@ -42,7 +42,6 @@
 /************************************************************************/
 
 LispPTR N_OP_aset1(register LispPTR data, LispPTR arrayarg, register int inx) {
-  register int type;
   register OneDArray *arrayblk;
   register LispPTR base;
   register int new;
@@ -57,14 +56,11 @@ LispPTR N_OP_aset1(register LispPTR data, LispPTR arrayarg, register int inx) {
   if (index >= arrayblk->totalsize) ERROR_EXIT(inx);
   index += arrayblk->offset;
 
-  /*  setup typenumber  */
-  type = 0xFF & arrayblk->typenumber;
-
   /*  setup base  */
   base = arrayblk->base;
 
   /*  disp on type  */
-  aset_switch(type, inx);
+  aset_switch(arrayblk->typenumber, inx);
 
 doufn:
   ERROR_EXIT(inx);

--- a/src/array5.c
+++ b/src/array5.c
@@ -41,7 +41,6 @@
 LispPTR N_OP_aref2(LispPTR arrayarg, LispPTR inx0, LispPTR inx1) {
 #define REG
   LispPTR baseL;
-  int type;
   int arindex, temp;
   LispArray *arrayblk;
   int j;
@@ -59,9 +58,6 @@ LispPTR N_OP_aref2(LispPTR arrayarg, LispPTR inx0, LispPTR inx1) {
   arindex *= j;
   arindex += temp;
 
-  /*  setup typenumber  */
-  type = 0xFF & arrayblk->typenumber;
-
   /*  disp on type  */
-  return (aref_switch(type, inx1, baseL, arindex));
+  return (aref_switch(arrayblk->typenumber, inx1, baseL, arindex));
 } /*  end N_OP_aref2()  */

--- a/src/array6.c
+++ b/src/array6.c
@@ -26,7 +26,6 @@
 
 /***	N_OP_aset2   -- op 357   (new-value array index0 index1)   ***/
 LispPTR N_OP_aset2(register LispPTR data, LispPTR arrayarg, LispPTR inx0, LispPTR inx1) {
-  register int type;
   register LispArray *arrayblk;
   register LispPTR base;
   register int new;
@@ -46,11 +45,8 @@ LispPTR N_OP_aset2(register LispPTR data, LispPTR arrayarg, LispPTR inx0, LispPT
   index *= j;
   index += temp;
 
-  /*  setup typenumber  */
-  type = 0xFF & arrayblk->typenumber;
-
   /*  disp on type  */
-  aset_switch(type, inx1);
+  aset_switch(arrayblk->typenumber, inx1);
 
 doufn:
   ERROR_EXIT(inx1);

--- a/src/dir.c
+++ b/src/dir.c
@@ -1602,7 +1602,7 @@ static int trim_finfo_highest(FINFO **fp, int highestp)
  * Name:	trim_finfo_version
  *
  * Argument:	FINFO	**fp	Linked list of the numerated FINFO structures.
- *		int	rver	Requested version number.
+ *		unsigned rver	Requested version number.
  *
  * Value:	Returns the total number of files still remaining in **fp.
  *
@@ -1614,7 +1614,7 @@ static int trim_finfo_highest(FINFO **fp, int highestp)
  * are got rid of.
  */
 
-static int trim_finfo_version(FINFO **fp, int rver)
+static int trim_finfo_version(FINFO **fp, unsigned rver)
 {
   register FINFO *tp, *sp, *mp, *cp, *pp, *vp;
   register int num, pnum;
@@ -1840,7 +1840,8 @@ static FINFO **prepare_sort_buf(register FINFO *fp, register int n)
 
 static int dsk_filecmp(FINFO **fp1, FINFO **fp2)
 {
-  register int res, v1, v2;
+  register int res;
+  unsigned v1, v2;
 
   if ((res = strcmp((*fp1)->no_ver_name, (*fp2)->no_ver_name)) != 0) return (res);
 
@@ -2032,7 +2033,8 @@ LispPTR COM_gen_files(register LispPTR *args)
 #ifdef DOS
   char drive[1];
 #endif
-  int dskp, count, highestp, propp, fid, version;
+  int dskp, count, highestp, fid;
+  unsigned propp, version;
   register char *cp;
   FINFO *fp;
   int dsk_filecmp(), unix_filecmp();
@@ -2193,7 +2195,8 @@ LispPTR COM_next_file(register LispPTR *args)
   register char *base;
   register DFINFO *dfp;
   register UFSGFS *gfsp;
-  int finfoid, propp;
+  int finfoid;
+  unsigned propp;
 
   ERRSETJMP(-1);
   Lisp_errno = &Dummy_errno;

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -851,7 +851,8 @@ LispPTR COM_closefile(register LispPTR *args)
 LispPTR DSK_getfilename(register LispPTR *args)
 {
   register char *base;
-  register int len, dirp, rval;
+  size_t len, rval;
+  register int dirp;
   int fatp;
   char lfname[MAXPATHLEN];
   char aname[MAXNAMLEN];
@@ -1510,7 +1511,8 @@ LispPTR DSK_directorynamep(register LispPTR *args)
 {
   char dirname[MAXPATHLEN];
   char fullname[MAXPATHLEN];
-  register int len, fatp;
+  size_t len;
+  register int fatp;
   register char *base;
 #ifdef DOS
   char drive[1], rawname[MAXNAMLEN];
@@ -1697,7 +1699,8 @@ LispPTR COM_getfileinfo(register LispPTR *args)
       *bufp = sbuf.st_mode;
       return (ATOM_T);
 
-    case AUTHOR:
+    case AUTHOR: {
+      size_t rval;
 #ifndef DOS
       TIMEOUT(pwd = getpwuid(sbuf.st_uid));
       if (pwd == (struct passwd *)NULL) {
@@ -1717,8 +1720,9 @@ LispPTR COM_getfileinfo(register LispPTR *args)
 #endif /* BYTESWAP */
 #endif /* DOS */
       return (GetSmallp(rval));
-
-    case ALL:
+    }
+    case ALL: {
+      size_t rval;
       /*
        * The format of the buffer which has been allocated by Lisp
        * is as follows.
@@ -1756,7 +1760,7 @@ LispPTR COM_getfileinfo(register LispPTR *args)
 #endif /* BYTESWAP	 */
 #endif /* DOS */
       return (GetSmallp(rval));
-
+    }
     default: return (NIL);
   }
 }
@@ -3395,7 +3399,8 @@ static int get_versionless(FileName *varray, char *file, char *dir)
 
 static int check_vless_link(char *vless, FileName *varray, char *to_file, int *highest_p)
 {
-  register int rval, max_no, found;
+  register int rval, found;
+  unsigned max_no;
   ino_t vless_ino;
   struct stat sbuf;
   char dir[MAXPATHLEN], name[MAXNAMLEN], ver[VERSIONLEN];

--- a/src/main.c
+++ b/src/main.c
@@ -490,7 +490,10 @@ int main(int argc, char *argv[])
 #else
   if (getuid() != geteuid()) {
     fprintf(stderr, "Effective user is not real user.  Setting euid to uid.\n");
-    seteuid(getuid());
+    if (seteuid(getuid()) == -1) {
+      fprintf(stderr, "Unable to reset effective user id to real user id\n");
+      exit(1);
+    }
   }
 #endif /* DOS */
 
@@ -624,7 +627,6 @@ void start_lisp() {
 
 int makepathname(char *src, char *dst)
 {
-  register int len;
   register char *base, *cp;
   register struct passwd *pwd;
   char name[MAXPATHLEN];
@@ -675,7 +677,7 @@ int makepathname(char *src, char *dst)
         if ((cp = (char *)strchr(base + 1, '/')) == 0)
           return (0);
         else {
-          len = (UNSIGNED)cp - (UNSIGNED)base - 1;
+          size_t len = cp - base - 1;
           strncpy(name, base + 1, len);
           name[len] = '\0';
 #ifndef DOS

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -156,7 +156,8 @@ exit_host_filesystem() {
 LispPTR UFS_getfilename(LispPTR *args)
 {
   register char *base;
-  register int len, rval;
+  size_t len;
+  register int rval;
   char lfname[MAXPATHLEN], file[MAXPATHLEN];
 
   ERRSETJMP(NIL);
@@ -369,7 +370,8 @@ LispPTR UFS_directorynamep(LispPTR *args)
 {
   char dirname[MAXPATHLEN];
   char fullname[MAXPATHLEN];
-  register int len, rval;
+  size_t len;
+  register int rval;
   register char *base;
   struct stat sbuf;
 

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -114,7 +114,7 @@ int c_string_to_lisp_string(char *C, LispPTR Lisp) {
         register size_t i;
         register char *dp;
         for (i = 0, dp = C; i < length + 1; i++) {
-          int ch = *dp++;
+          char ch = *dp++;
 #ifdef DOS
           if (ch == '\\') dp++; /* skip 2nd \ in \\ in C strings */
 #endif /* DOS */


### PR DESCRIPTION
This fixes a small subset of the warnings generated by clang-tidy's bugprone-* checks.

Nothing here should introduce any functional changes, or fix any actual bugs :-(