### PR TITLE
fix some compiler warnings

### DIFF
--- a/bin/mkvdate
+++ b/bin/mkvdate
@@ -1,5 +1,6 @@
 #!/bin/sh
 cat <<EOF
 #include <time.h>
-time_t MDate = $(date +%s);
+extern const time_t MDate;
+const time_t MDate = $(date +%s);
 EOF

--- a/inc/display.h
+++ b/inc/display.h
@@ -74,13 +74,4 @@ extern DLword *DisplayRegion68k;
 #undef DISPLAYBUFFER
 #endif /* XWINDOW */
 
-void flush_display_buffer();
-void flush_display_lineregion(UNSIGNED x, DLword *ybase, UNSIGNED w, UNSIGNED h);
-void flush_display_region(int x, int y, int w, int h);
-void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, UNSIGNED w, UNSIGNED h);
-
-#ifdef BYTESWAP
-void byte_swapped_displayregion(int x, int y, int w, int h);
-#endif
-
 #endif

--- a/inc/lispemul.h
+++ b/inc/lispemul.h
@@ -82,17 +82,17 @@ typedef struct interrupt_state_2 { /* alternate view of the interrupt state */
 } INTSTAT2;
 
 struct state {
-  DLword *ivar;               /* + 0 */
-  DLword *pvar;               /* + 4 */
-  DLword *csp;                /* + 8 */
-  LispPTR tosvalue;           /* + 12 */
-  ByteCode *currentpc;        /* + 16 */
-  struct fnhead *currentfunc; /* + 20*/
-  DLword *endofstack;         /* + 24*/
-  UNSIGNED irqcheck;          /* + 28 */
-  UNSIGNED irqend;            /* + 32 */
-  LispPTR scratch_cstk;       /* + 34 */
-  int errorexit;              /* + 38 */
+  DLword *ivar;
+  DLword *pvar;
+  DLword *csp;
+  ByteCode *currentpc;
+  struct fnhead *currentfunc;
+  DLword *endofstack;
+  UNSIGNED irqcheck;
+  UNSIGNED irqend;
+  LispPTR tosvalue;
+  LispPTR scratch_cstk;
+  int errorexit;
 };
 
 /***** Get_DLword(ptr) ptr is char* ***/
@@ -226,17 +226,17 @@ typedef struct interrupt_state_2 { /* alternate view of the interrupt state */
 } INTSTAT2;
 
 struct state {
-  DLword *ivar;               /* + 0 */
-  DLword *pvar;               /* + 4 */
-  DLword *csp;                /* + 8 */
-  LispPTR tosvalue;           /* + 12 */
-  ByteCode *currentpc;        /* + 16 */
-  struct fnhead *currentfunc; /* + 20*/
-  DLword *endofstack;         /* + 24*/
-  UNSIGNED irqcheck;          /* + 28 */
-  UNSIGNED irqend;            /* + 32 */
-  LispPTR scratch_cstk;       /* + 34 */
-  int errorexit;              /* + 38 */
+  DLword *ivar;
+  DLword *pvar;
+  DLword *csp;
+  ByteCode *currentpc;
+  struct fnhead *currentfunc;
+  DLword *endofstack;
+  UNSIGNED irqcheck;
+  UNSIGNED irqend;
+  LispPTR tosvalue;
+  LispPTR scratch_cstk;
+  int errorexit;
 };
 
 /* Fetching 2 bytes to make a word -- always do it the hard way */

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -111,7 +111,7 @@ LispPTR *fixp_value(LispPTR *ptr) {
 #define PAGES_IN_MBYTE 2048
 
 void init_ifpage(int sysout_size) {
-  extern time_t MDate;
+  extern const time_t MDate;
   extern int DisplayType;
   extern int Storage_expanded;
   int new_lastvmem;

--- a/src/main.c
+++ b/src/main.c
@@ -246,7 +246,7 @@ int flushing = FALSE; /* see dbprint.h if set, all debug/trace printing will cal
 extern DspInterface currentdsp;
 #endif /* DOS || XWINDOW */
 
-extern time_t MDate;
+extern const time_t MDate;
 extern int nokbdflag;
 extern int nomouseflag;
 #ifdef DOS

--- a/src/mkvdate.c
+++ b/src/mkvdate.c
@@ -41,7 +41,8 @@
 int main(void) {
   long dtime;
   time(&dtime);
-  printf("long MDate= %ld;\n", dtime);
+  printf("extern const long MDate;\n", dtime);
+  printf("const long MDate = %ld;\n", dtime);
   return (0);
 }
 #else
@@ -56,7 +57,8 @@ int main(void) {
    */
   gettimeofday(&time, NULL);
   printf("#include <time.h>\n");
-  printf("time_t MDate= %ld;\n", (long)time.tv_sec);
+  printf("extern const time_t MDate;\n");
+  printf("const time_t MDate = %ld;\n", (long)time.tv_sec);
   return (0);
 }
 


### PR DESCRIPTION
Just the smallest start on reducing the number of compiler warnings when compiling with -Wall -Weverything.  Getting the non-essential ones out of the way will make it easier to deal with any that are "real".