### PR TITLE
Remove support for GET-NATIVE-ADDR-FROM-LISP-PTR and GET-LISP-PTR-FROM-NATIVE-ADDR

### DIFF
--- a/src/subr.c
+++ b/src/subr.c
@@ -485,18 +485,27 @@ void OP_subrcall(int subr_no, int argnum) {
     case sb_GET_NATIVE_ADDR_FROM_LISP_PTR:
       POP_SUBR_ARGS;
       /* XXX: this WILL NOT WORK if Lisp memory is allocated outside the low 4GB */
+      /* not supported since native addresses can't be represented as
+         a Lisp FIXP
       ARITH_SWITCH(Addr68k_from_LADDR(args[0]), TopOfStack);
+      */
+      TopOfStack = NIL_PTR;
       break;
 
     case sb_GET_LISP_PTR_FROM_NATIVE_ADDR:
       POP_SUBR_ARGS;
+      /* not supported since native addresses can't be represented as
+         a Lisp FIXP
+
       {
         register UNSIGNED iarg;
         N_GETNUMBER(args[0], iarg, ret_nil);
         ARITH_SWITCH(LADDR_from_68k(iarg), TopOfStack);
         break;
       };
-
+      */
+      TopOfStack = NIL_PTR;
+      break;
     case sb_DSK_GETFILENAME:
       POP_SUBR_ARGS;
       TopOfStack = DSK_getfilename(args);


### PR DESCRIPTION
Since the native addresses for objects within the Lisp memory may be at locations
that can't be represented in 32-bits conversion between a native address and a
Lisp FIXP can't be supported.  For now, return NIL for conversion in either direction.

There are no known users of these two subrs.  Should it be necessary to reimplement them
at some future time the representation will need to be something that can hold 64 bits.