### PR TITLE
Prevent X11 error when resuming after call to RAID when -noscroll is in use

### DIFF
--- a/src/xinit.c
+++ b/src/xinit.c
@@ -133,13 +133,14 @@ void Xevent_before_raid(DspInterface dsp)
 
   XSelectInput(dsp->display_id, dsp->LispWindow, NoEventMask);
   XSelectInput(dsp->display_id, dsp->DisplayWindow, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->VerScrollBar, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->HorScrollBar, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->NEGrav, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->SEGrav, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->SWGrav, NoEventMask);
-  XSelectInput(dsp->display_id, dsp->NWGrav, NoEventMask);
-
+  if (noscroll == 0) {
+    XSelectInput(dsp->display_id, dsp->VerScrollBar, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->HorScrollBar, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->NEGrav, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->SEGrav, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->SWGrav, NoEventMask);
+    XSelectInput(dsp->display_id, dsp->NWGrav, NoEventMask);
+  }
   XLOCK;
   XFlush(dsp->display_id);
   XUNLOCK(dsp);


### PR DESCRIPTION
The device_before_raid() call that disables X11 scrolling and bit-gravity
selection needs to avoid referring to the scrollbars and other ancillary
windows that have not been initialized when the "-noscroll" option was
given at startup.

Closes interlisp/medley#835