### PR TITLE
Add some support for cross-compilation to MC68000 AmigaOS

### DIFF
--- a/bin/machinetype
+++ b/bin/machinetype
@@ -12,6 +12,7 @@
 os=${LDEARCH:-`./config.guess`}
 # o/s switch block
 case "$os" in
+        m68k-*)		      echo m68k ;;
         sparc-*)	      echo sparc ;;
         alpha-*)	      echo alpha ;;
 	i*86-*-*)             echo 386 ;;

--- a/bin/osversion
+++ b/bin/osversion
@@ -1,6 +1,7 @@
 #!/bin/sh
-os=`./config.guess`
+os=${LDEARCH:-`./config.guess`}
 case "$os" in
+        m68k-*-amigaos)		echo amigaos ;;
         sparc-sun-sunos*)	echo sunos4 ;;
         sparc-sun-solaris1*)	echo sunos4 ;;
         *-*-solaris2*)	        echo sunos5 ;;

--- a/inc/maiko/platform.h
+++ b/inc/maiko/platform.h
@@ -59,6 +59,13 @@
 #  define MAIKO_OS_DETECTED 1
 #endif
 
+#ifdef amigaos3
+#  define MAIKO_OS_AMIGAOS3 1
+#  define MAIKO_OS_NAME "AmigaOS 3"
+#  define MAIKO_OS_UNIX_LIKE 1
+#  define MAIKO_OS_DETECTED 1
+#endif
+
 /* __SVR4: Defined by clang, gcc, and Sun Studio.
  * __SVR4__ was only defined by Sun Studio. */
 #if defined(__sun) && defined(__SVR4)
@@ -134,6 +141,13 @@
 #  else
 #    define MAIKO_ARCH_WORD_BITS 32
 #  endif
+#  define MAIKO_ARCH_DETECTED 1
+#endif
+
+#ifdef __mc68000
+#  define MAIKO_ARCH_M68000 1
+#  define MAIKO_ARCH_NAME "Motorola68K"
+#  define MAIKO_ARCH_WORD_BITS 32
 #  define MAIKO_ARCH_DETECTED 1
 #endif
 


### PR DESCRIPTION
Add m68k to recognized CPUs (machinetype)
Add amigaos to recognized operating systems (osversion)
Add ability to override "config.guess" output w/ LDEARCH= to osversion
Add platform.h clauses to recognize AmigaOS 3 using gcc to cross-compile