### PR TITLE
Add missing uraidextdefs.h to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ SET(MAIKO_HDRS
     inc/unixfork.h
     inc/unwinddefs.h
     inc/uraiddefs.h
+    inc/uraidextdefs.h
     inc/usrsubrdefs.h
     inc/uutilsdefs.h
     inc/vars3defs.h


### PR DESCRIPTION
Fix in #428 missed adding the new file to CMakeLists.txt.