### PR TITLE
Ensure compiler sees debug printf even if won't be executed

### DIFF
--- a/inc/dbprint.h
+++ b/inc/dbprint.h
@@ -43,7 +43,7 @@ extern int flushing;
 #define DBPRINT(X) do {printf X ; if (flushing) fflush(stdout); } while(0)
 #define DEBUGGER(X) X
 #else
-#define DBPRINT(X) do {} while(0)
+#define DBPRINT(X) if (0) do {printf X ; } while(0)
 #define DEBUGGER(X)
 #endif
 
@@ -55,7 +55,7 @@ extern int flushing;
 #define TRACER(X) X
 #else /* TRACE */
 
-#define TPRINT(X) do { } while (0)
+#define TPRINT(X) if (0) do {  printf X; } while (0)
 #define TRACER(X)
 #endif /* TRACE */
 
@@ -67,7 +67,7 @@ extern int flushing;
 #define OPTPRINT(X) do { printf X; if (flushing) fflush(stdout); } while (0)
 #define OPTRACER(X) X
 #else
-#define OPTPRINT(X) do { } while (0)
+#define OPTPRINT(X) if (0) do {  printf X; } while (0)
 #define OPTRACER(X)
 #endif
 
@@ -78,7 +78,7 @@ extern int flushing;
 #define FNTPRINT(X) do { printf X; if (flushing) fflush(stdout); } while (0)
 #define FNTRACER(X)  X
 #else
-#define FNTPRINT(X) do { } while (0)
+#define FNTPRINT(X) if (0) do {  printf X; } while (0)
 #define FNTRACER(X)
 #endif
 
@@ -89,7 +89,7 @@ extern int flushing;
 #define FNCHKPRINT(X) do { printf X ; if (flushing) fflush(stdout); } while (0)
 #define FNCHECKER(X) X
 #else
-#define FNCHKPRINT(X) do { } while (0)
+#define FNCHKPRINT(X) if (0) do {  printf X; } while (0)
 #define FNCHECKER(X)
 #endif
 

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -397,9 +397,7 @@ LispPTR vmem_save(char *sysout_file_name)
   for (i = 0; i < vmemsize; i++) {
     if (GETPAGEOK(fptovp, i) != 0177777) {
       int oldfptovp = GETFPTOVP(fptovp, i);
-#ifdef DEBUG
       int saveoldfptovp = oldfptovp;
-#endif
       int contig_pages = 0;
       register char *base_addr;
 


### PR DESCRIPTION
If the debugging printf macros are elided by the preprocessor
rather than being removed by the compiler's optimizer then
the debugging statements may get out-of-date as variables are
modified.  Wrap the non-debug case in "if (0) ..." instead.