### PR TITLE
Correct integer type warnings

### DIFF
--- a/inc/timeout.h
+++ b/inc/timeout.h
@@ -61,8 +61,8 @@ extern	int	TIMEOUT_TIME;
 /************************************************************************/
 
 #define INTRSAFE(exp)				\
-  do {} while ((int)(exp) == -1 && errno == EINTR)
+  do {errno = 0; } while ((exp) == -1 && errno == EINTR)
 
 #define INTRSAFE0(exp)				\
-  do {} while ((int)(exp) == 0 && errno == EINTR)
+  do {errno = 0; } while ((exp) == NULL && errno == EINTR)
 #endif /* TIMEOUT_H */

--- a/inc/xinitdefs.h
+++ b/inc/xinitdefs.h
@@ -6,5 +6,5 @@ void lisp_Xexit(DspInterface dsp);
 void Xevent_before_raid(DspInterface dsp);
 void Xevent_after_raid(DspInterface dsp);
 void Open_Display(DspInterface dsp);
-DspInterface X_init(DspInterface dsp, char *lispbitmap, int width_hint, int height_hint, int depth_hint);
+DspInterface X_init(DspInterface dsp, LispPTR lispbitmap, int width_hint, int height_hint, int depth_hint);
 #endif

--- a/src/dir.c
+++ b/src/dir.c
@@ -691,7 +691,7 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
       nextp->prop->wdate = (unsigned)ToLispTime(sbuf.st_mtime);
       nextp->prop->rdate = (unsigned)ToLispTime(sbuf.st_atime);
       nextp->prop->protect = (unsigned)sbuf.st_mode;
-      TIMEOUT(pwd = getpwuid(sbuf.st_uid));
+      TIMEOUT0(pwd = getpwuid(sbuf.st_uid));
       if (pwd == (struct passwd *)NULL) {
         nextp->prop->au_len = 0;
       } else {
@@ -1080,7 +1080,7 @@ static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
   char namebuf[MAXPATHLEN];
 
   errno = 0;
-  TIMEOUT(dirp = opendir(dir));
+  TIMEOUT0(dirp = opendir(dir));
   if (dirp == NULL) {
     *Lisp_errno = errno;
     return (-1);
@@ -1263,7 +1263,7 @@ static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
   char namebuf[MAXPATHLEN];
 
   errno = 0;
-  TIMEOUT(dirp = opendir(dir));
+  TIMEOUT0(dirp = opendir(dir));
   if (dirp == NULL) {
     *Lisp_errno = errno;
     return (-1);

--- a/src/draw.c
+++ b/src/draw.c
@@ -17,9 +17,9 @@
 
 #include "version.h"
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
-
 
 #include "lispemul.h"
 #include "lspglob.h"
@@ -268,21 +268,21 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
 #endif /* COLOR */
 
   {
-    DLword *start_addr, *temp_s, *temp_e;
-
+    DLword *start_addr;
     start_addr = (DLword *)Addr68k_from_LADDR(ptr);
 
-    if (((int)(temp_s = (DLword *)(start_addr - DisplayRegion68k)) >= 0) &&
-        (start_addr < DisplayRegion68k_end_addr) &&
-        ((int)(temp_e = (DLword *)(dataptr - DisplayRegion68k)) >= 0) &&
-        ((DLword *)dataptr < DisplayRegion68k_end_addr)) {
+    if (in_display_segment(start_addr) && in_display_segment(dataptr)) {
       int start_x, start_y, end_x, end_y, w, h;
+      ptrdiff_t temp_s, temp_e;
 
-      start_y = (int)temp_s / DisplayRasterWidth;
-      start_x = ((int)temp_s % DisplayRasterWidth) * BITSPER_DLWORD;
+      temp_s = start_addr - DisplayRegion68k;
+      temp_e = dataptr - DisplayRegion68k;
 
-      end_y = (int)temp_e / DisplayRasterWidth;
-      end_x = ((int)temp_e % DisplayRasterWidth) * BITSPER_DLWORD + (BITSPER_DLWORD - 1);
+      start_y = temp_s / DisplayRasterWidth;
+      start_x = (temp_s % DisplayRasterWidth) * BITSPER_DLWORD;
+
+      end_y = temp_e / DisplayRasterWidth;
+      end_x = (temp_e % DisplayRasterWidth) * BITSPER_DLWORD + (BITSPER_DLWORD - 1);
 
       w = abs(start_x - end_x) + 1;
       h = abs(start_y - end_y) + 1;
@@ -290,10 +290,8 @@ int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int 
       if (start_x > end_x) start_x = end_x;
       if (start_y > end_y) start_y = end_y;
 
-
 #if defined(XWINDOW) || defined(BYTESWAP)
       flush_display_region(start_x, start_y, w, h);
-
 #endif /* XWINDOW */
     }
   }

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -1702,7 +1702,7 @@ LispPTR COM_getfileinfo(register LispPTR *args)
     case AUTHOR: {
       size_t rval;
 #ifndef DOS
-      TIMEOUT(pwd = getpwuid(sbuf.st_uid));
+      TIMEOUT0(pwd = getpwuid(sbuf.st_uid));
       if (pwd == (struct passwd *)NULL) {
         /*
          * Returns Lisp 0.  Lisp code handles this case as author
@@ -1748,7 +1748,7 @@ LispPTR COM_getfileinfo(register LispPTR *args)
       bufp = (unsigned *)(Addr68k_from_LADDR(laddr));
       *bufp = sbuf.st_mode;
 #ifndef DOS
-      TIMEOUT(pwd = getpwuid(sbuf.st_uid));
+      TIMEOUT0(pwd = getpwuid(sbuf.st_uid));
       if (pwd == (struct passwd *)NULL) { return (GetSmallp(0)); }
       laddr = cdr(car(cdr(cdr(cdr(cdr(args[2]))))));
       STRING_BASE(laddr, base);

--- a/src/dspif.c
+++ b/src/dspif.c
@@ -27,9 +27,6 @@ DspInterface currentdsp = &curdsp;
 #ifdef XWINDOW
 extern int LispDisplayRequestedWidth;
 extern int LispDisplayRequestedHeight;
-
-extern DspInterface X_init(DspInterface dsp, char *lispbitmap, int width_hint, int height_hint,
-                           int depth_hint);
 #endif /* XWINDOW */
 
 #ifdef DOS

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -139,8 +139,7 @@ void init_ifpage(int sysout_size) {
 
 #ifdef BIGVM
   /* For BIGVM system, save the value in \LASTVMEMFILEPAGE for lisp's use */
-  if ((LispPTR)LASTVMEMFILEPAGE_word != 0xFFFFFFFF)
-    *LASTVMEMFILEPAGE_word = InterfacePage->dllastvmempage;
+  *LASTVMEMFILEPAGE_word = InterfacePage->dllastvmempage;
 #endif /* BIGVM */
 
   /* unfortunately, Lisp only looks at a 16 bit serial number */

--- a/src/main.c
+++ b/src/main.c
@@ -659,7 +659,7 @@ int makepathname(char *src, char *dst)
 #ifdef DOS
         pwd = 0;
 #else
-        TIMEOUT(pwd = getpwuid(getuid()));
+        TIMEOUT0(pwd = getpwuid(getuid()));
 #endif /* DOS */
         if (pwd == NULL) {
           *Lisp_errno = errno;
@@ -678,7 +678,7 @@ int makepathname(char *src, char *dst)
           strncpy(name, base + 1, len);
           name[len] = '\0';
 #ifndef DOS
-          TIMEOUT(pwd = getpwnam(name));
+          TIMEOUT0(pwd = getpwnam(name));
 #endif /* DOS */
           if (pwd == NULL) {
             *Lisp_errno = errno;

--- a/src/subr.c
+++ b/src/subr.c
@@ -484,6 +484,7 @@ void OP_subrcall(int subr_no, int argnum) {
 
     case sb_GET_NATIVE_ADDR_FROM_LISP_PTR:
       POP_SUBR_ARGS;
+      /* XXX: this WILL NOT WORK if Lisp memory is allocated outside the low 4GB */
       ARITH_SWITCH(Addr68k_from_LADDR(args[0]), TopOfStack);
       break;
 

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -566,7 +566,7 @@ int unixpathname(char *src, char *dst, int versionp, int genp)
     case '~':
       if (*(cp + 1) == '>' || *(cp + 1) == '\0') {
         /* "~>" or "~" means the user's home directory. */
-        TIMEOUT(pwd = getpwuid(getuid()));
+        TIMEOUT0(pwd = getpwuid(getuid()));
         if (pwd == NULL) return (0);
 
         strcpy(dst, pwd->pw_dir);
@@ -590,7 +590,7 @@ int unixpathname(char *src, char *dst, int versionp, int genp)
          */
         for (++cp, np = name; *cp != '\0' && *cp != '>';) *np++ = *cp++;
         *np = '\0';
-        TIMEOUT(pwd = getpwnam(name));
+        TIMEOUT0(pwd = getpwnam(name));
         if (pwd == NULL) return (0);
 
         strcpy(dst, pwd->pw_dir);

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -222,7 +222,7 @@ void Open_Display(DspInterface dsp)
 /*                                                                   */
 /*********************************************************************/
 
-DspInterface X_init(DspInterface dsp, char *lispbitmap, int width_hint, int height_hint,
+DspInterface X_init(DspInterface dsp, LispPTR lispbitmap, int width_hint, int height_hint,
                     int depth_hint)
 {
   Screen *Xscreen;


### PR DESCRIPTION
Corrects a number of issues related to casting values to a smaller type.

Warnings revealed usage of the wrong `TIMEOUT` (vs `TIMEOUT0`) macro, now corrected.
Some pointer arithmetic done with integers corrected to use modern `ptrdiff_t` type.
Comment added to (currently unused) code noting that you can't get a native address as a FIXP on a 64-bit pointer architecture.  If this code eventually gets used it will need to create/accept a 64-bit lisp object.