### PR TITLE
If SHELL is not set, fall back to /bin/sh so CHAT("SHELL") should work.

### DIFF
--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -129,6 +129,8 @@ static int ForkUnixShell(int slot, char *PtySlave, char *termtype, char *shellar
   }
   /* Start up shell -- use SHELL environment variable as long as it's in /etc/shells */
   shell = getenv("SHELL");
+  if (shell == NULL) /* shell of last resort */
+    shell = "/bin/sh";
   for (userShell = getusershell(); userShell != NULL && strcmp(shell, userShell) != 0; userShell = getusershell());
   if (userShell == NULL) {
     perror("$(SHELL) not found in /etc/shells");


### PR DESCRIPTION
Shell of last resort is /bin/sh, assuming it's in /etc/shells, CHAT("SHELL") should work.

Closes Interlisp/medley#782