### PR TITLE
Use SHELL rather than /bin/csh when forking shells.

### DIFF
--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -351,7 +351,7 @@ static int FindAvailablePty(char *Slave) {
 /*		     => byte count (<= 512), NIL (no data), or T (EOF)          */
 /*	   10 Set Window Size, Arg2 = rows, Arg3 = columns                  */
 /*	   11 Fork PTY to Shell (obsoletes command 4)                       */
-/*        Arg1 = termtype, Arg2 = csh command string                    */
+/*        Arg1 = termtype, Arg2 = shell command string                    */
 /*		     => Job # or NIL                                            */
 /*     12 Create Unix Socket                                            */
 /*        Arg1 = pathname to bind socket to (string)                    */


### PR DESCRIPTION
As long as $(SHELL) names an executable that appears in /etc/shells (as determined
by the getusershell() function) use that.  It used to always use /bin/csh, but some
modern distros do not ship with csh installed.  Using the user's preferred shell
seems like a better choice, while allowing the choice from /etc/shells gives some
additional flexibility.