### PR TITLE
Drop setuid privilege correctly.

### DIFF
--- a/src/ether.c
+++ b/src/ether.c
@@ -742,7 +742,7 @@ static int check_filter(u_char *buffer)
 static void init_uid() {
   int rid;
   rid = getuid();
-  seteuid(rid);
+  setuid(rid);
 }
 #endif /* MAIKO_ENABLE_ETHERNET */
 
@@ -830,7 +830,7 @@ void init_ether() {
         /* JDS 991228 remove	perror("Can't open network; XNS unavailable.\n"); */
         ether_fd = -1;
       }
-      seteuid(getuid());
+      setuid(getuid());
     }
 #elif defined(USE_NIT)
 #ifndef OS4
@@ -952,7 +952,7 @@ void init_ether() {
     perror("Can't open network; XNS unavailable.\n");
     ether_fd = -1;
   }
-  seteuid(getuid());
+  setuid(getuid());
 }
 
 #endif /* OS4 */

--- a/src/ldeether.c
+++ b/src/ldeether.c
@@ -214,7 +214,7 @@ int main(int argc, char *argv[]) {
       ether_fd = -1;
       /*	exit();	*/
     }
-    seteuid(getuid());
+    setuid(getuid());
   }
 
   /* OK, right here do other stuff like scan args */

--- a/src/main.c
+++ b/src/main.c
@@ -490,9 +490,9 @@ int main(int argc, char *argv[])
   probemouse(); /* See if the mouse is connected. */
 #else
   if (getuid() != geteuid()) {
-    fprintf(stderr, "Effective user is not real user.  Setting euid to uid.\n");
-    if (seteuid(getuid()) == -1) {
-      fprintf(stderr, "Unable to reset effective user id to real user id\n");
+    fprintf(stderr, "Effective user is not real user.  Resetting uid\n");
+    if (setuid(getuid()) == -1) {
+      fprintf(stderr, "Unable to reset user id to real user id\n");
       exit(1);
     }
   }


### PR DESCRIPTION
The ethernet access code, which in certain circumstances needs to run setuid root in order to open the network device, should drop the privilege irrevocably when it is done:  `setuid(getuid())` rather than `seteuid(getuid())`.  This avoids a hack being able to execute a seteuid(0) to regain the privilege.    