### PR TITLE
Create missing directories when opening directory/file on {UNIX} device for output

### DIFF
--- a/src/dsk.c
+++ b/src/dsk.c
@@ -327,29 +327,23 @@ LispPTR COM_openfile(register LispPTR *args)
 
         case ACCESS_OUTPUT:
           flags = O_RDWR | O_TRUNC | O_CREAT;
-          if (dskp) {
-            unpack_filename(file, dir, name, ver, 1);
-            if (make_directory(dir) == 0) return (NIL);
-            link_check_flg = 1;
-          }
+          unpack_filename(file, dir, name, ver, 1);
+          if (make_directory(dir) == 0) return (NIL);
+          if (dskp) link_check_flg = 1;
           break;
 
         case ACCESS_BOTH:
           flags = O_RDWR | O_CREAT;
-          if (dskp) {
-            unpack_filename(file, dir, name, ver, 1);
-            if (make_directory(dir) == 0) return (NIL);
-            link_check_flg = 1;
-          }
+          unpack_filename(file, dir, name, ver, 1);
+          if (make_directory(dir) == 0) return (NIL);
+          if (dskp) link_check_flg = 1;
           break;
 
         case ACCESS_APPEND:
           flags = O_RDWR | O_CREAT;
-          if (dskp) {
-            unpack_filename(file, dir, name, ver, 1);
-            if (make_directory(dir) == 0) return (NIL);
-            link_check_flg = 1;
-          }
+          unpack_filename(file, dir, name, ver, 1);
+          if (make_directory(dir) == 0) return (NIL);
+          if (dskp) link_check_flg = 1;
           break;
       }
       break;


### PR DESCRIPTION

Prior to this change there was no mechanism within Medley to create a new directory
on a {UNIX} style device.  This change makes the {UNIX} directory creation happen in
the same manner that {DSK} directory creation is done.  Opening a file with access
OUTPUT, BOTH, or APPEND, which would create the file if it does not exist, will also
create any missing directories in the path.