### PR TITLE
Correct -Wformat-pedantic warnings

### DIFF
--- a/inc/initdspdefs.h
+++ b/inc/initdspdefs.h
@@ -10,6 +10,6 @@ void display_before_exit(void);
 void flush_display_buffer(void);
 void flush_display_region(int x, int y, int w, int h);
 void byte_swapped_displayregion(int x, int y, int w, int h);
-void flush_display_lineregion(UNSIGNED x, DLword *ybase, UNSIGNED w, UNSIGNED h);
-void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, UNSIGNED w, UNSIGNED h);
+void flush_display_lineregion(UNSIGNED x, DLword *ybase, int w, int h);
+void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, int w, int h);
 #endif

--- a/inc/tosfns.h
+++ b/inc/tosfns.h
@@ -368,7 +368,7 @@
       }                                                                                        \
       LOCFNCELL = (struct fnhead *)Addr68k_from_LADDR(defcell->defpointer);                    \
       BCE_CURRENTFX->pc = ((UNSIGNED)PCMAC - (UNSIGNED)FuncObj) + fn_opcode_size;              \
-      FNTPRINT(("Saving PC = 0%o (0x%x).\n", BCE_CURRENTFX->pc, PCMAC + fn_opcode_size));      \
+      FNTPRINT(("Saving PC = 0%o (%p).\n", BCE_CURRENTFX->pc, (void *)PCMAC + fn_opcode_size)); \
       FN_STACK_CHECK;                                                                          \
       APPLY_POP_PUSH_TEST;                                                                     \
       {                                                                                        \

--- a/src/dbgtool.c
+++ b/src/dbgtool.c
@@ -718,7 +718,7 @@ void nt(LispPTR index)
   }
 
   printf("***DUMP Func Header << ");
-  printf("start at 0x%x lisp address(%p 68k)\n", LADDR_from_68k(fnobj), fnobj);
+  printf("start at 0x%x lisp address(%p 68k)\n", LADDR_from_68k(fnobj), (void *)fnobj);
   print(index);
   putchar('\n');
 

--- a/src/dlpi.c
+++ b/src/dlpi.c
@@ -328,7 +328,7 @@ int dlpi_devtype(int fd)
     case DL_FDDI: return (DLT_FDDI);
 #endif
     default:
-      fprintf(stderr, "%s: DLPI MACtype %d unknown, ", pname, dlp->info_ack.dl_mac_type);
+      fprintf(stderr, "%s: DLPI MACtype %ld unknown, ", pname, (long)dlp->info_ack.dl_mac_type);
       fprintf(stderr, "assuming ethernet.\n");
       return (DLT_EN10MB);
   }

--- a/src/dspif.c
+++ b/src/dspif.c
@@ -108,8 +108,8 @@ void describedsp(DspInterface dsp) {
   printf("BytesPerLine= %d\n", dsp->BytesPerLine);
   printf("DisplayStartAddr= %d\n", dsp->DisplayStartAddr);
 #endif /* DOS */
-  printf("bitblt_to_screen= %p\n", dsp->bitblt_to_screen);
-  printf("cleardisplay= %p\n", dsp->cleardisplay);
+  printf("bitblt_to_screen= %p\n", (void *)dsp->bitblt_to_screen);
+  printf("cleardisplay= %p\n", (void *)dsp->cleardisplay);
 #ifdef DOS
   printf("mouse_visible= %d\n", dsp->mouse_visible);
   printf("mouse_invisible= %d\n", dsp->mouse_invisible);

--- a/src/ether.c
+++ b/src/ether.c
@@ -480,7 +480,7 @@ int *ether_debug() {
 #ifdef MAIKO_ENABLE_ETHERNET
   estat[0] = 0;
   if (ether_fd < 0) return (NIL);
-  printf("fd %d bsize %d buf %p icb %X in %d out %d\n ", ether_fd, ether_bsize, ether_buf,
+  printf("fd %d bsize %d buf %p icb %X in %d out %d\n ", ether_fd, ether_bsize, (void *)ether_buf,
          IOPage->dlethernet[3], ether_in, ether_out);
 #endif /* MAIKO_ENABLE_ETHERNET */
 

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -107,7 +107,7 @@ LispPTR aref1(LispPTR array, int index) {
     printf("Invalid index in GC's AREF1:  0x%x\n", index);
     printf(" Array size limit:  0x%x\n", actarray->totalsize);
     printf(" Array ptr: 0x%x\n", array);
-    printf(" Array 68K ptr: %p\n", actarray);
+    printf(" Array 68K ptr: %p\n", (void *)actarray);
     printf("base:     0x%x\n", actarray->base);
     printf("offset:   0x%x\n", actarray->offset);
     printf("type #:   0x%x\n", actarray->typenumber);

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -527,15 +527,15 @@ void printarrayblock(LispPTR base) {
   printf("          Length: %d cells.\n\n", bbase->arlen);
 
   addr = ((LispPTR *)bbase) - 20;
-  for (; addr < (LispPTR *)bbase; addr++) printf("%p	%8x\n", addr, *addr);
-  printf("%p	%8x <- array header\n", addr, *addr);
+  for (; addr < (LispPTR *)bbase; addr++) printf("%p	%8x\n", (void *)addr, *addr);
+  printf("%p	%8x <- array header\n", (void *)addr, *addr);
   addr++;
-  for (; addr < (LispPTR *)bbase + 20; addr++) printf("%p	%8x\n", addr, *addr);
+  for (; addr < (LispPTR *)bbase + 20; addr++) printf("%p	%8x\n", (void *)addr, *addr);
   printf(". . .\n");
 
   addr = ((LispPTR *)btrailer) - 20;
-  for (; addr < (LispPTR *)btrailer; addr++) printf("%p	%8x\n", addr, *addr);
-  printf("%p	%8x <- array trailer\n", addr, *addr);
+  for (; addr < (LispPTR *)btrailer; addr++) printf("%p	%8x\n", (void *)addr, *addr);
+  printf("%p	%8x <- array trailer\n", (void *)addr, *addr);
   addr++;
-  for (; addr < (LispPTR *)btrailer + 20; addr++) printf("%p	%8x\n", addr, *addr);
+  for (; addr < (LispPTR *)btrailer + 20; addr++) printf("%p	%8x\n", (void *)addr, *addr);
 }

--- a/src/gcmain3.c
+++ b/src/gcmain3.c
@@ -196,7 +196,7 @@ LispPTR gcscanstack(void) {
     char debugStr[100];
     sprintf(debugStr,
             "Frame ptr (%p) not to word bound at start of gcscanstack.",
-            basicframe);
+            (void *)basicframe);
     error(debugStr);
   }
 
@@ -275,7 +275,7 @@ LispPTR gcscanstack(void) {
               sprintf(debugStr,
                       "Frame ptr (%p) not to word bound "
                       "in gcscanstack() STK_FX case; old frame = %p.",
-                      basicframe, obasicframe);
+                      (void *)basicframe, (void *)obasicframe);
               error(debugStr);
             }
 
@@ -296,7 +296,7 @@ LispPTR gcscanstack(void) {
                 sprintf(debugStr,
                         "Frame ptr (%p) not to word bound "
                         "in gcscanstack() scantemps; old frame = %p.",
-                        basicframe, obasicframe);
+                        (void *)basicframe, (void *)obasicframe);
                 error(debugStr);
               }
 
@@ -313,7 +313,7 @@ LispPTR gcscanstack(void) {
               sprintf(debugStr,
                       "Frame ptr (%p) not to word bound "
                       "in gcscanstack(), end scantemps; old frame = %p.",
-                      basicframe, obasicframe);
+                      (void *)basicframe, (void *)obasicframe);
               error(debugStr);
             }
 
@@ -333,7 +333,7 @@ LispPTR gcscanstack(void) {
             sprintf(debugStr,
                     "Frame ptr (%p) not to word bound "
                     "in gcscanstack() STK_GUARD; old frame = %p.",
-                    basicframe, obasicframe);
+                    (void *)basicframe, (void *)obasicframe);
             error(debugStr);
           }
         };
@@ -348,7 +348,7 @@ LispPTR gcscanstack(void) {
           sprintf(debugStr,
                   "Frame ptr (%p) not to word bound "
                   "in gcscanstack() STK_FSB; old frame = %p.",
-                  basicframe, obasicframe);
+                  (void *)basicframe, (void *)obasicframe);
           error(debugStr);
         }
 

--- a/src/inet.c
+++ b/src/inet.c
@@ -219,7 +219,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
       }
       FD_SET(result, &LispIOFds);  /* so we get interrupts */
       FD_SET(result, &LispReadFds);
-      DBPRINT(("LispIOFds = 0x%x.\n", LispIOFds));
+      DBPRINT(("LispIOFds = %p\n", (void *)&LispIOFds));
       return (GetSmallp(result));
       break;
 
@@ -273,7 +273,7 @@ LispPTR subr_TCP_ops(int op, LispPTR nameConn, LispPTR proto, LispPTR length, Li
 
       FD_SET(result, &LispIOFds);  /* so we get interrupts */
       FD_SET(result, &LispReadFds);
-      DBPRINT(("LispIOFds = 0x%x.\n", LispIOFds));
+      DBPRINT(("LispIOFds = %p\n", (void *)&LispIOFds));
       return (GetSmallp(result));
       break;
 

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -189,7 +189,7 @@ void init_display2(DLword *display_addr, int display_max)
   init_cursor();
   DisplayByteSize = ((displaywidth * displayheight / 8 + (getpagesize() - 1)) & -getpagesize());
 
-  DBPRINT(("Display address: 0x%x\n", DisplayRegion68k));
+  DBPRINT(("Display address: %p\n", (void *)DisplayRegion68k));
   DBPRINT(("        length : 0x%x\n", DisplayByteSize));
   DBPRINT(("        pg size: 0x%x\n", getpagesize()));
 
@@ -327,13 +327,13 @@ void byte_swapped_displayregion(int x, int y, int w, int h)
 /*									*/
 /************************************************************************/
 
-void flush_display_lineregion(UNSIGNED x, DLword *ybase, UNSIGNED w, UNSIGNED h)
+void flush_display_lineregion(UNSIGNED x, DLword *ybase, int w, int h)
 {
   int y;
   y = ((DLword *)ybase - DisplayRegion68k) / DLWORD_PERLINE;
 
 #if (defined(XWINDOW) || defined(DOS))
-  TPRINT(("Enter flush_display_lineregion x=%d, y=%d, w=%d, h=%d\n", x, y, w, h));
+  TPRINT(("Enter flush_display_lineregion x=%p, y=%d, w=%d, h=%d\n", (void *)x, y, w, h));
   (currentdsp->bitblt_to_screen)(currentdsp, DisplayRegion68k, x, y, w, h);
   TPRINT(("Exit flush_display_lineregion\n"));
 #endif /* DOS */
@@ -356,7 +356,7 @@ void flush_display_lineregion(UNSIGNED x, DLword *ybase, UNSIGNED w, UNSIGNED h)
 
 #define BITSPERWORD 16
 
-void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, UNSIGNED w, UNSIGNED h)
+void flush_display_ptrregion(DLword *ybase, UNSIGNED bitoffset, int w, int h)
 {
   int y, x, baseoffset;
   baseoffset = (((DLword *)ybase) - DisplayRegion68k);

--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -372,7 +372,7 @@ static u_char *make_X_keymap() {
   for (i = 0; i < codecount * symspercode; i += symspercode) {
       printf("%d:", minkey + (i / symspercode));
       for (int j = 0; j < symspercode; j++) {
-          printf("\t %8x", mapping[i+j]);
+        printf("\t %8lx", (unsigned long)mapping[i+j]);
       }
       printf("\n");
   }

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -229,8 +229,8 @@ void build_lisp_map(void) {
   Defspace = (DLword *)Addr68k_from_LADDR(DEFS_OFFSET);
   Valspace = (DLword *)Addr68k_from_LADDR(VALS_OFFSET);
 
-  DBPRINT(("Stackspace = 0x%x.\n", Stackspace));
-  DBPRINT(("AtomHT = 0x%x.\n", AtomHT));
+  DBPRINT(("Stackspace = %p.\n", (void *)Stackspace));
+  DBPRINT(("AtomHT = %p.\n", (void *)AtomHT));
 
   ListpDTD = (struct dtd *)GetDTD(TYPE_LISTP);
 
@@ -280,8 +280,8 @@ void build_lisp_map(void) {
   Package_from_Index_word = MakeAtom68k("*PACKAGE-FROM-INDEX*");
   Package_from_Name_word = MakeAtom68k("*PACKAGE-FROM-NAME*");
   Keyword_Package_word = MakeAtom68k("*KEYWORD-PACKAGE*");
-  DBPRINT(("Package_from_Index_word = 0x%x.\n", Package_from_Index_word));
-  DBPRINT(("Package_from_Name_word  = 0x%x.\n", Package_from_Name_word));
+  DBPRINT(("Package_from_Index_word = %p\n", (void *)Package_from_Index_word));
+  DBPRINT(("Package_from_Name_word  = %p\n", (void *)Package_from_Name_word));
 
   /*** The following atom-index cache is for CL:VALUES opcode JDS 4/5/89 ***/
 
@@ -299,7 +299,7 @@ void build_lisp_map(void) {
     Deleted_Implicit_Hash_Slot_word = (LispPTR *)malloc(4);
     *Deleted_Implicit_Hash_Slot_word = NIL;
   } else {
-    DBPRINT(("%d %d %d %d %d", Stackspace, Plistspace, DTDspace, MDStypetbl, AtomHT));
+    DBPRINT(("%p %p %p %p %p", (void *)Stackspace, (void *)Plistspace, (void *)DTDspace, (void *)MDStypetbl, (void *)AtomHT));
 
     index = get_package_atom("*CLOSURE-CACHE-ENABLED*", 23, "SI", 2, NIL);
     Closure_Cache_Enabled_word = GetVALCELL68k(index);

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -64,10 +64,10 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
 #else
   DLword *fptovp; /* FPTOVP */
 #endif                /* BIGVM */
-  long fptovp_offset; /* FPTOVP start offset */
+  off_t fptovp_offset; /* FPTOVP start offset */
 
   char *lispworld_scratch; /* scratch area for lispworld */
-  long lispworld_offset;   /* lispworld offset */
+  size_t lispworld_offset;   /* lispworld offset */
 
   unsigned sysout_size; /* sysout size in page */
   struct stat stat_buf; /* file stat buf */
@@ -182,7 +182,7 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
   /* now you can access lispworld */
   Lisp_world = (DLword *)lispworld_scratch;
 
-  DBPRINT(("VM allocated = 0x%x at 0x%x\n", sys_size * MBYTE, Lisp_world));
+  DBPRINT(("VM allocated = 0x%x at %p\n", sys_size * MBYTE, (void *)Lisp_world));
   DBPRINT(("Native Load Address = 0x%x\n", native_load_address));
 
   /*
@@ -192,7 +192,7 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
   /* get FPTOVP location from IFPAGE */
   fptovp_offset = ifpage.fptovpstart;
 
-  DBPRINT(("FPTOVP Location %d \n", fptovp_offset));
+  DBPRINT(("FPTOVP Location %ld \n", (long)fptovp_offset));
 
   /* get sysout file size in halfpage(256) */
   if (fstat(sysout, &stat_buf) == -1) {
@@ -306,7 +306,7 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
       lispworld_offset = GETFPTOVP(fptovp, i) * BYTESPER_PAGE;
       if (read(sysout, lispworld_scratch + lispworld_offset, BYTESPER_PAGE) == -1) {
         printf("sysout_loader: can't read sysout file at %d\n", i);
-        printf("               offset was 0x%lx (0x%x pages).\n", lispworld_offset,
+        printf("               offset was 0x%zx (0x%x pages).\n", lispworld_offset,
                GETFPTOVP(fptovp, i));
         perror("read() error was");
         for (int j = 0; j < 10; j++) {

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -333,7 +333,7 @@ SCAN:
       StackWord *orig68k = scanptr68k;
 #endif
       while (STKWORD(scanptr68k)->flags != STK_BF) {
-        S_WARN(STKWORD(scanptr68k)->flags == STK_NOTFLG, "NOTFLG not on", scanptr68k);
+        S_WARN(STKWORD(scanptr68k)->flags == STK_NOTFLG, "NOTFLG not on", (void *)scanptr68k);
         scanptr68k = (StackWord *)(((DLword *)scanptr68k) + DLWORDSPER_CELL);
       };
 
@@ -602,7 +602,7 @@ void stack_check(StackWord *start68k) {
         top_ivar = (DLword *)scanptr68k;
         while (STKWORD(scanptr68k)->flags != STK_BF) {
           if (STKWORD(scanptr68k)->flags != STK_NOTFLG) {
-            WARN("StackCheck:!=STK_NOTFLG", printf("content:0x%x\n", GETWORD(scanptr68k)));
+            WARN("StackCheck:!=STK_NOTFLG", printf("content:0x%x\n", GETWORD((DLword *)scanptr68k)));
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
         } /* while end */;
@@ -623,7 +623,7 @@ void stack_check(StackWord *start68k) {
     if (scanptr68k != start68k) {
       if (scanptr68k > endstack68k) {
         WARN("scanptr exceeded end stack",
-             printf("scanptr68k=%p endstack68k=%p", scanptr68k, endstack68k));
+             printf("scanptr68k=%p endstack68k=%p", (void *)scanptr68k, (void *)endstack68k));
       }
     }
   } /* while end */
@@ -700,7 +700,7 @@ void walk_stack(StackWord *start68k) {
   printf("  End of stack = 0x%tx.\n\n", (DLword *)endstack68k - Stackspace);
 
   if (STKWORD(endstack68k)->flags != STK_GUARD)
-    printf("?? endstack is not GUARD BLK\nendstack = %p, flags = %d\n\n", endstack68k,
+    printf("?? endstack is not GUARD BLK\nendstack = %p, flags = %d\n\n", (void *)endstack68k,
            STKWORD(endstack68k)->flags);
 
   while (scanptr68k < endstack68k) {
@@ -771,7 +771,7 @@ void walk_stack(StackWord *start68k) {
         while (STKWORD(scanptr68k)->flags != STK_BF) {
           if (STKWORD(scanptr68k)->flags != STK_NOTFLG) {
             printf("%04tx:  Bad BF IVAR 0x%x\n", (DLword *)scanptr68k - Stackspace,
-                   GETWORD(scanptr68k));
+                   GETWORD((DLword *)scanptr68k));
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
         } /* while end */;
@@ -793,7 +793,7 @@ void walk_stack(StackWord *start68k) {
     if (scanptr68k != start68k) {
       if (scanptr68k > endstack68k) {
         WARN("scanptr exceeded end stack",
-             printf("scanptr68k=%p endstack68k=%p", scanptr68k, endstack68k));
+             printf("scanptr68k=%p endstack68k=%p", (void *)scanptr68k, (void *)endstack68k));
       }
     }
   } /* while end */
@@ -896,7 +896,7 @@ int quick_stack_check(void) {
         while (STKWORD(scanptr68k)->flags != STK_BF) {
           if (STKWORD(scanptr68k)->flags != STK_NOTFLG) {
             warn("StackCheck:!=STK_NOTFLG");
-            printf("content:0x%x\n", GETWORD(scanptr68k));
+            printf("content:0x%x\n", GETWORD((DLword *)scanptr68k));
             return(1);
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
@@ -915,7 +915,7 @@ int quick_stack_check(void) {
     if (scanptr68k != start68k) {
       if (scanptr68k > endstack68k) {
         WARN("scanptr exceeded end stack",
-             printf("scanptr68k=%p endstack68k=%p", scanptr68k, endstack68k));
+             printf("scanptr68k=%p endstack68k=%p", (void *)scanptr68k, (void *)endstack68k));
       }
     }
   } /* while end */

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -356,7 +356,7 @@ void dump_fnbody(LispPTR fnblockaddr)
   fnobj = (struct fnhead *)Addr68k_from_LADDR(fnblockaddr);
 
   printf("***DUMP Func Obj << ");
-  printf("start at 0x%x lisp address(%p 68k)\n", LADDR_from_68k(fnobj), fnobj);
+  printf("start at 0x%x lisp address(%p 68k)\n", LADDR_from_68k(fnobj), (void *)fnobj);
 
   print(fnobj->framename);
   putchar('\n');
@@ -375,7 +375,7 @@ void dump_fnbody(LispPTR fnblockaddr)
   for (i = 20; i < (fnobj->startpc); i += 2) {
     int word;
     word = (int)(0xffff & (GETWORD((DLword *)(scratch + i))));
-    printf(" 0x%x(%p 68k): 0%6o  0x%4x\n", LADDR_from_68k(scratch + i), scratch + i, word, word);
+    printf(" 0x%x(%p 68k): 0%6o  0x%4x\n", LADDR_from_68k(scratch + i), (void *)(scratch + i), word, word);
   }
 
   scratch = (DLbyte *)fnobj + (fnobj->startpc);
@@ -1196,8 +1196,8 @@ void all_stack_dump(DLword start, DLword end, DLword silent)
 
       badblock:
         SD_morep;
-        printf("\n0x%x: Invalid, %x %x", LADDR_from_68k(stkptr), GETWORD(stkptr),
-               GETWORD(stkptr + 1));
+        printf("\n0x%x: Invalid, %x %x", LADDR_from_68k(stkptr), GETWORD((DLword *)stkptr),
+               GETWORD((DLword *)(stkptr + 1)));
       incptr:
         stkptr = (STKH *)(((DLword *)stkptr) + 2);
         break;

--- a/src/timer.c
+++ b/src/timer.c
@@ -473,7 +473,7 @@ static void int_timer_init()
   timert.it_interval.tv_usec = timert.it_value.tv_usec = TIMER_INTERVAL;
   setitimer(ITIMER_VIRTUAL, &timert, NULL);
 
-  DBPRINT(("Timer interval set to %d usec\n", timert.it_value.tv_usec));
+  DBPRINT(("Timer interval set to %ld usec\n", (long)timert.it_value.tv_usec));
 #endif /* DOS */
 }
 

--- a/src/tty.c
+++ b/src/tty.c
@@ -198,6 +198,6 @@ void tty_debug(const char *name)
 
   printf("DEBUG:\n");
   printf("DEBUG: \t\tSymbol       Address        Contents\n");
-  printf("DEBUG: \t\tIOPAGE       %p\n", Addr68k_from_LADDR(IOPAGE_OFFSET));
+  printf("DEBUG: \t\tIOPAGE       %p\n", (void *)Addr68k_from_LADDR(IOPAGE_OFFSET));
   /* In the future, we could print out the various fields of DLTTYOut, DLTTYIn, and DLTTYPortCmd */
 }

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -270,7 +270,7 @@ int fork_Unix() {
       perror("Error reading packet by slave");
       exit(0);
     } else if (len != 6) {
-      DBPRINT(("Input packet wrong length: %d", len));
+      DBPRINT(("Input packet wrong length: %zd", len));
       exit(0);
     }
     slot = IOBuf[3];
@@ -420,7 +420,7 @@ int fork_Unix() {
           IOBuf[1] = pid & 0xFF;
           IOBuf[0] = (pid >> 8) & 0xFF;
         }
-        DBPRINT(("wait3 returned pid = %d.\n", pid));
+        DBPRINT(("wait3 returned pid = %ld.\n", (long)pid));
       }
 
       break;

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -413,7 +413,7 @@ LispPTR vmem_save(char *sysout_file_name)
         contig_pages++, oldfptovp++, i++;
       }
       i--; /* Previous loop always overbumps i */
-      DBPRINT(("%4d: writing %d pages from %x (%d)\n", i, contig_pages, base_addr - (char *)Lisp_world, saveoldfptovp));
+      DBPRINT(("%4d: writing %d pages from %tx (%d)\n", i, contig_pages, base_addr - (char *)Lisp_world, saveoldfptovp));
 
 #ifdef BYTESWAP
       word_swap_page((unsigned short *)base_addr, contig_pages * BYTESPER_PAGE / 4);

--- a/src/xc.c
+++ b/src/xc.c
@@ -246,9 +246,7 @@ nextopcode:
   if ((struct fnhead *)Addr68k_from_LADDR(0x2ed600) == FuncObj) {
     quick_stack_check();
 #endif /* MYOPTRACE */
-
-    OPTPRINT(
-             ("PC= 0x%x (fn+%d) op= 0%o TOS= 0x%x\n", (int)PCMAC, (int)PCMAC - (int)FuncObj, Get_BYTE_PCMAC0, TOPOFSTACK));
+    OPTPRINT(("PC= %p (fn+%td) op= %02x TOS= 0x%x\n", (void *)PCMAC, PCMAC - (char *)FuncObj, Get_BYTE_PCMAC0, TOPOFSTACK));
 #ifdef MYOPTRACE
   }
 #endif /* MYOPTRACE */


### PR DESCRIPTION
Many of the warnings were newly visible after the DBPRINT macro
was modified, but the pedantic warnings also caught existing printf
family usage which was not strictly correct.

Mostly replacing 0x%x with %p for pointers, adding (void *) for
those and other pointers, %td for ptrdiff_t, but also changing
some function parameters from UNSIGNED (uintptr_t) to int
where that was the more appropriate type.