### PR TITLE
The pointers Atomspace, Spospspace, Snegspace, Arrayspace can be removed

### DIFF
--- a/inc/lspglob.h
+++ b/inc/lspglob.h
@@ -31,7 +31,6 @@
 #include "lispemul.h" /* for LispPTR, DLword */
 #include "miscstat.h" /* for MISCSTAT */
 
- extern  DLword *Atomspace; 		/* ATOMSPACE */
  extern  DLword *Stackspace;		/* STACKSPACE*/
  extern  DLword *Plistspace;		/* PLISTSPACE */
  extern  DLword *DTDspace;		/* DTDSPACE */
@@ -41,8 +40,6 @@
  extern  DLword *AtomSpace;		/* New atoms, initial set */
  extern  DLword *Defspace;		/* DEFSPACE */
  extern  DLword *Valspace;		/* VALSPACE */
- extern  DLword *Spospspace;		/* POSITIVE Smallp */
- extern  DLword *Snegspace;		/* NEGATIVE Smallp */
  
 /* For Virtual Mem Management */
 #ifdef BIGVM
@@ -82,7 +79,6 @@ extern DLword *UFNTable ;
 
 
 /* FLEX STORAGES */
- extern  DLword *Arrayspace;  /* Start of ARRAYSPACE */
  extern  DLword *MDS_space_bottom;  /* Start of MDS (pre -2) */
  extern  DLword *PnCharspace ;	/* Space for PN char codes (Thin only) */
 

--- a/src/main.c
+++ b/src/main.c
@@ -75,7 +75,6 @@
 DLword *Lisp_world; /* lispworld */
 
 /********** 68k address for Lisp Space **********/
-DLword *Atomspace;
 DLword *Stackspace;
 DLword *Plistspace;
 DLword *DTDspace;
@@ -85,8 +84,6 @@ DLword *Pnamespace;
 DLword *AtomSpace;
 DLword *Defspace;
 DLword *Valspace;
-DLword *Spospspace;
-DLword *Snegspace;
 
 /********** For Virtual Memory Management **********/
 #ifdef BIGVM
@@ -124,7 +121,6 @@ DLword *HTcoll;
 DLword *DisplayRegion;
 int DisplayInitialized = NIL;
 
-DLword *Arrayspace;
 DLword *MDS_space_bottom;
 DLword *PnCharspace;
 struct dtd *ListpDTD;

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -267,7 +267,6 @@ LispPTR compare_lisp_chars(register const char *char1, register const char *char
 LispPTR make_atom(const char *char_base, DLword offset, DLword length, short int non_numericp)
 /* if it is NIL then these chars are treated as NUMBER */
 {
-  extern DLword *Spospspace;
   extern DLword *AtomHT;
   extern DLword *Pnamespace;
   extern DLword *AtomSpace;


### PR DESCRIPTION
These pointers are neither initialized nor referenced anywhere in the code.