### PR TITLE
Rework make_atom() to allow removal of parse_number()

### DIFF
--- a/inc/mkatomdefs.h
+++ b/inc/mkatomdefs.h
@@ -5,6 +5,5 @@ DLword compute_hash(const char *char_base, DLword offset, DLword length);
 DLword compute_lisp_hash(const char *char_base, DLword offset, DLword length, DLword fatp);
 LispPTR compare_chars(register const char *char1, register const char *char2, register DLword length);
 LispPTR compare_lisp_chars(register const char *char1, register const char *char2, register DLword length, DLword fat1, DLword fat2);
-LispPTR make_atom(const char *char_base, DLword offset, DLword length, short int non_numericp);
-LispPTR parse_number(const char *char_base, short int length);
+LispPTR make_atom(const char *char_base, DLword offset, DLword length);
 #endif

--- a/src/storage.c
+++ b/src/storage.c
@@ -35,7 +35,7 @@
 #include "conspagedefs.h"
 #include "gcfinaldefs.h"
 #include "gchtfinddefs.h"
-#include "mkatomdefs.h"
+#include "testtooldefs.h"
 
 #define MINARRAYBLOCKSIZE 4
 #define GUARDVMEMFULL 500
@@ -374,7 +374,7 @@ LispPTR newpage(LispPTR base) {
     } else if (InterfacePage->key == IFPVALID_KEY) {
       *VMEM_FULL_STATE_word = ATOM_T;
     } else
-      *VMEM_FULL_STATE_word = make_atom("DIRTY", 0, 5, 0);
+      *VMEM_FULL_STATE_word = MAKEATOM("DIRTY");
   }
 
   return (base);

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -1018,7 +1018,7 @@ FX *get_nextFX(FX *fx) {
 } /* get_nextFX end */
 
 LispPTR MAKEATOM(char *string) {
-    return (make_atom(string, 0, strlen(string), 0));
+    return (make_atom(string, 0, strlen(string)));
 }
 
 /************************************************************************/
@@ -1032,7 +1032,7 @@ LispPTR MAKEATOM(char *string) {
 
 LispPTR *MakeAtom68k(char *string) {
   LispPTR index;
-  index = make_atom(string, 0, strlen(string), 0);
+  index = make_atom(string, 0, strlen(string));
   if (index == 0xffffffff) {
       error("MakeAtom68k: no such atom found");
   }

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -286,7 +286,7 @@ LispPTR parse_atomstring(char *string)
     namelen = cnt - 1;
 
   if ((packagelen == 0) || (strncmp(packageptr, "IL", packagelen) == 0)) { /* default IL: */
-    aindex = make_atom(nameptr, 0, namelen, T);
+    aindex = make_atom(nameptr, 0, namelen);
     if (aindex == 0xffffffff) {
       printf("trying IL:\n");
       aindex = get_package_atom(nameptr, namelen, "INTERLISP", 9, 0);


### PR DESCRIPTION
No calls to make_atom() depend on the ability to parse the atom's
pname as a number.  Additionally, the parse_number() implementation
used here was non-functional.

Here we remove parse_number() and adjust the parameter list of make_atom()
to remove the non_numericp flag.

Closes interlisp/medley#30