### PR TITLE
Implement -noscroll option to ldex to disable X window scroll bars

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -210,7 +210,8 @@ int UnixPipeIn;
 int UnixPipeOut;
 int UnixPID;
 int please_fork = 1;
-
+/* disable X11 scroll bars if requested */
+int noscroll = 0;
 /*** STACK handle staff(Takeshi) **/
 LispPTR *STACKOVERFLOW_word;
 LispPTR *GuardStackAddr_word;

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -51,6 +51,7 @@
 extern DLword *Lisp_world;
 extern char Display_Name[128];
 extern DLword *DisplayRegion68k;
+extern int noscroll;
 bool Lisp_Xinitialized = false;
 int xsync = False;
 
@@ -86,15 +87,16 @@ void init_Xevent(DspInterface dsp)
 
   XSelectInput(dsp->display_id, dsp->LispWindow, dsp->EnableEventMask);
   XSelectInput(dsp->display_id, dsp->DisplayWindow, dsp->EnableEventMask);
-  XSelectInput(dsp->display_id, dsp->HorScrollBar, BarMask);
-  XSelectInput(dsp->display_id, dsp->VerScrollBar, BarMask);
-  XSelectInput(dsp->display_id, dsp->HorScrollButton, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->VerScrollButton, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->NEGrav, GravMask);
-  XSelectInput(dsp->display_id, dsp->SEGrav, GravMask);
-  XSelectInput(dsp->display_id, dsp->SWGrav, GravMask);
-  XSelectInput(dsp->display_id, dsp->NWGrav, GravMask);
-
+  if (noscroll == 0) {
+    XSelectInput(dsp->display_id, dsp->HorScrollBar, BarMask);
+    XSelectInput(dsp->display_id, dsp->VerScrollBar, BarMask);
+    XSelectInput(dsp->display_id, dsp->HorScrollButton, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->VerScrollButton, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->NEGrav, GravMask);
+    XSelectInput(dsp->display_id, dsp->SEGrav, GravMask);
+    XSelectInput(dsp->display_id, dsp->SWGrav, GravMask);
+    XSelectInput(dsp->display_id, dsp->NWGrav, GravMask);
+  }
 } /*end init_Xevent */
 
 /************************************************************************/
@@ -237,8 +239,13 @@ DspInterface X_init(DspInterface dsp, char *lispbitmap, int width_hint, int heig
   Xscreen = ScreenOfDisplay(dsp->display_id, DefaultScreen(dsp->display_id));
 
   /* Set the scrollbar and border widths */
-  dsp->ScrollBarWidth = SCROLL_WIDTH;
-  dsp->InternalBorderWidth = DEF_BDRWIDE;
+  if (noscroll == 0) {
+    dsp->ScrollBarWidth = SCROLL_WIDTH;
+    dsp->InternalBorderWidth = DEF_BDRWIDE;
+  } else {
+    dsp->ScrollBarWidth = 0;
+    dsp->InternalBorderWidth = 0;
+  }
 
   dsp->Visible.x = LispDisplayRequestedX;
   dsp->Visible.y = LispDisplayRequestedY;

--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -58,6 +58,7 @@ Cursor WaitCursor, DefaultCursor, VertScrollCursor, VertThumbCursor, ScrollUpCur
 
 extern int LispWindowRequestedX, LispWindowRequestedY;
 extern unsigned LispWindowRequestedWidth, LispWindowRequestedHeight;
+extern int noscroll;
 
 /************************************************************************/
 /*									*/
@@ -187,86 +188,87 @@ void Create_LispWindow(DspInterface dsp)
   set_Xcursor(dsp, scrollup_cursor.cuimage, (int)scrollup_cursor.cuhotspotx,
               (int)(15 - scrollup_cursor.cuhotspoty), &ScrollUpCursor, 0);
 
-  /********************************/
-  /* Make all the toolkit windows */
-  /********************************/
-  dsp->VerScrollBar = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2,
-                                          0 - dsp->InternalBorderWidth, /* y */
-                                          dsp->ScrollBarWidth,          /* width */
-                                          dsp->Visible.height, dsp->InternalBorderWidth,
-                                          BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
-  DefineCursor(dsp, dsp->VerScrollBar, &VertScrollCursor);
-  XMapWindow(dsp->display_id, dsp->VerScrollBar);
+  if (noscroll == 0) {
+    /********************************/
+    /* Make all the toolkit windows */
+    /********************************/
+    dsp->VerScrollBar = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2,
+                                            0 - dsp->InternalBorderWidth, /* y */
+                                            dsp->ScrollBarWidth,          /* width */
+                                            dsp->Visible.height, dsp->InternalBorderWidth,
+                                            BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
+    DefineCursor(dsp, dsp->VerScrollBar, &VertScrollCursor);
+    XMapWindow(dsp->display_id, dsp->VerScrollBar);
 
-  dsp->HorScrollBar = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow,
-                                          0 - dsp->InternalBorderWidth, Row2, /* y */
-                                          dsp->Visible.width,                /* width */
-                                          dsp->ScrollBarWidth, dsp->InternalBorderWidth,
-                                          BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
-  DefineCursor(dsp, dsp->HorScrollBar, &HorizScrollCursor);
-  XChangeWindowAttributes(dsp->display_id, dsp->HorScrollBar, CWOverrideRedirect,
-                          &Lisp_SetWinAttributes);
-  XMapWindow(dsp->display_id, dsp->HorScrollBar);
+    dsp->HorScrollBar = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow,
+                                            0 - dsp->InternalBorderWidth, Row2, /* y */
+                                            dsp->Visible.width,                /* width */
+                                            dsp->ScrollBarWidth, dsp->InternalBorderWidth,
+                                            BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
+    DefineCursor(dsp, dsp->HorScrollBar, &HorizScrollCursor);
+    XChangeWindowAttributes(dsp->display_id, dsp->HorScrollBar, CWOverrideRedirect,
+                            &Lisp_SetWinAttributes);
+    XMapWindow(dsp->display_id, dsp->HorScrollBar);
 
-  dsp->VerScrollButton = XCreateSimpleWindow(
-      dsp->display_id, dsp->VerScrollBar, 0 - dsp->InternalBorderWidth,      /* x */
-      (int)((dsp->Visible.y * dsp->Visible.height) / dsp->Display.height), /* y */
-      dsp->ScrollBarWidth,                                                   /* width */
-      (int)((dsp->Visible.height * dsp->Visible.height) / dsp->Display.height) + 1,
-      dsp->InternalBorderWidth, BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
-  XChangeWindowAttributes(dsp->display_id, dsp->VerScrollButton, CWOverrideRedirect,
-                          &Lisp_SetWinAttributes);
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->VerScrollButton, dsp->ScrollBarPixmap);
-  XClearWindow(dsp->display_id, dsp->VerScrollButton);
-  XMapWindow(dsp->display_id, dsp->VerScrollButton);
+    dsp->VerScrollButton = XCreateSimpleWindow(
+                                               dsp->display_id, dsp->VerScrollBar, 0 - dsp->InternalBorderWidth,      /* x */
+                                               (int)((dsp->Visible.y * dsp->Visible.height) / dsp->Display.height), /* y */
+                                               dsp->ScrollBarWidth,                                                   /* width */
+                                               (int)((dsp->Visible.height * dsp->Visible.height) / dsp->Display.height) + 1,
+                                               dsp->InternalBorderWidth, BlackPixelOfScreen(screen), WhitePixelOfScreen(screen));
+    XChangeWindowAttributes(dsp->display_id, dsp->VerScrollButton, CWOverrideRedirect,
+                            &Lisp_SetWinAttributes);
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->VerScrollButton, dsp->ScrollBarPixmap);
+    XClearWindow(dsp->display_id, dsp->VerScrollButton);
+    XMapWindow(dsp->display_id, dsp->VerScrollButton);
 
-  dsp->HorScrollButton = XCreateSimpleWindow(
-      dsp->display_id, dsp->HorScrollBar,
-      (int)((dsp->Visible.x * dsp->Visible.width) / dsp->Display.width),
-      0 - dsp->InternalBorderWidth, /* y */
-      (int)((dsp->Visible.width * dsp->Visible.width) / dsp->Display.width) + 1,
-      dsp->ScrollBarWidth, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
-      WhitePixelOfScreen(screen));
-  XChangeWindowAttributes(dsp->display_id, dsp->HorScrollButton, CWOverrideRedirect,
-                          &Lisp_SetWinAttributes);
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->HorScrollButton, dsp->ScrollBarPixmap);
-  XClearWindow(dsp->display_id, dsp->HorScrollButton);
-  XMapWindow(dsp->display_id, dsp->HorScrollButton);
+    dsp->HorScrollButton = XCreateSimpleWindow(
+                                               dsp->display_id, dsp->HorScrollBar,
+                                               (int)((dsp->Visible.x * dsp->Visible.width) / dsp->Display.width),
+                                               0 - dsp->InternalBorderWidth, /* y */
+                                               (int)((dsp->Visible.width * dsp->Visible.width) / dsp->Display.width) + 1,
+                                               dsp->ScrollBarWidth, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
+                                               WhitePixelOfScreen(screen));
+    XChangeWindowAttributes(dsp->display_id, dsp->HorScrollButton, CWOverrideRedirect,
+                            &Lisp_SetWinAttributes);
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->HorScrollButton, dsp->ScrollBarPixmap);
+    XClearWindow(dsp->display_id, dsp->HorScrollButton);
+    XMapWindow(dsp->display_id, dsp->HorScrollButton);
 
-  dsp->NWGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2, Row2, GravSize,
-                                    GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
-                                    WhitePixelOfScreen(screen));
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->NWGrav, dsp->GravityOnPixmap);
-  DefineCursor(dsp, dsp->NWGrav, &DefaultCursor);
-  XChangeWindowAttributes(dsp->display_id, dsp->NWGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
-  XClearWindow(dsp->display_id, dsp->NWGrav);
-  XMapWindow(dsp->display_id, dsp->NWGrav);
+    dsp->NWGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2, Row2, GravSize,
+                                      GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
+                                      WhitePixelOfScreen(screen));
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->NWGrav, dsp->GravityOnPixmap);
+    DefineCursor(dsp, dsp->NWGrav, &DefaultCursor);
+    XChangeWindowAttributes(dsp->display_id, dsp->NWGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
+    XClearWindow(dsp->display_id, dsp->NWGrav);
+    XMapWindow(dsp->display_id, dsp->NWGrav);
 
-  dsp->SEGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col3, Row3, GravSize,
-                                    GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
-                                    WhitePixelOfScreen(screen));
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->SEGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp, dsp->SEGrav, &DefaultCursor);
-  XChangeWindowAttributes(dsp->display_id, dsp->SEGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
-  XClearWindow(dsp->display_id, dsp->NWGrav);
-  XMapWindow(dsp->display_id, dsp->SEGrav);
+    dsp->SEGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col3, Row3, GravSize,
+                                      GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
+                                      WhitePixelOfScreen(screen));
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->SEGrav, dsp->GravityOffPixmap);
+    DefineCursor(dsp, dsp->SEGrav, &DefaultCursor);
+    XChangeWindowAttributes(dsp->display_id, dsp->SEGrav, CWOverrideRedirect, &Lisp_SetWinAttributes);
+    XClearWindow(dsp->display_id, dsp->NWGrav);
+    XMapWindow(dsp->display_id, dsp->SEGrav);
 
-  dsp->SWGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2, Row3, GravSize,
-                                    GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
-                                    WhitePixelOfScreen(screen));
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->SWGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp, dsp->SWGrav, &DefaultCursor);
-  XClearWindow(dsp->display_id, dsp->NWGrav);
-  XMapWindow(dsp->display_id, dsp->SWGrav);
+    dsp->SWGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col2, Row3, GravSize,
+                                      GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
+                                      WhitePixelOfScreen(screen));
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->SWGrav, dsp->GravityOffPixmap);
+    DefineCursor(dsp, dsp->SWGrav, &DefaultCursor);
+    XClearWindow(dsp->display_id, dsp->NWGrav);
+    XMapWindow(dsp->display_id, dsp->SWGrav);
 
-  dsp->NEGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col3, Row2, GravSize,
-                                    GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
-                                    WhitePixelOfScreen(screen));
-  XSetWindowBackgroundPixmap(dsp->display_id, dsp->NEGrav, dsp->GravityOffPixmap);
-  DefineCursor(dsp, dsp->NEGrav, &DefaultCursor);
-  XClearWindow(dsp->display_id, dsp->NWGrav);
-  XMapWindow(dsp->display_id, dsp->NEGrav);
-
+    dsp->NEGrav = XCreateSimpleWindow(dsp->display_id, dsp->LispWindow, Col3, Row2, GravSize,
+                                      GravSize, dsp->InternalBorderWidth, BlackPixelOfScreen(screen),
+                                      WhitePixelOfScreen(screen));
+    XSetWindowBackgroundPixmap(dsp->display_id, dsp->NEGrav, dsp->GravityOffPixmap);
+    DefineCursor(dsp, dsp->NEGrav, &DefaultCursor);
+    XClearWindow(dsp->display_id, dsp->NWGrav);
+    XMapWindow(dsp->display_id, dsp->NEGrav);
+  }
   /* DefineCursor( dsp, dsp->DisplayWindow, &WaitCursor ); */
 
   XLOCK;

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -68,6 +68,7 @@ static XrmOptionDescRec opTable[] = {
     {"-m", "*memory", XrmoptionSepArg, (XPointer)NULL},
     {"-NF", "*NoFork", XrmoptionIsArg, (XPointer)NULL},
     {"-NoFork", "*NoFork", XrmoptionIsArg, (XPointer)NULL},
+    {"-noscroll", "*noscroll", XrmoptionIsArg, (XPointer) NULL},
     {"-INIT", "*Init", XrmoptionIsArg, (XPointer)NULL},
     {"-EtherNet", "*EtherNet", XrmoptionSepArg, (XPointer)NULL},
     {"-E", "*EtherNet", XrmoptionSepArg, (XPointer)NULL},
@@ -85,7 +86,7 @@ char Window_Title[255];
 char Icon_Title[255];
 
 extern char sysout_name[];
-extern int sysout_size, for_makeinit, please_fork;
+extern int sysout_size, for_makeinit, please_fork, noscroll;
 /* diagnostic flag for sysout dumping */
 /* extern int maxpages; */
 
@@ -173,8 +174,7 @@ void read_Xoption(int *argc, char *argv[])
   }
 
   sysout_name[0] = '\0';
-  if (*argc == 2) /* There was probably a sysoutarg */
-  {
+  if (*argc == 2) { /* There was probably a sysoutarg */
     (void)strncpy(sysout_name, argv[1], PATH_MAX - 1);
   } else if ((envname = getenv("LDESRCESYSOUT")) != NULL) {
     strncpy(sysout_name, envname, PATH_MAX - 1);
@@ -184,8 +184,9 @@ void read_Xoption(int *argc, char *argv[])
     envname = getenv("HOME");
     (void)strcat(sysout_name, envname);
     (void)strcat(sysout_name, "/lisp.virtualmem");
-
-    if (access(sysout_name, R_OK) != 0) { (void)strcat(sysout_name, ""); }
+  }
+  if (access(sysout_name, R_OK) != 0) {
+    sysout_name[0] = '\0';
   }
 
   /* In order to access other DB's we have to open the main display now */
@@ -276,6 +277,10 @@ void read_Xoption(int *argc, char *argv[])
 
   if (XrmGetResource(rDB, "ldex.NoFork", "Ldex.NoFork", str_type, &value) == True) {
     please_fork = 0;
+  }
+
+  if (XrmGetResource(rDB, "ldex.noscroll", "Ldex.noscroll", str_type, &value) == True) {
+    noscroll = 1;
   }
 
   /*    if (XrmGetResource(rDB,

--- a/src/xwinman.c
+++ b/src/xwinman.c
@@ -30,7 +30,7 @@ int Mouse_Included = FALSE;
 
 extern Cursor WaitCursor, DefaultCursor, VertScrollCursor, VertThumbCursor, ScrollUpCursor,
     ScrollDownCursor, HorizScrollCursor, HorizThumbCursor, ScrollLeftCursor, ScrollRightCursor;
-
+extern int noscroll;
 extern DspInterface currentdsp;
 
 extern DLword *EmCursorX68K, *EmCursorY68K;
@@ -109,33 +109,35 @@ static void lisp_Xconfigure(DspInterface dsp, int x, int y, int lspWinWidth, int
   XLOCK;
   XMoveResizeWindow(dsp->display_id, dsp->DisplayWindow, 0, 0, dsp->Visible.width,
                     dsp->Visible.height);
-  /* Scroll bars */
-  XMoveResizeWindow(dsp->display_id, dsp->VerScrollBar, Col2, 0 - dsp->InternalBorderWidth, /* y */
-                    dsp->ScrollBarWidth,   /* width */
-                    dsp->Visible.height); /* height */
-  XMoveResizeWindow(dsp->display_id, dsp->HorScrollBar, 0 - dsp->InternalBorderWidth, Row2, /* y */
-                    dsp->Visible.width,  /* width */
-                    dsp->ScrollBarWidth); /* height */
+  if (noscroll == 0) {
+    /* Scroll bars */
+    XMoveResizeWindow(dsp->display_id, dsp->VerScrollBar, Col2, 0 - dsp->InternalBorderWidth, /* y */
+                      dsp->ScrollBarWidth,   /* width */
+                      dsp->Visible.height); /* height */
+    XMoveResizeWindow(dsp->display_id, dsp->HorScrollBar, 0 - dsp->InternalBorderWidth, Row2, /* y */
+                      dsp->Visible.width,  /* width */
+                      dsp->ScrollBarWidth); /* height */
 
-  /* Scroll buttons */
-  XMoveResizeWindow(
-      dsp->display_id, dsp->HorScrollButton,
-      (int)((dsp->Visible.x * dsp->Visible.width) / dsp->Display.width),         /* x */
-      0 - dsp->InternalBorderWidth,                                                /* y */
-      (int)((dsp->Visible.width * dsp->Visible.width) / dsp->Display.width) + 1, /* width */
-      dsp->ScrollBarWidth);                                                        /* height */
-  XMoveResizeWindow(
-      dsp->display_id, dsp->VerScrollButton, 0 - dsp->InternalBorderWidth,             /* x */
-      (int)((dsp->Visible.y * dsp->Visible.height) / dsp->Display.height),           /* y */
-      dsp->ScrollBarWidth,                                                             /* width */
-      (int)((dsp->Visible.height * dsp->Visible.height) / dsp->Display.height) + 1); /* height */
+    /* Scroll buttons */
+    XMoveResizeWindow(
+                      dsp->display_id, dsp->HorScrollButton,
+                      (int)((dsp->Visible.x * dsp->Visible.width) / dsp->Display.width),         /* x */
+                      0 - dsp->InternalBorderWidth,                                                /* y */
+                      (int)((dsp->Visible.width * dsp->Visible.width) / dsp->Display.width) + 1, /* width */
+                      dsp->ScrollBarWidth);                                                        /* height */
+    XMoveResizeWindow(
+                      dsp->display_id, dsp->VerScrollButton, 0 - dsp->InternalBorderWidth,             /* x */
+                      (int)((dsp->Visible.y * dsp->Visible.height) / dsp->Display.height),           /* y */
+                      dsp->ScrollBarWidth,                                                             /* width */
+                      (int)((dsp->Visible.height * dsp->Visible.height) / dsp->Display.height) + 1); /* height */
 
-  /* Gravity windows */
-  XMoveResizeWindow(dsp->display_id, dsp->NWGrav, Col2, Row2, GravSize, GravSize);
-  XMoveResizeWindow(dsp->display_id, dsp->NEGrav, Col3, Row2, GravSize, GravSize);
-  XMoveResizeWindow(dsp->display_id, dsp->SEGrav, Col3, Row3, GravSize, GravSize);
-  XMoveResizeWindow(dsp->display_id, dsp->SWGrav, Col2, Row3, GravSize, GravSize);
-  Scroll(dsp, dsp->Visible.x, dsp->Visible.y);
+    /* Gravity windows */
+    XMoveResizeWindow(dsp->display_id, dsp->NWGrav, Col2, Row2, GravSize, GravSize);
+    XMoveResizeWindow(dsp->display_id, dsp->NEGrav, Col3, Row2, GravSize, GravSize);
+    XMoveResizeWindow(dsp->display_id, dsp->SEGrav, Col3, Row3, GravSize, GravSize);
+    XMoveResizeWindow(dsp->display_id, dsp->SWGrav, Col2, Row3, GravSize, GravSize);
+    Scroll(dsp, dsp->Visible.x, dsp->Visible.y);
+  }
   XFlush(dsp->display_id);
   XUNLOCK(dsp);
 } /* end lisp_Xconfigure */


### PR DESCRIPTION
Adds a -noscroll option, parsed as an X option, also accessible via
resource ldex*noscroll, which avoids adding the bottom and side scroll
bars and the bit-gravity control buttons to the main Lisp display window.

Unless the geometry given for the X window in which the Lisp screen is
displayed is at least as big as the Lisp screen part of the Lisp screen
(bottom, right) will not be visible.

At least on macOS with XQuartz, maximizing the X window will bring it to
the size of the Lisp screen (or the size of the display, whichever is smaller)