### PR TITLE
Update memory allocator function

### DIFF
--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -172,8 +172,7 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
 
   /* allocate Virtual Memory Space */
 
-  lispworld_scratch = valloc(sys_size * MBYTE);
-  if (lispworld_scratch == NULL) {
+  if (posix_memalign((void *)&lispworld_scratch, getpagesize(), sys_size * MBYTE) != 0) {
     fprintf(stderr, "sysout_loader: can't allocate Lisp %dMBytes VM \n", sys_size);
     exit(-1);
   }

--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -16,6 +16,7 @@
 #include <sys/ioctl.h>
 #include <sys/types.h>
 #include <sys/file.h>
+#include <unistd.h>
 
 #include "lispemul.h"
 #include "lispmap.h"

--- a/src/truecolor.c
+++ b/src/truecolor.c
@@ -13,6 +13,7 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <pixrect/pixrect_hs.h>
+#include <unistd.h>
 
 #include "lispemul.h"
 #include "lsptypes.h"
@@ -309,7 +310,6 @@ void truecolor_before_exit() {
 
 } /* truecolor_before_exit */
 
-char *valloc();
 char *HideOverlayRegion;
 #ifdef VIDEO
 char *HideVideoEnableRegion;
@@ -323,8 +323,8 @@ void truecolor_before_raid() {
   if (Inited_TrueColor) {
     size = ((displaywidth * displayheight / 8 + (getpagesize() - 1)) & -getpagesize());
 
-    if ((HideOverlayRegion = valloc(size)) == 0) {
-      printf("can't valloc hide space\n");
+    if (posix_memalign((void *)&HideOverlayRegion, getpagesize(), size) != 0) {
+      printf("can't allocate hide space\n");
       return (-1);
     } /* end if( HideOverlayRegion ) */
 
@@ -343,8 +343,8 @@ void truecolor_before_raid() {
 #ifdef VIDEO
   if (Inited_Video) {
     if ((video_onoff = Video_OnOff_Flg)) Video_OnOff(FALSE);
-    if ((HideVideoEnableRegion = valloc(size)) == 0) {
-      printf("can't valloc hide space\n");
+    if (posix_memalign((void *)&HideVideoEnableRegion, getpagesize(), size) != 0) {
+      printf("can't allocate hide space\n");
       return (-1);
     } /* end if( HideVideoEnableRegion ) */
 


### PR DESCRIPTION
Update from using valloc() to posix_memalign() for larger memory allocations.

valloc() is deprecated, and not available on some systems (Android w/ bionic library) whereas posix_memalign() is available on all systems that we currently compile for.