### PR TITLE
Fix ldeinit segmentation fault on keyboard/mouse input

### DIFF
--- a/src/xc.c
+++ b/src/xc.c
@@ -1118,7 +1118,9 @@ check_interrupt:
      * If the system is configured with SIGIO handling we have a hint
      * that allows us to cheaply skip if there's nothing to do
      */
+#ifndef INIT
     process_Xevents(currentdsp);
+#endif
 
     if (IO_Signalled) {
       IO_Signalled = FALSE;


### PR DESCRIPTION
Keyboard, cursor, and mouse pointers are not initialized in
ldeinit.  Do not process X events as they will cause a segmentation
fault referencing the uninitialized pointers.

Closes interlisp/medley#792