### PR TITLE
Update github workflow runners list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-18.04]
+        os: [macos-11, ubuntu-22.04, ubuntu-18.04]
     steps:
       - uses: actions/checkout@v2
       - name: Install X11 dependencies on MacOS
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, ubuntu-20.04, ubuntu-18.04]
+        os: [macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
     env:
       BUILD_TYPE: Release
     steps:


### PR DESCRIPTION
Github is deprecating the MacOS-10.15 environment as MacOS-12 is coming
online (currently beta), so this runner must be updated to MacOS-11

Ubuntu 22.04 LTS is now available so add that to the builds.

Ubuntu 18.04 LTS should be supported until April 2023.