### PR TITLE
Start to address warnings from -Weverything

### DIFF
--- a/inc/allocmdsdefs.h
+++ b/inc/allocmdsdefs.h
@@ -1,6 +1,6 @@
 #ifndef ALLOCMDSDEFS_H
 #define ALLOCMDSDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
-LispPTR initmdspage(register LispPTR *base, register DLword size, register LispPTR prev);
-LispPTR *alloc_mdspage(register short int type);
+LispPTR initmdspage(LispPTR *base, DLword size, LispPTR prev);
+LispPTR *alloc_mdspage(short int type);
 #endif

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -80,7 +80,7 @@ static inline LispPTR GetPosSmallp(unsigned long x) {
         switch (GetTypeNumber(sour)) {                                                    \
           case TYPE_FIXP: (dest) = FIXP_VALUE(sour); break;               \
           case TYPE_FLOATP: {                                                             \
-            register float temp;                                                          \
+            float temp;                                                          \
             temp = FLOATP_VALUE(sour);                                                    \
             /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                              \
             if ((temp > ((float)0x7fffffff)) || (temp < ((float)0x80000000))) goto label; \

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -38,29 +38,27 @@
 
 #define N_GETNUMBER(sour, dest, label)                        \
   do {                                                        \
-    (dest) = (sour); /* access memory once */                 \
-    switch (SEGMASK & (dest)) {                               \
-      case S_POSITIVE: (dest) &= 0xFFFF; break;       \
-      case S_NEGATIVE: (dest) |= (int)0xFFFF0000; break; \
+    switch (SEGMASK & (sour)) {                               \
+    case S_POSITIVE: (dest) = (int)((sour) & 0xFFFF); break;  \
+    case S_NEGATIVE: (dest) = (int)((sour) | 0xFFFF0000); break; \
       default:                                                \
         /* NOLINTNEXTLINE(bugprone-macro-parentheses) */      \
-        if (GetTypeNumber(dest) != TYPE_FIXP) goto label;     \
-        (dest) = FIXP_VALUE(dest);                            \
+        if (GetTypeNumber(sour) != TYPE_FIXP) goto label;     \
+        (dest) = FIXP_VALUE(sour);                            \
     }                                                         \
   } while (0)
 
 #define N_IGETNUMBER(sour, dest, label)                                                   \
   do {                                                                                    \
-    (dest) = (sour); /* access memory once */                                             \
-    switch (SEGMASK & (dest)) {                                                           \
-      case S_POSITIVE: (dest) &= 0xFFFF; break;                                   \
-      case S_NEGATIVE: (dest) |= (int)0xFFFF0000; break; \
+    switch (SEGMASK & (sour)) {                                                           \
+    case S_POSITIVE: (dest) = (int)((sour) & 0xFFFF); break;            \
+    case S_NEGATIVE: (dest) = (int)((sour) | 0xFFFF0000); break;        \
       default:                                                                            \
-        switch (GetTypeNumber(dest)) {                                                    \
-          case TYPE_FIXP: (dest) = FIXP_VALUE(dest); break;               \
+        switch (GetTypeNumber(sour)) {                                                    \
+          case TYPE_FIXP: (dest) = FIXP_VALUE(sour); break;               \
           case TYPE_FLOATP: {                                                             \
             register float temp;                                                          \
-            temp = FLOATP_VALUE(dest);                                                    \
+            temp = FLOATP_VALUE(sour);                                                    \
             /* NOLINTNEXTLINE(bugprone-macro-parentheses) */                              \
             if ((temp > ((float)0x7fffffff)) || (temp < ((float)0x80000000))) goto label; \
             (dest) = (int)temp;                                                           \

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -22,15 +22,22 @@
 #define MAX_FIXP 2147483647  /* == 0x7FFFFFFF  */
 #define MIN_FIXP (-2147483648) /* == 0x80000000  */
 
-#define GetSmalldata(x)          \
-  (((SEGMASK & (x)) == S_POSITIVE)            \
-       ? (0xFFFF & (x))            \
-       : (((SEGMASK & (x)) == S_NEGATIVE) ? (0xFFFF0000 | (x)) : error("Not smallp address")))
+static inline int GetSmalldata(LispPTR x) {
+  if ((SEGMASK & (int)x) == S_POSITIVE) return (int)(x & 0xFFFF);
+  if ((SEGMASK & (int)x) == S_NEGATIVE) return (int)(x | 0xFFFF0000);
+  error("Not smallp address");
+  return (0);
+}
 
-#define GetSmallp(x)                                                                  \
-  ((0xFFFF0000 & (x)) ? (((0xFFFF0000 & (x)) == 0xFFFF0000) ? (S_NEGATIVE | (0xFFFF & (x))) \
-                                                        : error("Not Smallp data"))   \
-                    : (S_POSITIVE | (0xFFFF & (x))))
+static inline LispPTR GetSmallp(int x) {
+  if (x >= 0) {
+    if (x <= MAX_SMALL) return (LispPTR)(S_POSITIVE | x);
+  } else {
+    if (x >= MIN_SMALL) return (LispPTR)(S_NEGATIVE | (x & 0xFFFF));
+  }
+  error("Not Smallp data");
+  return (S_POSITIVE | 0);
+}
 
 #define FIXP_VALUE(dest) *((int *)Addr68k_from_LADDR(dest))
 

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -75,39 +75,15 @@
       case 0: (result) = (S_POSITIVE | (int)(arg)); break;                 \
       case (int)0xFFFF0000: (result) = (S_NEGATIVE | (0xFFFF & (arg))); break; \
       default: {                                                           \
-        register LispPTR *wordp;                                           \
+        int *fixpp;                                           \
         /* arg is FIXP, call createcell */                                 \
-        wordp = (LispPTR *)createcell68k(TYPE_FIXP);                       \
-        *((int *)wordp) = (int)(arg);                                      \
-        (result) = (LADDR_from_68k(wordp));                                \
+        fixpp = (int *)createcell68k(TYPE_FIXP);                       \
+        *((int *)fixpp) = (int)(arg);                                      \
+        (result) = (LADDR_from_68k(fixpp));                                \
         break;                                                             \
       }                                                                    \
     }                                                                      \
   } while (0)
-
-/* *******
-        NEED to See if this is faster than the N_ARITH_SWITCH macro
-
-        if( (MIN_FIXP <= result) && (result <= MAX_FIXP) ){
-                if(0 <= result){
-                        if(result <= MAX_SMALL)
-                                return(S_POSITIVE | result);
-                        else{
-                                wordp = createcell68k(TYPE_FIXP);
-                                *((unsigned int *)wordp) = result;
-                                return(LADDR_from_68k(wordp));
-                        }
-                }else{
-                        if(MIN_SMALL <= result)
-                                return(S_NEGATIVE | (0xFFFF & result));
-                        else{
-                                wordp = createcell68k(TYPE_FIXP);
-                                *((unsigned int *)wordp) = result;
-                                return(LADDR_from_68k(wordp));
-                        }
-                }/
-        }
-****** */
 
 #define N_ARITH_SWITCH(arg)                                  \
   do {                                                       \
@@ -115,10 +91,10 @@
     case 0: return (LispPTR) (S_POSITIVE | (arg));                       \
     case (int)0xFFFF0000: return (LispPTR)(S_NEGATIVE | (0xFFFF & (arg))); \
       default: {                                             \
-        register LispPTR *fixpp;                             \
+        int *fixpp;                             \
         /* arg is FIXP, call createcell */                   \
-        fixpp = (LispPTR *)createcell68k(TYPE_FIXP);         \
-        *((int *)fixpp) = arg;                               \
+        fixpp = (int *)createcell68k(TYPE_FIXP);         \
+        *fixpp = arg;                                       \
         return (LADDR_from_68k(fixpp));                      \
       }                                                      \
     }                                                        \

--- a/inc/arith.h
+++ b/inc/arith.h
@@ -22,6 +22,9 @@
 #define MAX_FIXP 2147483647  /* == 0x7FFFFFFF  */
 #define MIN_FIXP (-2147483648) /* == 0x80000000  */
 
+/**
+ * extract an integer value from a smallp
+ */
 static inline int GetSmalldata(LispPTR x) {
   if ((SEGMASK & (int)x) == S_POSITIVE) return (int)(x & 0xFFFF);
   if ((SEGMASK & (int)x) == S_NEGATIVE) return (int)(x | 0xFFFF0000);
@@ -29,12 +32,25 @@ static inline int GetSmalldata(LispPTR x) {
   return (0);
 }
 
-static inline LispPTR GetSmallp(int x) {
+/**
+ * construct a smallp from an integer value
+ */
+
+static inline LispPTR GetSmallp(long x) {
   if (x >= 0) {
     if (x <= MAX_SMALL) return (LispPTR)(S_POSITIVE | x);
   } else {
     if (x >= MIN_SMALL) return (LispPTR)(S_NEGATIVE | (x & 0xFFFF));
   }
+  error("Not Smallp data");
+  return (S_POSITIVE | 0);
+}
+
+/**
+ * construct a smallp from an unsigned value
+ */
+static inline LispPTR GetPosSmallp(unsigned long x) {
+  if (x <= MAX_SMALL) return (LispPTR)(S_POSITIVE | x);
   error("Not Smallp data");
   return (S_POSITIVE | 0);
 }

--- a/inc/arithopsdefs.h
+++ b/inc/arithopsdefs.h
@@ -1,23 +1,23 @@
 #ifndef ARITHOPSDEFS_H
 #define ARITHOPSDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_plus2(int tosm1, int tos);
-LispPTR N_OP_iplus2(int tosm1, int tos);
-LispPTR N_OP_difference(int tosm1, int tos);
-LispPTR N_OP_idifference(int tosm1, int tos);
-LispPTR N_OP_logxor(int tosm1, int tos);
-LispPTR N_OP_logand(int tosm1, int tos);
-LispPTR N_OP_logor(int tosm1, int tos);
-LispPTR N_OP_greaterp(int tosm1, int tos);
-LispPTR N_OP_igreaterp(int tosm1, int tos);
-LispPTR N_OP_iplusn(int tos, int n);
-LispPTR N_OP_idifferencen(int tos, int n);
-LispPTR N_OP_makenumber(int tosm1, int tos);
-LispPTR N_OP_boxiplus(int a, int tos);
-LispPTR N_OP_boxidiff(int a, int tos);
-LispPTR N_OP_times2(int tosm1, int tos);
-LispPTR N_OP_itimes2(int tosm1, int tos);
-LispPTR N_OP_quot(int tosm1, int tos);
-LispPTR N_OP_iquot(int tosm1, int tos);
-LispPTR N_OP_iremainder(int tosm1, int tos);
+LispPTR N_OP_plus2(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_iplus2(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_difference(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_idifference(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_logxor(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_logand(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_logor(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_greaterp(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_igreaterp(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_iplusn(LispPTR tos, int n);
+LispPTR N_OP_idifferencen(LispPTR tos, int n);
+LispPTR N_OP_makenumber(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_boxiplus(LispPTR a, LispPTR tos);
+LispPTR N_OP_boxidiff(LispPTR a, LispPTR tos);
+LispPTR N_OP_times2(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_itimes2(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_quot(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_iquot(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_iremainder(LispPTR tosm1, LispPTR tos);
 #endif

--- a/inc/bb.h
+++ b/inc/bb.h
@@ -389,7 +389,7 @@
  do_partial_transfer						\
  dst32addr++;							\
  switch (op)							\
- { register int cnt;						\
+ { int cnt;						\
    case op_repl_src: ForInner { DestGetsF(=)  } break;		\
    case op_fn_and:   ForInner { DestGetsF(&=) } break;		\
    case op_fn_or:    ForInner { DestGetsF(|=) } break;		\
@@ -416,14 +416,14 @@
  if (aligned_loop)						\
  {								\
    if (src_comp) switch (op)					\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {*dst32addr++  = ~*src32addr++;} break;	\
      case op_fn_and:   ForInner {*dst32addr++ &= ~*src32addr++;} break;	\
      case op_fn_or:    ForInner {*dst32addr++ |= ~*src32addr++;} break;	\
      case op_fn_xor:   ForInner {*dst32addr++ ^= ~*src32addr++;} break;	\
    }									\
    else switch (op)							\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {*dst32addr++  = *src32addr++;} break;	\
      case op_fn_and:   ForInner {*dst32addr++ &= *src32addr++;} break;	\
      case op_fn_or:    ForInner {*dst32addr++ |= *src32addr++;} break;	\
@@ -433,14 +433,14 @@
  else									\
  {									\
    if (src_comp) switch (op)						\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {GetSrcCF DestGetsF(=)  } break;	\
      case op_fn_and:   ForInner {GetSrcCF DestGetsF(&=) } break;	\
      case op_fn_or:    ForInner {GetSrcCF DestGetsF(|=) } break;	\
      case op_fn_xor:   ForInner {GetSrcCF DestGetsF(^=) } break;	\
    }									\
    else switch (op)							\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {GetSrcF  DestGetsF(=)  } break;	\
      case op_fn_and:   ForInner {GetSrcF  DestGetsF(&=) } break;	\
      case op_fn_or:    ForInner {GetSrcF  DestGetsF(|=) } break;	\
@@ -470,14 +470,14 @@
  if (aligned_loop)						\
  {								\
    if (src_comp) switch (op)					\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {*dst32addr--  = ~*src32addr--;} break;	\
      case op_fn_and:   ForInner {*dst32addr-- &= ~*src32addr--;} break;	\
      case op_fn_or:    ForInner {*dst32addr-- |= ~*src32addr--;} break;	\
      case op_fn_xor:   ForInner {*dst32addr-- ^= ~*src32addr--;} break;	\
    }									\
    else switch (op)							\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {*dst32addr--  = *src32addr--;} break;	\
      case op_fn_and:   ForInner {*dst32addr-- &= *src32addr--;} break;	\
      case op_fn_or:    ForInner {*dst32addr-- |= *src32addr--;} break;	\
@@ -487,14 +487,14 @@
  else									\
  {									\
    if (src_comp) switch (op)						\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {GetSrcCB DestGetsB(=)  } break;	\
      case op_fn_and:   ForInner {GetSrcCB DestGetsB(&=) } break;	\
      case op_fn_or:    ForInner {GetSrcCB DestGetsB(|=) } break;	\
      case op_fn_xor:   ForInner {GetSrcCB DestGetsB(^=) } break;	\
    }									\
    else switch (op)							\
-   { register int cnt;							\
+   { int cnt;							\
      case op_repl_src: ForInner {GetSrcB  DestGetsB(=)  } break;	\
      case op_fn_and:   ForInner {GetSrcB  DestGetsB(&=) } break;	\
      case op_fn_or:    ForInner {GetSrcB  DestGetsB(|=) } break;	\
@@ -698,7 +698,7 @@
 /*	However, YOU must set up the control variables that are used	*/
 /*	as "arguments" to the bitblt code:				*/
 /*									*/
-/*	register DLword	*srcbase, *dstbase;				*/
+/*	DLword	*srcbase, *dstbase;				*/
 /*	int	sx, dx, w, h, srcbpl, dstbpl, backwardflg;		*/
 /*	int	src_comp, op, gray, num_gray, curr_gray_line;		*/
 /*									*/
@@ -713,9 +713,9 @@ int abc, dst32rbit, src32rbit, fwd;				\
 unsigned int *OrigSrcAddr, *OrigDstAddr;			\
 int bb_fast;							\
 unsigned int preloop_mask, postloop_mask, sdw_mask;		\
-register unsigned int *dst32addr, *src32addr;			\
-register unsigned int shS, savedS, newS;			\
-register int srcRshift;
+unsigned int *dst32addr, *src32addr;			\
+unsigned int shS, savedS, newS;			\
+int srcRshift;
 
 
 

--- a/inc/bindefs.h
+++ b/inc/bindefs.h
@@ -1,5 +1,5 @@
 #ifndef BINDEFS_H
 #define BINDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_bin(register int tos);
+LispPTR N_OP_bin(LispPTR tos);
 #endif

--- a/inc/bindsdefs.h
+++ b/inc/bindsdefs.h
@@ -1,7 +1,7 @@
 #ifndef BINDSDEFS_H
 #define BINDSDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR *N_OP_bind(register LispPTR *stack_pointer, register LispPTR tos, int byte1, int byte2);
-LispPTR *N_OP_unbind(register LispPTR *stack_pointer);
-LispPTR *N_OP_dunbind(register LispPTR *stack_pointer, register LispPTR tos);
+LispPTR *N_OP_bind(LispPTR *stack_pointer, LispPTR tos, int byte1, int byte2);
+LispPTR *N_OP_unbind(LispPTR *stack_pointer);
+LispPTR *N_OP_dunbind(LispPTR *stack_pointer, LispPTR tos);
 #endif

--- a/inc/bitbltdefs.h
+++ b/inc/bitbltdefs.h
@@ -1,7 +1,7 @@
 #ifndef BITBLTDEFS_H
 #define BITBLTDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
-LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl,int tos);
+LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl, LispPTR tos);
 int cursorin(DLword addrhi, DLword addrlo, int w, int h, int backward);
 #endif
 

--- a/inc/bltdefs.h
+++ b/inc/bltdefs.h
@@ -1,6 +1,6 @@
 #ifndef BLTDEFS_H
 #define BLTDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_blt(LispPTR destptr, LispPTR sourceptr, register LispPTR wordcount);
+LispPTR N_OP_blt(LispPTR destptr, LispPTR sourceptr, LispPTR wordcount);
 #endif
 

--- a/inc/byteswapdefs.h
+++ b/inc/byteswapdefs.h
@@ -16,7 +16,7 @@ static inline unsigned int swapx(unsigned int word) {
 /*                                                              */
 /****************************************************************/
 static inline unsigned short byte_swap_word(unsigned short word) {
-  return (((word >> 8) & 0xff) | ((word & 0xff) << 8));
+  return ((word >> 8) | (unsigned short)((word & 0xff) << 8));
 }
 
 void byte_swap_page(unsigned short *page, int wordcount);

--- a/inc/car-cdrdefs.h
+++ b/inc/car-cdrdefs.h
@@ -2,13 +2,13 @@
 #define CAR_CDRDEFS_H 1
 #include "cell.h" /* for ConsCell */
 #include "lispemul.h" /* for LispPTR */
-LispPTR car(register LispPTR datum);
-LispPTR cdr(register LispPTR datum);
-LispPTR rplaca(register LispPTR x, register LispPTR y);
-LispPTR rplacd(LispPTR x, register LispPTR y);
-LispPTR N_OP_car(register LispPTR tos);
-LispPTR N_OP_cdr(register LispPTR tos);
-LispPTR N_OP_rplaca(register LispPTR tosm1, register LispPTR tos);
-LispPTR N_OP_rplacd(register LispPTR tosm1, register LispPTR tos);
+LispPTR car(LispPTR datum);
+LispPTR cdr(LispPTR datum);
+LispPTR rplaca(LispPTR x, LispPTR y);
+LispPTR rplacd(LispPTR x, LispPTR y);
+LispPTR N_OP_car(LispPTR tos);
+LispPTR N_OP_cdr(LispPTR tos);
+LispPTR N_OP_rplaca(LispPTR tosm1, LispPTR tos);
+LispPTR N_OP_rplacd(LispPTR tosm1, LispPTR tos);
 ConsCell *find_close_prior_cell(struct conspage *page, LispPTR oldcell);
 #endif

--- a/inc/cell.h
+++ b/inc/cell.h
@@ -417,7 +417,7 @@ struct cadr_cell {
 
 #define S_N_CHECKANDCADR(sour, dest, tos)    \
   {                                          \
-    register LispPTR parm = sour;            \
+    LispPTR parm = sour;            \
     if (GetTypeNumber(parm) != TYPE_LISTP) { \
       ERROR_EXIT(tos);                       \
     } else                                   \

--- a/inc/conspagedefs.h
+++ b/inc/conspagedefs.h
@@ -2,6 +2,6 @@
 #define CONSPAGEDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
 struct conspage *next_conspage(void);
-LispPTR N_OP_cons(register int cons_car, register int cons_cdr);
+LispPTR N_OP_cons(int cons_car, int cons_cdr);
 LispPTR cons(LispPTR cons_car, LispPTR cons_cdr);
 #endif

--- a/inc/dirdefs.h
+++ b/inc/dirdefs.h
@@ -67,7 +67,7 @@ int make_old_version(char *old, char *file);
 void print_finfo(FINFO *fp);
 #endif
 int init_finfo(void);
-LispPTR COM_gen_files(register LispPTR *args);
-LispPTR COM_next_file(register LispPTR *args);
-LispPTR COM_finish_finfo(register LispPTR *args);
+LispPTR COM_gen_files(LispPTR *args);
+LispPTR COM_next_file(LispPTR *args);
+LispPTR COM_finish_finfo(LispPTR *args);
 #endif

--- a/inc/dskdefs.h
+++ b/inc/dskdefs.h
@@ -6,20 +6,20 @@ void separate_host(char *lfname, char *host, char *drive);
 #else
 void separate_host(char *lfname, char *host);
 #endif
-LispPTR COM_openfile(register LispPTR *args);
-LispPTR COM_closefile(register LispPTR *args);
-LispPTR DSK_getfilename(register LispPTR *args);
-LispPTR DSK_deletefile(register LispPTR *args);
-LispPTR DSK_renamefile(register LispPTR *args);
-LispPTR DSK_directorynamep(register LispPTR *args);
-LispPTR COM_getfileinfo(register LispPTR *args);
-LispPTR COM_setfileinfo(register LispPTR *args);
-LispPTR COM_readpage(register LispPTR *args);
-LispPTR COM_writepage(register LispPTR *args);
-LispPTR COM_truncatefile(register LispPTR *args);
-LispPTR COM_changedir(register LispPTR *args);
-LispPTR COM_getfreeblock(register LispPTR *args);
+LispPTR COM_openfile(LispPTR *args);
+LispPTR COM_closefile(LispPTR *args);
+LispPTR DSK_getfilename(LispPTR *args);
+LispPTR DSK_deletefile(LispPTR *args);
+LispPTR DSK_renamefile(LispPTR *args);
+LispPTR DSK_directorynamep(LispPTR *args);
+LispPTR COM_getfileinfo(LispPTR *args);
+LispPTR COM_setfileinfo(LispPTR *args);
+LispPTR COM_readpage(LispPTR *args);
+LispPTR COM_writepage(LispPTR *args);
+LispPTR COM_truncatefile(LispPTR *args);
+LispPTR COM_changedir(LispPTR *args);
+LispPTR COM_getfreeblock(LispPTR *args);
 void separate_version(char *name, char *ver, int checkp);
 int unpack_filename(char *file, char *dir, char *name, char *ver, int checkp);
-int true_name(register char *path);
+int true_name(char *path);
 #endif

--- a/inc/dspsubrsdefs.h
+++ b/inc/dspsubrsdefs.h
@@ -5,7 +5,7 @@ void DSP_dspbout(LispPTR *args);
 void DSP_showdisplay(LispPTR *args);
 LispPTR DSP_VideoColor(LispPTR *args);
 void DSP_Cursor(LispPTR *args, int argnum);
-void DSP_SetMousePos(register LispPTR *args);
+void DSP_SetMousePos(LispPTR *args);
 LispPTR DSP_ScreenWidth(LispPTR *args);
 LispPTR DSP_ScreenHight(LispPTR *args);
 void flip_cursor(void);

--- a/inc/eqfdefs.h
+++ b/inc/eqfdefs.h
@@ -1,8 +1,8 @@
 #ifndef EQFDEFS_H
 #define EQFDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_clequal(int arg1, int arg2);
-LispPTR N_OP_eqlop(int arg1, int arg2);
-LispPTR N_OP_equal(int arg1, int arg2);
-LispPTR N_OP_eqq(int arg1, int arg2);
+LispPTR N_OP_clequal(LispPTR arg1, LispPTR arg2);
+LispPTR N_OP_eqlop(LispPTR arg1, LispPTR arg2);
+LispPTR N_OP_equal(LispPTR arg1, LispPTR arg2);
+LispPTR N_OP_eqq(LispPTR arg1, LispPTR arg2);
 #endif

--- a/inc/eqfdefs.h
+++ b/inc/eqfdefs.h
@@ -1,8 +1,8 @@
 #ifndef EQFDEFS_H
 #define EQFDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_clequal(register int arg1, register int arg2);
-LispPTR N_OP_eqlop(register int arg1, register int arg2);
-LispPTR N_OP_equal(register int arg1, register int arg2);
-LispPTR N_OP_eqq(register int arg1, register int arg2);
+LispPTR N_OP_clequal(int arg1, int arg2);
+LispPTR N_OP_eqlop(int arg1, int arg2);
+LispPTR N_OP_equal(int arg1, int arg2);
+LispPTR N_OP_eqq(int arg1, int arg2);
 #endif

--- a/inc/etherdefs.h
+++ b/inc/etherdefs.h
@@ -13,5 +13,5 @@ int *ether_debug(void);
 LispPTR check_ether(void);
 void init_ifpage_ether(void);
 void init_ether(void);
-LispPTR check_sum(register LispPTR *args);
+LispPTR check_sum(LispPTR *args);
 #endif

--- a/inc/findkeydefs.h
+++ b/inc/findkeydefs.h
@@ -1,5 +1,5 @@
 #ifndef FINDKEYDEFS_H
 #define FINDKEYDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_findkey(register LispPTR tos, register int byte);
+LispPTR N_OP_findkey(LispPTR tos, int byte);
 #endif

--- a/inc/fvardefs.h
+++ b/inc/fvardefs.h
@@ -2,10 +2,10 @@
 #define FVARDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
 #include "stack.h" /* for fnhead, frameex1 */
-LispPTR N_OP_fvarn(register int n);
+LispPTR N_OP_fvarn(int n);
 LispPTR N_OP_stkscan(LispPTR tos);
-LispPTR N_OP_fvar_(register LispPTR tos, register int n);
-void nnewframe(register struct frameex1 *newpfra2, register DLword *achain, register int name);
-void nfvlookup(struct frameex1 *apframe1, register DLword *achain, register struct fnhead *apfnhead1);
+LispPTR N_OP_fvar_(LispPTR tos, int n);
+void nnewframe(struct frameex1 *newpfra2, DLword *achain, int name);
+void nfvlookup(struct frameex1 *apframe1, DLword *achain, struct fnhead *apfnhead1);
 LispPTR native_newframe(int slot);
 #endif

--- a/inc/gcscandefs.h
+++ b/inc/gcscandefs.h
@@ -1,6 +1,6 @@
 #ifndef GCSCANDEFS_H
 #define GCSCANDEFS_H 1
 #include "lispemul.h" /* for DLword */
-DLword gcscan1(register int probe);
-DLword gcscan2(register int probe);
+DLword gcscan1(int probe);
+DLword gcscan2(int probe);
 #endif

--- a/inc/gvar2defs.h
+++ b/inc/gvar2defs.h
@@ -1,6 +1,6 @@
 #ifndef GVAR2DEFS_H
 #define GVAR2DEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_gvar_(register LispPTR tos, unsigned int atom_index);
-LispPTR N_OP_rplptr(register LispPTR tos_m_1, register LispPTR tos, unsigned int alpha);
+LispPTR N_OP_gvar_(LispPTR tos, unsigned int atom_index);
+LispPTR N_OP_rplptr(LispPTR tos_m_1, LispPTR tos, unsigned int alpha);
 #endif

--- a/inc/inlineC.h
+++ b/inc/inlineC.h
@@ -101,7 +101,7 @@
 #define OPCAR                                                                                     \
   do {                                                                                            \
     if (Listp(TOPOFSTACK)) {                                                                      \
-      register ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));                 \
+      ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));                 \
       if (DATUM68K->cdr_code == CDR_INDIRECT) {                                                   \
         TOPOFSTACK = ((LispPTR)((ConsCell *)Addr68k_from_LADDR(DATUM68K->car_field))->car_field); \
         nextop1;                                                                                  \
@@ -122,8 +122,8 @@
 #define OPCDR                                                                              \
   do {                                                                                     \
     if (Listp(TOPOFSTACK)) {                                                               \
-      register ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));          \
-      register int CDRCODEX = DATUM68K->cdr_code;                                          \
+      ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));          \
+      int CDRCODEX = DATUM68K->cdr_code;                                          \
       if (CDRCODEX == CDR_NIL) {                                                           \
         /* cdr-nil */                                                                      \
         TOPOFSTACK = (NIL_PTR);                                                            \
@@ -152,8 +152,8 @@
 #define OPCDR                                                                                  \
   do {                                                                                         \
     if (Listp(TOPOFSTACK)) {                                                                   \
-      register ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));              \
-      register int CDRCODEX = DATUM68K->cdr_code;                                              \
+      ConsCell *DATUM68K = (ConsCell *)(Addr68k_from_LADDR(TOPOFSTACK));              \
+      int CDRCODEX = DATUM68K->cdr_code;                                              \
       if (CDRCODEX == CDR_NIL) {                                                               \
         /* cdr-nil */                                                                          \
         TOPOFSTACK = (NIL_PTR);                                                                \
@@ -250,8 +250,8 @@
   } while (0)
 #define PUTBASEBYTE                                                                    \
   do {                                                                                 \
-    register int byteoffset;                                                           \
-    register char *p_data;                                                             \
+    int byteoffset;                                                           \
+    char *p_data;                                                             \
     if (((SEGMASK & TOPOFSTACK) != S_POSITIVE) || ((unsigned short)TOPOFSTACK >= 256)) \
       goto op_ufn;                                                                     \
     byteoffset = GET_TOS_1;                                                            \
@@ -290,7 +290,7 @@
 
 #define PUTBASEPTR_N(n)                                        \
   do {                                                         \
-    register int base;                                         \
+    int base;                                         \
     base = POINTERMASK & POP_TOS_1;                            \
     *((LispPTR *)Addr68k_from_LADDR(base + (n))) = TOPOFSTACK; \
     TOPOFSTACK = base;                                         \
@@ -299,7 +299,7 @@
 
 #define PUTBASE_N(n)                                                           \
   do {                                                                         \
-    register int base;                                                         \
+    int base;                                                         \
     if (GetHiWord(TOPOFSTACK) != (S_POSITIVE >> 16)) goto op_ufn;              \
     base = POINTERMASK & POP_TOS_1;                                            \
     GETWORD((DLword *)Addr68k_from_LADDR(base + (n))) = GetLoWord(TOPOFSTACK); \
@@ -337,7 +337,7 @@
 #elif defined(BIGVM)
 #define GVAR(x)                                                                  \
   do {                                                                           \
-    register int tx = x;                                                         \
+    int tx = x;                                                         \
     if (tx & SEGMASK) {                                                          \
       PUSH(GetLongWord(Addr68k_from_LADDR((tx) + NEWATOM_VALUE_OFFSET)));        \
     } else                                                                       \
@@ -348,7 +348,7 @@
 #else
 #define GVAR(x)                                                           \
   do {                                                                    \
-    register int tx = x;                                                  \
+    int tx = x;                                                  \
     if (tx & SEGMASK) {                                                   \
       PUSH(GetLongWord(Addr68k_from_LADDR((tx) + NEWATOM_VALUE_OFFSET))); \
     } else                                                                \
@@ -366,7 +366,7 @@
 
 #define SWAP                \
   do {                      \
-    register LispPTR temp;  \
+    LispPTR temp;  \
     temp = GET_TOS_1;       \
     GET_TOS_1 = TOPOFSTACK; \
     TOPOFSTACK = temp;      \
@@ -421,8 +421,8 @@
 
 #define BIN                                                                                  \
   do {                                                                                       \
-    register Stream *stream68k; /* stream instance on TOS */                                 \
-    register char *buff68k;     /* pointer to BUFF */                                        \
+    Stream *stream68k; /* stream instance on TOS */                                 \
+    char *buff68k;     /* pointer to BUFF */                                        \
                                                                                              \
     if (GetTypeNumber(TOPOFSTACK) == TYPE_STREAM) {                                          \
       stream68k = (Stream *)Addr68k_from_LADDR(TOPOFSTACK);                                  \
@@ -496,11 +496,11 @@
 
 #define BIND                                                    \
   do {                                                          \
-    register int byte = Get_BYTE_PCMAC1;                        \
-    register unsigned n1;                                       \
-    register unsigned n2;                                       \
-    register LispPTR *ppvar;                                    \
-    register int i;                                             \
+    int byte = Get_BYTE_PCMAC1;                        \
+    unsigned n1;                                       \
+    unsigned n2;                                       \
+    LispPTR *ppvar;                                    \
+    int i;                                             \
     n1 = byte >> 4;                                             \
     n2 = byte & 0xf;                                            \
     ppvar = (LispPTR *)PVAR + 1 + Get_BYTE_PCMAC2;              \
@@ -517,10 +517,10 @@
 
 #define UNBIND                                                  \
   do {                                                          \
-    register int num;                                           \
-    register LispPTR *ppvar;                                    \
-    register int i;                                             \
-    register LispPTR value;                                     \
+    int num;                                           \
+    LispPTR *ppvar;                                    \
+    int i;                                             \
+    LispPTR value;                                     \
     for (; (((int)*--CSTKPTRL) >= 0);)                          \
       ;                                                         \
     value = *CSTKPTR;                                           \
@@ -532,10 +532,10 @@
 
 #define DUNBIND                                                          \
   do {                                                                   \
-    register int num;                                                    \
-    register LispPTR *ppvar;                                             \
-    register int i;                                                      \
-    register LispPTR value;                                              \
+    int num;                                                    \
+    LispPTR *ppvar;                                             \
+    int i;                                                      \
+    LispPTR value;                                              \
     if ((int)TOPOFSTACK < 0) {                                           \
       num = (~TOPOFSTACK) >> 16;                                         \
       if (num != 0) {                                                    \
@@ -567,7 +567,7 @@
 
 #define GETBITS_N_M(a, b)                                                                          \
   do {                                                                                             \
-    register int temp, bb = b;                                                                     \
+    int temp, bb = b;                                                                     \
     temp = 0xF & bb;                                                                               \
     TOPOFSTACK = S_POSITIVE | (((GETWORD(Addr68k_from_LADDR(POINTERMASK & (TOPOFSTACK + (a))))) >> \
                                 (16 - ((0xF & (bb >> 4)) + temp + 1))) &                           \
@@ -578,9 +578,9 @@
 #define PUTBITS_N_M(a, b)                                                                \
   do {                                                                                   \
     int base;                                                                            \
-    register int bb = b;                                                                 \
-    register DLword *pword;                                                              \
-    register int shift_size, field_size, fmask;                                          \
+    int bb = b;                                                                 \
+    DLword *pword;                                                              \
+    int shift_size, field_size, fmask;                                          \
     if ((SEGMASK & TOPOFSTACK) != S_POSITIVE) { goto op_ufn; };                          \
     base = POINTERMASK & POP_TOS_1;                                                      \
     pword = (DLword *)Addr68k_from_LADDR(base + (a));                                    \
@@ -606,7 +606,7 @@
 
 #define MYARGCOUNT                                                \
   do {                                                            \
-    register UNSIGNED arg_num;                                    \
+    UNSIGNED arg_num;                                    \
     if ((CURRENTFX->alink & 1) == 0)                              \
       arg_num = (UNSIGNED)((LispPTR *)(CURRENTFX)-1);             \
     else                                                          \
@@ -671,7 +671,7 @@
 
 #define CLARITHEQUAL                            \
   do {                                          \
-    register int arg2;                          \
+    int arg2;                          \
     SV;                                         \
     arg2 = POP_TOS_1;                           \
     if ((TOPOFSTACK & SEGMASK) == S_POSITIVE) { \
@@ -690,9 +690,9 @@
 #define AREF1                                                                                      \
   do {                                                                                             \
     LispPTR arrayarg;                                                                              \
-    register LispPTR baseL;                                                                        \
-    register int index;                                                                            \
-    register OneDArray *arrayblk;                                                                  \
+    LispPTR baseL;                                                                        \
+    int index;                                                                            \
+    OneDArray *arrayblk;                                                                  \
     SV;                                                                                            \
     arrayarg = POP_TOS_1;                                                                          \
     if (GetTypeNumber(arrayarg) != TYPE_ONED_ARRAY) goto aref_ufn;                                 \
@@ -723,7 +723,7 @@
           case 0: TOPOFSTACK |= S_POSITIVE; break;                                                 \
           case (unsigned)0xFFFF0000: TOPOFSTACK &= S_NEGATIVE; break;                              \
           default: {                                                                               \
-            register DLword *wordp;                                                                \
+            DLword *wordp;                                                                \
             wordp = createcell68k(TYPE_FIXP);                                                      \
             *((int *)wordp) = TOPOFSTACK;                                                          \
             TOPOFSTACK = (LispPTR)LADDR_from_68k(wordp);                                           \
@@ -744,7 +744,7 @@
             S_POSITIVE | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF);      \
         nextop1;                                                                                   \
       case 54: /* Float : 32 bits */ {                                                             \
-        register DLword *wordp;                                                                    \
+        DLword *wordp;                                                                    \
         wordp = createcell68k(TYPE_FLOATP);                                                        \
         *((int *)wordp) = *(((int *)Addr68k_from_LADDR(baseL)) + index);                           \
         TOPOFSTACK = (LispPTR)LADDR_from_68k(wordp);                                               \
@@ -766,8 +766,8 @@
 #ifdef BIGVM
 #define DTEST(n)                                                                                   \
   do {                                                                                             \
-    register int atom_index;                                                                       \
-    register struct dtd *dtd68k;                                                                   \
+    int atom_index;                                                                       \
+    struct dtd *dtd68k;                                                                   \
     atom_index = n;                                                                                \
     for (dtd68k = (struct dtd *)GetDTD(GetTypeNumber(TOPOFSTACK)); atom_index != dtd68k->dtd_name; \
          dtd68k = (struct dtd *)GetDTD(dtd68k->dtd_supertype)) {                                   \
@@ -778,8 +778,8 @@
 #else /* BIGVM */
 #define DTEST(n)                                                               \
   do {                                                                         \
-    register int atom_index;                                                   \
-    register struct dtd *dtd68k;                                               \
+    int atom_index;                                                   \
+    struct dtd *dtd68k;                                               \
     atom_index = n;                                                            \
     for (dtd68k = (struct dtd *)GetDTD(GetTypeNumber(TOPOFSTACK));             \
          atom_index != dtd68k->dtd_namelo + ((int)(dtd68k->dtd_namehi) << 16); \
@@ -792,7 +792,7 @@
 
 #define FVAR(n)                                                                             \
   do {                                                                                      \
-    register LispPTR *chain;                                                                \
+    LispPTR *chain;                                                                \
     chain = (LispPTR *)(PVar + (n));                                                        \
     if (WBITSPTR(chain)->LSB) {                                                             \
       PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(native_newframe((n) >> 1))))); \
@@ -804,8 +804,8 @@
 
 #define FVARX(n)                                                                           \
   do {                                                                                     \
-    register int nn = n;                                                                   \
-    register LispPTR *chain;                                                               \
+    int nn = n;                                                                   \
+    LispPTR *chain;                                                               \
     chain = (LispPTR *)(PVar + nn);                                                        \
     if (WBITSPTR(chain)->LSB) {                                                            \
       PUSH(GetLongWord(Addr68k_from_LADDR(POINTERMASK &swapx(native_newframe(nn >> 1))))); \
@@ -835,7 +835,7 @@
 #elif defined(BIGVM)
 #define ATOMCELL_N(n)                                                                             \
   do {                                                                                            \
-    register int nn = n;                                                                          \
+    int nn = n;                                                                          \
     if (0 == ((unsigned int)(TOPOFSTACK &= POINTERMASK) & SEGMASK)) {                             \
       /* old-symbol case; just add cell-number arg */                                             \
       switch (nn) {                                                                               \
@@ -879,7 +879,7 @@
 
 #define ATOMCELL_N(n)                                         \
   do {                                                        \
-    register int nn = n;                                      \
+    int nn = n;                                      \
     if (0 == ((unsigned int)TOPOFSTACK & SEGMASK)) {          \
       /* old-symbol case; just add cell-number arg */         \
       TOPOFSTACK = (nn << 16) + (TOPOFSTACK << 1);            \

--- a/inc/inlnPS2.h
+++ b/inc/inlnPS2.h
@@ -39,8 +39,8 @@
 /*									*/
 /*		   R E G I S T E R   C O N V E N T I O N S		*/
 /*									*/
-/*	The following register conventions hold in the dispatch loop,	*/
-/*	and are set up by register ... asm("...") decls in xc.c:	*/
+/*	The following conventions hold in the dispatch loop,	*/
+/*	and are set up by ... asm("...") decls in xc.c:	*/
 /*									*/
 /*		esi	pccache	- the current PC			*/
 /*		edi	cspcache - the current lisp stack ptr.		*/
@@ -60,7 +60,7 @@
 /*									*/
 /*    G E N E R A L - P U R P O S E   I N L I N E   F U N C T I O N S	*/
 /*									*/
-/*	These functions don't rely on register conventions.		*/
+/*	These functions don't rely on conventions.		*/
 /*									*/
 /************************************************************************/
 
@@ -88,7 +88,7 @@
 extern inline const unsigned int Get_BYTE_PCMAC0fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("leal	-1(%1),%0 \n\
 	xorl	$3,%0 \n\
 	movzbl	(%0),%0 \n\
@@ -99,7 +99,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_BYTE_PCMAC1fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("movl	%1,%0 \n\
 	xorl	$3,%0 \n\
 	movzbl	(%0),%0 \n\
@@ -110,7 +110,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_BYTE_PCMAC2fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("leal	1(%1),%0 \n\
 	xorl	$3,%0 \n\
 	movzbl	(%0),%0 \n\
@@ -121,7 +121,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_BYTE_PCMAC3fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("leal	2(%1),%0 \n\
 	xorl	$3,%0 \n\
 	movzbl	(%0),%0 \n\
@@ -144,7 +144,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_DLword_PCMAC0fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("movl	%1,%%edx \n\
 	xorb	$3,%%dl \n\
 	movzbl	(%%edx),%%eax \n\
@@ -158,7 +158,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_DLword_PCMAC1fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	1(%1),%%edx \n\
 	xorb	$3,%%dl \n\
 	movzbl	(%%edx),%%eax \n\
@@ -173,7 +173,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_DLword_PCMAC2fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	2(%1),%%edx \n\
 	xorb	$3,%%dl \n\
 	movzbl	(%%edx),%%eax \n\
@@ -187,7 +187,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_DLword_PCMAC3fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	3(%1),%%edx \n\
 	xorb	$3,%%dl \n\
 	movzbl	(%%edx),%%eax \n\
@@ -211,7 +211,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC0fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	-1(%1),%%edx	\n\
 	xorb	$3,%%dl		\n\
 	movzbl	(%%edx),%%eax	\n\
@@ -229,7 +229,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC1fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	(%1),%%edx	\n\
 	xorb	$3,%%dl		\n\
 	movzbl	(%%edx),%%eax	\n\
@@ -248,7 +248,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC2fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("leal	1(%1),%%edx	\n\
 	xorb	$3,%%dl		\n\
 	movzbl	(%%edx),%%eax	\n\

--- a/inc/inlnSPARC.h
+++ b/inc/inlnSPARC.h
@@ -26,7 +26,7 @@
 /*
 	Get_BYTE(PCMAC+1);			\
 xc.c:		#define PCMAC pccache
-xc.c:		register InstPtr pccache;
+xc.c:		InstPtr pccache;
 xc.c:		typedef ByteCode *InstPtr;  CHANGED TO
 xc.c:		typedef BYTECODE *InstPtr;
 lispemul.h:	typedef char ByteCode;
@@ -51,7 +51,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 
 #define BOX_INTO(result, dest){					\
 	if (NSMALLP_RANGE(result))/* dest = box_fixp(result);*/	\
-		{register LispPTR *wordp; 			\
+		{LispPTR *wordp; 			\
 		wordp = (LispPTR *) createcell68k(TYPE_FIXP);	\
 		*((int *)wordp) = result;			\
 		dest = (LADDR_from_68k(wordp));	}		\
@@ -59,7 +59,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 
 
 #define ARITH_OP(op, exceptions, handler) 			\
-	{register int arg1, arg2, result;			\
+	{int arg1, arg2, result;			\
 	arg1 = GET_TOS_1;		 /* w/o side effect */	\
 	if(!NSMALLP(TOPOFSTACK) && !NSMALLP(arg1)) {		\
 		arg2 = UNBOX_SMALLP(TOPOFSTACK);		\
@@ -71,7 +71,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 	N_OP_CALL_2(handler); }
 
 #define BINARY_OP(exp, exceptions) {				\
-	register int arg1, arg2, result;			\
+	int arg1, arg2, result;			\
 	arg1 = GET_TOS_1;		 /* w/o side effect */	\
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg2);			\
 	UNBOX_ELSE_UFN(arg1, arg1);				\
@@ -84,7 +84,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 #undef IGREATERP
 
 #define GREATERP {						\
-	register int arg1, arg2, result;			\
+	int arg1, arg2, result;			\
 	arg1 = GET_TOS_1;		 /* w/o side effect */	\
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg2);			\
 	UNBOX_ELSE_UFN(arg1, arg1);				\
@@ -92,7 +92,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 	POP_TOS_1; nextop1;}
 
 #define IGREATERP {						\
-	register int arg1, arg2, result;			\
+	int arg1, arg2, result;			\
 	arg1 = GET_TOS_1;		 /* w/o side effect */	\
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg2);			\
 	UNBOX_ELSE_UFN(arg1, arg1);				\
@@ -122,7 +122,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 #define LOGXOR		BINARY_OP(arg1 ^ arg2, 0)
 
 #define UNARY_OP(exp, exceptions) {				\
-	register int arg, result; 						\
+	int arg, result; 						\
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg);			\
 	result = exp;						\
 	if (exceptions) goto op_ufn;				\
@@ -141,7 +141,7 @@ lispemul.h:	typedef struct {unsigned code : 8;} BYTECODE;
 
 #undef ADDBASE
 #define ADDBASE {						\
-	register int arg1, arg2;				\
+	int arg1, arg2;				\
 	UNBOX_ELSE_UFN(TOPOFSTACK, arg2);			\
 	TOPOFSTACK = POP_TOS_1 + arg2;				\
 	nextop1;}

--- a/inc/inlndos.h
+++ b/inc/inlndos.h
@@ -39,8 +39,8 @@
 /*									*/
 /*		   R E G I S T E R   C O N V E N T I O N S		*/
 /*									*/
-/*	The following register conventions hold in the dispatch loop,	*/
-/*	and are set up by register ... asm("...") decls in xc.c:	*/
+/*	The following conventions hold in the dispatch loop,	*/
+/*	and are set up by ... asm("...") decls in xc.c:	*/
 /*									*/
 /*		esi	pccache	- the current PC			*/
 /*		edi	cspcache - the current lisp stack ptr.		*/
@@ -60,7 +60,7 @@
 /*									*/
 /*    G E N E R A L - P U R P O S E   I N L I N E   F U N C T I O N S	*/
 /*									*/
-/*	These functions don't rely on register conventions.		*/
+/*	These functions don't rely on conventions.		*/
 /*									*/
 /************************************************************************/
 
@@ -88,7 +88,7 @@
 extern inline  unsigned int Get_BYTE_PCMAC0fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("lea	%0,-1[%1] \n\
 	xor	%0,3 \n\
 	movzx	%0,BYTE PTR [%0] \n\
@@ -99,7 +99,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_BYTE_PCMAC1fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("lea	%0,[%1] \n\
 	xor	%0,3 \n\
 	movzx	%0,BYTE PTR [%0] \n\
@@ -110,7 +110,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_BYTE_PCMAC2fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("lea	%0,1[%1] \n\
 	xor	%0,3 \n\
 	movzx	%0,BYTE PTR [%0] \n\
@@ -121,7 +121,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_BYTE_PCMAC3fn (pccache)
 unsigned int pccache;
  {
-    register unsigned int word;
+    unsigned int word;
     asm("lea	%0,2[%1] \n\
 	xor	%0,3 \n\
 	movzx	%0,BYTE PTR [%0] \n\
@@ -144,7 +144,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_DLword_PCMAC0fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("mov	edx,%1 \n\
 	xor	dl,3 \n\
 	movzx	eax, byte ptr [edx] \n\
@@ -158,7 +158,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_DLword_PCMAC1fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,1[%1] \n\
 	xor	dl,3 \n\
 	movzx	eax, byte ptr [edx] \n\
@@ -173,7 +173,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_DLword_PCMAC2fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,2[%1] \n\
 	xor	dl,3 \n\
 	movzx	eax, byte ptr [edx] \n\
@@ -187,7 +187,7 @@ unsigned int pccache;
 extern inline  unsigned int Get_DLword_PCMAC3fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,3[%1] \n\
 	xor	dl,3 \n\
 	movzx	eax, byte ptr [edx] \n\
@@ -211,7 +211,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC0fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,-1[%1]	\n\
 	xor	dl,3		\n\
 	movzx	eax,byte ptr [edx]	\n\
@@ -229,7 +229,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC1fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,[%1]	\n\
 	xor	dl,3		\n\
 	movzx	eax,byte ptr [edx]	\n\
@@ -248,7 +248,7 @@ unsigned int pccache;
 extern inline const unsigned int Get_Pointer_PCMAC2fn(pccache)
 unsigned int pccache;
  {
-    register unsigned int word asm("ax");
+    unsigned int word asm("ax");
     asm("lea	edx,1[%1]	\n\
 	xor	dl,3		\n\
 	movzx	eax,byte ptr [edx]	\n\

--- a/inc/intcalldefs.h
+++ b/inc/intcalldefs.h
@@ -1,4 +1,4 @@
 #ifndef INTCALLDEFS_H
 #define INTCALLDEFS_H 1
-void cause_interruptcall(register unsigned int atom_index);
+void cause_interruptcall(unsigned int atom_index);
 #endif

--- a/inc/keyeventdefs.h
+++ b/inc/keyeventdefs.h
@@ -1,7 +1,7 @@
 #ifndef KEYEVENTDEFS_H
 #define KEYEVENTDEFS_H 1
 #include <sys/types.h>
-void process_io_events();
+void process_io_events(void);
 void kb_trans(u_short keycode, u_short upflg);
 void taking_mouse_down(void);
 void copy_cursor(int newx, int newy);

--- a/inc/lineblt8defs.h
+++ b/inc/lineblt8defs.h
@@ -2,6 +2,6 @@
 #define LINEBLT8DEFS_H 1
 #include <sys/types.h> /* for u_char */
 #include "lispemul.h" /* for LispPTR, DLword */
-void lineBlt8(DLword *srcbase, register int offset, register u_char *destl, register int width,
+void lineBlt8(DLword *srcbase, int offset, u_char *destl, int width,
               u_char color0, u_char color1, LispPTR sourcetype, LispPTR operation);
 #endif

--- a/inc/lisp2cdefs.h
+++ b/inc/lisp2cdefs.h
@@ -2,7 +2,7 @@
 #define LISP2CDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
 int LispStringP(LispPTR object);
-int LispStringLength(LispPTR lispstring);
+int LispStringSimpleLength(LispPTR lispstring);
 void LispStringToCStr(LispPTR lispstring, char *cstring);
 int LispIntToCInt(LispPTR lispint);
 LispPTR CIntToLispInt(int cint);

--- a/inc/lispver1.h
+++ b/inc/lispver1.h
@@ -6,8 +6,8 @@
 #define LispVersionToUnixVersion(pathname, ver)				\
   {									\
 									\
-    register char	*cp;						\
-    register char	*vp;						\
+    char	*cp;						\
+    char	*vp;						\
     char		ver_buf[VERSIONLEN];				\
 									\
     cp = pathname;							\

--- a/inc/lispver2.h
+++ b/inc/lispver2.h
@@ -6,9 +6,9 @@
 
 #define LispVersionToUnixVersion(pathname){				\
 									\
-	register char	*lv_cp;						\
-	register char	*lv_vp;						\
-	register unsigned lv_ver;					\
+	char	*lv_cp;						\
+	char	*lv_vp;						\
+	unsigned lv_ver;					\
 	char		lv_ver_buf[VERSIONLEN];				\
 									\
 	lv_cp = pathname;						\

--- a/inc/llstkdefs.h
+++ b/inc/llstkdefs.h
@@ -4,9 +4,9 @@
 #include "stack.h" /* for FX, StackWord, Bframe */
 int do_stackoverflow(int incallp);
 DLword *freestackblock(DLword n, StackWord *start68k, int align);
-void decusecount68k(register FX *frame68k);
+void decusecount68k(FX *frame68k);
 void flip_cursorbar(int n);
-void blt(register DLword *dest68k, register DLword *source68k, int nw);
+void blt(DLword *dest68k, DLword *source68k, int nw);
 void stack_check(StackWord *start68k);
 void walk_stack(StackWord *start68k);
 int quick_stack_check(void);

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -45,15 +45,17 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			/* For getfileinfo. For WDATE&RDATE */
 			/* 29969152 == (timer.c)LISP_UNIX_TIME_DIFF */
 
-#define StrNCpyFromCToLisp(lispbuf, cbuf ,len)	{int lf_i;	\
-			char *lf_sptr,*lf_dptr;		\
-			for(lf_i=0,lf_sptr=(cbuf),lf_dptr =(lispbuf);lf_i<(len);lf_i++)\
+#define StrNCpyFromCToLisp(lispbuf, cbuf ,len)	{	\
+			char *lf_sptr = (cbuf);		\
+                        char *lf_dptr = (lispbuf);                      \
+			for(size_t lf_i=0;lf_i<(len);lf_i++)\
 				GETBYTE(lf_dptr++) = *lf_sptr++;		\
 		}
 
-#define StrNCpyFromLispToC(cbuf , lispbuf, len)	{int lf_i;	\
-			char *lf_sptr,*lf_dptr;			\
-			for(lf_i=0,lf_sptr=(lispbuf),lf_dptr =(cbuf);lf_i<(len);lf_i++)\
+#define StrNCpyFromLispToC(cbuf , lispbuf, len)	{	\
+			char *lf_sptr = (lispbuf);                                          \
+			char *lf_dptr = (cbuf);                       \
+			for(size_t lf_i=0;lf_i<(len);lf_i++)\
 				*lf_dptr++ = GETBYTE(lf_sptr++);		\
 		}
 
@@ -83,7 +85,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
     OneDArray	*lf_arrayp;						\
     char	*lf_base, *lf_dp;						\
     short	*lf_sbase;							\
-    int	lf_i, lf_length;						\
+    size_t		 lf_length;						\
     lf_arrayp = (OneDArray *)(Addr68k_from_LADDR(Lisp));			\
     lf_length = min(MaxLen, lf_arrayp->fillpointer);			\
     switch(lf_arrayp->typenumber)						\
@@ -98,8 +100,9 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	case FAT_CHAR_TYPENUMBER:					\
 		lf_sbase = ((short *)(Addr68k_from_LADDR(lf_arrayp->base)))	\
 		       + ((int)(lf_arrayp->offset));			\
-		for(lf_i=0,lf_dp=C;lf_i<(lf_length);lf_i++)	\
-		  *lf_dp++ = (char)(*lf_sbase++);				\
+                lf_dp = C;						\
+		for(size_t lf_i=0;lf_i<(lf_length);lf_i++)		\
+		  *lf_dp++ = (char)(*lf_sbase++);			\
 		*lf_dp = '\0';						\
 		break;							\
 	default:							\
@@ -112,7 +115,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
     OneDArray	*lf_arrayp;						\
     char	*lf_base, *lf_dp;						\
     short	*lf_sbase;							\
-    int	lf_ii, lf_length;						\
+    size_t 	lf_length;						\
     lf_arrayp = (OneDArray *)(Addr68k_from_LADDR(Lisp));			\
     lf_length = min(MaxLen, lf_arrayp->fillpointer);			\
     switch(lf_arrayp->typenumber)						\
@@ -127,7 +130,8 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	case FAT_CHAR_TYPENUMBER:					\
 		lf_sbase = ((short *)(Addr68k_from_LADDR(lf_arrayp->base)))	\
 		       + ((int)(lf_arrayp->offset));			\
-		for(lf_ii=0,lf_dp=C;lf_ii<(lf_length);lf_ii++,lf_sbase++)  \
+                lf_dp = C;						\
+		for(size_t lf_ii=0;lf_ii<(lf_length);lf_ii++,lf_sbase++)  \
                     *lf_dp++ = (char)(GETWORD(lf_sbase));               \
 		*lf_dp = '\0';						\
 		break;							\

--- a/inc/loopsopsdefs.h
+++ b/inc/loopsopsdefs.h
@@ -1,12 +1,12 @@
 #ifndef LOOPSOPSDEFS_H
 #define LOOPSOPSDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR lcfuncall(register unsigned int atom_index, register int argnum, register int bytenum);
+LispPTR lcfuncall(unsigned int atom_index, int argnum, int bytenum);
 LispPTR LCinit(void);
-LispPTR LCFetchMethod(register LispPTR class, register LispPTR selector);
-LispPTR LCFetchMethodOrHelp(register LispPTR object, register LispPTR selector);
-LispPTR LCFindVarIndex(register LispPTR iv, register LispPTR object);
-LispPTR LCGetIVValue(register LispPTR object, register LispPTR iv);
-LispPTR LCPutIVValue(register LispPTR object, register LispPTR iv, register LispPTR val);
-LispPTR lcfuncall(register unsigned int atom_index, register int argnum, register int bytenum);
+LispPTR LCFetchMethod(LispPTR class, LispPTR selector);
+LispPTR LCFetchMethodOrHelp(LispPTR object, LispPTR selector);
+LispPTR LCFindVarIndex(LispPTR iv, LispPTR object);
+LispPTR LCGetIVValue(LispPTR object, LispPTR iv);
+LispPTR LCPutIVValue(LispPTR object, LispPTR iv, LispPTR val);
+LispPTR lcfuncall(unsigned int atom_index, int argnum, int bytenum);
 #endif

--- a/inc/lowlev1defs.h
+++ b/inc/lowlev1defs.h
@@ -1,8 +1,8 @@
 #ifndef LOWLEV1DEFS_H
 #define LOWLEV1DEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_putbitsnfd(register LispPTR base, register LispPTR data, int word_offset, register int beta);
-LispPTR N_OP_getbitsnfd(int base_addr, register int word_offset, int beta);
-LispPTR N_OP_putbasen(register LispPTR base, register LispPTR tos, int n);
-LispPTR N_OP_putbaseptrn(register LispPTR base, register LispPTR tos, int n);
+LispPTR N_OP_putbitsnfd(LispPTR base, LispPTR data, int word_offset, int beta);
+LispPTR N_OP_getbitsnfd(int base_addr, int word_offset, int beta);
+LispPTR N_OP_putbasen(LispPTR base, LispPTR tos, int n);
+LispPTR N_OP_putbaseptrn(LispPTR base, LispPTR tos, int n);
 #endif

--- a/inc/lowlev2defs.h
+++ b/inc/lowlev2defs.h
@@ -1,7 +1,7 @@
 #ifndef LOWLEV2DEFS_H
 #define LOWLEV2DEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_addbase(register int base, register int offset);
-LispPTR N_OP_getbasebyte(register LispPTR base_addr, register int byteoffset);
-LispPTR N_OP_putbasebyte(register LispPTR base_addr, register int byteoffset, register int tos);
+LispPTR N_OP_addbase(LispPTR base, LispPTR offset);
+LispPTR N_OP_getbasebyte(LispPTR base_addr, LispPTR byteoffset);
+LispPTR N_OP_putbasebyte(LispPTR base_addr, LispPTR byteoffset, LispPTR tos);
 #endif

--- a/inc/lsptypes.h
+++ b/inc/lsptypes.h
@@ -18,6 +18,7 @@
 */
 /**********************************************************************/
 #include "version.h" /* for BIGVM, BIGATOMS */
+#include <stdint.h> /* for int32_t */
 #include "lispemul.h" /* for LispPTR, DLword */
 
 /************************************************************************/
@@ -238,8 +239,8 @@ typedef struct oned_array {
 		unsigned int extendablep : 1;
 		unsigned int typenumber : 8 ;
 		DLword offset;
-		LispPTR fillpointer ;
-		LispPTR totalsize ; } OneDArray;
+		int32_t fillpointer ;
+		int32_t totalsize ; } OneDArray;
 
 typedef struct oned_array NEWSTRINGP;
 
@@ -256,10 +257,10 @@ typedef struct general_array {
 		unsigned int extendablep : 1;
 		unsigned int typenumber : 8 ;
 		unsigned int nil2:16;
-		LispPTR Dim0;
-		LispPTR totalsize;
-		LispPTR Dim1 ;
-		LispPTR Dim2 ; } LispArray;
+		int32_t Dim0;
+		int32_t totalsize;
+		int32_t Dim1 ;
+		int32_t Dim2 ; } LispArray;
 
 typedef struct compiled_closure {
 		unsigned int nil1	: 4 ;
@@ -434,8 +435,8 @@ typedef struct oned_array {
 		unsigned int bitp :1 ;
 		unsigned int indirectp : 1; /* as used arrayheader */
 		unsigned int readonlyp :1 ;
-		LispPTR fillpointer ;
-		LispPTR totalsize ; } OneDArray;
+		int32_t fillpointer ;
+		int32_t totalsize ; } OneDArray;
 
 
 typedef struct oned_array NEWSTRINGP;
@@ -453,10 +454,10 @@ typedef struct general_array {
 		unsigned int bitp :1 ;
 		unsigned int indirectp : 1; /* as used arrayheader */
 		unsigned int readonlyp :1 ;
-		LispPTR Dim0;
-		LispPTR totalsize;
-		LispPTR Dim1 ;
-		LispPTR Dim2 ; } LispArray;
+		int32_t Dim0;
+		int32_t totalsize;
+		int32_t Dim1 ;
+		int32_t Dim2 ; } LispArray;
 
 typedef struct compiled_closure {
 		unsigned int def_ptr	: 28; /* function */

--- a/inc/lsptypes.h
+++ b/inc/lsptypes.h
@@ -631,6 +631,7 @@ typedef struct
 /* This MACRO is similar to LISTP */
 #define Listp(address)	(GetTypeNumber(address) == TYPE_LISTP)
 
+#define Numberp(address) (GetTypeEntry(address) & TT_NUMBERP)
 
 	/******************************************/
 	/*        Lisp's PATHNAME datatype        */

--- a/inc/lsthandldefs.h
+++ b/inc/lsthandldefs.h
@@ -1,7 +1,7 @@
 #ifndef LSTHANDLDEFS_H
 #define LSTHANDLDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_fmemb(register LispPTR item, register LispPTR tos);
-LispPTR fmemb(register LispPTR item, register LispPTR list);
-LispPTR N_OP_listget(register LispPTR plist, register LispPTR tos);
+LispPTR N_OP_fmemb(LispPTR item, LispPTR tos);
+LispPTR fmemb(LispPTR item, LispPTR list);
+LispPTR N_OP_listget(LispPTR plist, LispPTR tos);
 #endif

--- a/inc/mkatomdefs.h
+++ b/inc/mkatomdefs.h
@@ -3,7 +3,7 @@
 #include "lispemul.h" /* for LispPTR, DLword */
 DLword compute_hash(const char *char_base, DLword offset, DLword length);
 DLword compute_lisp_hash(const char *char_base, DLword offset, DLword length, DLword fatp);
-LispPTR compare_chars(register const char *char1, register const char *char2, register DLword length);
-LispPTR compare_lisp_chars(register const char *char1, register const char *char2, register DLword length, DLword fat1, DLword fat2);
+LispPTR compare_chars(const char *char1, const char *char2, DLword length);
+LispPTR compare_lisp_chars(const char *char1, const char *char2, DLword length, DLword fat1, DLword fat2);
 LispPTR make_atom(const char *char_base, DLword offset, DLword length);
 #endif

--- a/inc/mkcelldefs.h
+++ b/inc/mkcelldefs.h
@@ -1,6 +1,6 @@
 #ifndef MKCELLDEFS_H
 #define MKCELLDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
-LispPTR N_OP_createcell(register LispPTR tos);
+LispPTR N_OP_createcell(LispPTR tos);
 DLword *createcell68k(unsigned int type);
 #endif

--- a/inc/mvsdefs.h
+++ b/inc/mvsdefs.h
@@ -4,6 +4,6 @@
 #include "stack.h" /* for FX2 */
 LispPTR make_value_list(int argcount, LispPTR *argarray);
 void simulate_unbind(FX2 *frame, int unbind_count, FX2 *returner);
-LispPTR values(int arg_count, register LispPTR *args);
-LispPTR values_list(int arg_count, register LispPTR *args);
+LispPTR values(int arg_count, LispPTR *args);
+LispPTR values_list(int arg_count, LispPTR *args);
 #endif

--- a/inc/my.h
+++ b/inc/my.h
@@ -76,40 +76,50 @@
 
 static inline LispPTR
 aref_switch(unsigned type, LispPTR tos, LispPTR baseL, int index)
-{								  
-  LispPTR result;
+{
+  int result;
   DLword *wordp;
 
   switch (type)
     {
     case 38: /* pointer : 32 bits */
-      return(*(((LispPTR *)Addr68k_from_LADDR(baseL)) + index));		
-    case 20: /* signed : 16 bits */					
+      return(*(((LispPTR *)Addr68k_from_LADDR(baseL)) + index));
+
+    case 20: /* signed : 16 bits */
       result = (GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF;
       if (result & 0x8000) return(result | S_NEGATIVE);
-      else return(result | S_POSITIVE);				
-    case 67: /* Character :  8 bits */				
-      return(S_CHARACTER | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));								
-    case 22: /* signed : 32 bits */					
-      result = *(((LispPTR *)Addr68k_from_LADDR(baseL)) + index);	
-      N_ARITH_SWITCH(result);					
-    case 0: /* unsigned : 1 bit per element */			
-      return(S_POSITIVE | (((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + (index >> 3))) >> (7 - (index & 7))) & 1));					
-    case 3: /* unsigned : 8 bits per element */			
-      return(S_POSITIVE | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));								
-    case 4: /* unsigned : 16 bits per element */			
-      return(S_POSITIVE | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));								
-    case 54: /* Float : 32 bits */					
-      wordp = createcell68k(TYPE_FLOATP);				
-      *((LispPTR *)wordp) = *(((LispPTR *)Addr68k_from_LADDR(baseL)) + index);										
-      return(LADDR_from_68k(wordp));					
-    case 68: /* Character :  16 bits */				
-      return(S_CHARACTER | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));								
-    case 86: /* XPointer : 32 bits */					
-      return(*(((LispPTR *)Addr68k_from_LADDR(baseL)) + index));		
-    default: /* Illegal or Unimplemented */				
-      ERROR_EXIT(tos);						
-    }/* end switch typenumber */					
+      else return(result | S_POSITIVE);
+
+    case 67: /* Character :  8 bits */
+      return(S_CHARACTER | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));
+
+    case 22: /* signed : 32 bits */
+      result = *(((int *)Addr68k_from_LADDR(baseL)) + index);
+      N_ARITH_SWITCH(result);
+
+    case 0: /* unsigned : 1 bit per element */
+      return(S_POSITIVE | (((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + (index >> 3))) >> (7 - (index & 7))) & 1));
+
+    case 3: /* unsigned : 8 bits per element */
+      return(S_POSITIVE | ((GETBYTE(((char *)Addr68k_from_LADDR(baseL)) + index)) & 0xFF));
+
+    case 4: /* unsigned : 16 bits per element */
+      return(S_POSITIVE | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));
+
+    case 54: /* Float : 32 bits */
+      wordp = createcell68k(TYPE_FLOATP);
+      *((LispPTR *)wordp) = *(((LispPTR *)Addr68k_from_LADDR(baseL)) + index);
+      return(LADDR_from_68k(wordp));
+
+    case 68: /* Character :  16 bits */
+      return(S_CHARACTER | ((GETWORD(((DLword *)Addr68k_from_LADDR(baseL)) + index)) & 0xFFFF));
+
+    case 86: /* XPointer : 32 bits */
+      return(*(((LispPTR *)Addr68k_from_LADDR(baseL)) + index));
+
+   default: /* Illegal or Unimplemented */
+      ERROR_EXIT(tos);
+    }/* end switch typenumber */
 }
 
 #define aset_switch(type, tos)						\

--- a/inc/my.h
+++ b/inc/my.h
@@ -26,13 +26,6 @@
 #include "lsptypes.h"    // for GETBYTE, GETWORD, GetTypeNumber, TYPE_FLOATP
 #include "mkcelldefs.h"  // for createcell68k
 
-#ifdef BIGVM
-#define IsNumber(address)     ((GETWORD(MDStypetbl +(((address) & 0x0fffff00)>>9))) & 0x1000)
-#else
-#define IsNumber(address)     ((GETWORD(MDStypetbl +(((address) & 0x0ffff00)>>9))) & 0x1000)
-#endif
-
-
 /************************************************************************/
 /*									*/
 /*			N _ M a k e F l o a t				*/

--- a/inc/return.h
+++ b/inc/return.h
@@ -67,7 +67,7 @@
 /** in CONTEXTSW , for exchanging context **/
 
 #define Midpunt(fxnum) 							\
-  { register DLword midpunt; 					\
+  { DLword midpunt; 					\
     midpunt = LOLOC(LADDR_from_68k(CURRENTFX));			\
     PVar=(DLword *)							\
 	    Addr68k_from_StkOffset(					\
@@ -98,7 +98,7 @@
 
 
 #define AFTER_CONTEXTSW							\
-  { register DLword *ac_ptr68k,*ac_freeptr;					\
+  { DLword *ac_ptr68k,*ac_freeptr;					\
     ac_ptr68k = (DLword*)Addr68k_from_StkOffset(CURRENTFX->nextblock);	\
     if(GETWORD(ac_ptr68k) != STK_FSB_WORD) error("pre_moveframe: MP9316");	\
     CHECK_FX(CURRENTFX);						\

--- a/inc/returndefs.h
+++ b/inc/returndefs.h
@@ -2,5 +2,5 @@
 #define RETURNDEFS_H 1
 #include "lispemul.h" /* for DLword */
 void OP_contextsw(void);
-void contextsw(register DLword fxnum, register DLword bytenum, register DLword flags);
+void contextsw(DLword fxnum, DLword bytenum, DLword flags);
 #endif

--- a/inc/rplconsdefs.h
+++ b/inc/rplconsdefs.h
@@ -1,5 +1,5 @@
 #ifndef RPLCONSDEFS_H
 #define RPLCONSDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_rplcons(register LispPTR list, register LispPTR item);
+LispPTR N_OP_rplcons(LispPTR list, LispPTR item);
 #endif

--- a/inc/shiftdefs.h
+++ b/inc/shiftdefs.h
@@ -1,9 +1,9 @@
 #ifndef SHIFTDEFS_H
 #define SHIFTDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_llsh1(int a);
-LispPTR N_OP_llsh8(int a);
-LispPTR N_OP_lrsh1(int a);
-LispPTR N_OP_lrsh8(int a);
-LispPTR N_OP_lsh(int a, int b);
+LispPTR N_OP_llsh1(LispPTR a);
+LispPTR N_OP_llsh8(LispPTR a);
+LispPTR N_OP_lrsh1(LispPTR a);
+LispPTR N_OP_lrsh8(LispPTR a);
+LispPTR N_OP_lsh(LispPTR a, LispPTR b);
 #endif

--- a/inc/storagedefs.h
+++ b/inc/storagedefs.h
@@ -1,7 +1,7 @@
 #ifndef STORAGEDEFS_H
 #define STORAGEDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-void checkfor_storagefull(register unsigned int npages);
+void checkfor_storagefull(unsigned int npages);
 LispPTR newpage(LispPTR base);
 void init_storage(void);
 #endif

--- a/inc/timeout.h
+++ b/inc/timeout.h
@@ -16,7 +16,7 @@ extern jmp_buf jmpbuf;
 /*** TIMEOUT_TIME is changeable by UNIX env var LDEFILETIMEOUT. 
 #define	TIMEOUT_TIME	10 **/
 
-extern	int	TIMEOUT_TIME;
+extern	unsigned int TIMEOUT_TIME;
 
 #define	SETJMP(x)	\
   {				\

--- a/inc/tosfns.h
+++ b/inc/tosfns.h
@@ -183,9 +183,9 @@
 
 #define OPFN(argcount, num_args_fn, fn_xna_args, fn_native)                            \
   do { /* argcount is a number of the arguments on stack */                               \
-    register struct fnhead *LOCFNCELL;                                                 \
-    register int defcell_word;                                                         \
-    register int NEXTBLOCK;                                                            \
+    struct fnhead *LOCFNCELL;                                                 \
+    int defcell_word;                                                         \
+    int NEXTBLOCK;                                                            \
     FNTRACER(Trace_FNCall(argcount, Get_AtomNo_PCMAC1, TOPOFSTACK, CSTKPTR - 1));      \
     FNCHECKER(if (quick_stack_check())                                                 \
                   Trace_FNCall(argcount, Get_AtomNo_PCMAC1, TOPOFSTACK, CSTKPTR - 1)); \
@@ -202,13 +202,13 @@
     BCE_CURRENTFX->pc = ((UNSIGNED)PCMAC - (UNSIGNED)FuncObj) + FN_OPCODE_SIZE;        \
     FN_STACK_CHECK;                                                                    \
     {                                                                                  \
-      register UNSIGNED newivar;                                                       \
+      UNSIGNED newivar;                                                       \
       newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR - (argcount) + 1));              \
       BCE_CURRENTFX->nextblock = NEXTBLOCK = StkOffset_from_68K(newivar);              \
     }                                                                                  \
     HARD_PUSH(TOPOFSTACK); /* save TOS */                                              \
     if (LOCFNCELL->na >= 0) {                                                          \
-      register int RESTARGS;                                                           \
+      int RESTARGS;                                                           \
       RESTARGS = (argcount) - LOCFNCELL->na;                                           \
       while (RESTARGS < 0) {                                                           \
         HARD_PUSH(NIL_PTR);                                                            \
@@ -238,9 +238,9 @@
 /*************** OPFNX *************/
 #define OPFNX                                                                          \
   do {                                                                                    \
-    register struct fnhead *LOCFNCELL;                                                 \
-    register DefCell *defcell; /* this reg is not allocated */                         \
-    register int NEXTBLOCK;                                                            \
+    struct fnhead *LOCFNCELL;                                                 \
+    DefCell *defcell; /* this reg is not allocated */                         \
+    int NEXTBLOCK;                                                            \
     int num_args = Get_BYTE_PCMAC1;                                                    \
     defcell = (DefCell *)GetDEFCELL68k(Get_AtomNo_PCMAC2);                             \
     FNTRACER(Trace_FNCall(num_args, Get_AtomNo_PCMAC2, TOPOFSTACK, CSTKPTR - 1));      \
@@ -258,13 +258,13 @@
     BCE_CURRENTFX->pc = ((UNSIGNED)PCMAC - (UNSIGNED)FuncObj) + FNX_OPCODE_SIZE;       \
     FN_STACK_CHECK;                                                                    \
     {                                                                                  \
-      register UNSIGNED newivar;                                                       \
+      UNSIGNED newivar;                                                       \
       newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR - num_args + 1));                \
       BCE_CURRENTFX->nextblock = NEXTBLOCK = StkOffset_from_68K(newivar);              \
     }                                                                                  \
     HARD_PUSH(TOPOFSTACK); /* save TOS */                                              \
     if (LOCFNCELL->na >= 0) {                                                          \
-      register int RESTARGS;                                                           \
+      int RESTARGS;                                                           \
       RESTARGS = num_args - LOCFNCELL->na;                                             \
       while (RESTARGS < 0) {                                                           \
         HARD_PUSH(NIL_PTR);                                                            \
@@ -296,7 +296,7 @@
 #ifdef BIGATOMS
 #define OPCHECKAPPLY                                                                        \
   do {                                                                                         \
-    register DefCell *defcell;                                                              \
+    DefCell *defcell;                                                              \
     defcell = (DefCell *)GetDEFCELL68k(TOPOFSTACK & POINTERMASK);                           \
     if (!(defcell->ccodep &&                                                                \
           (((TOPOFSTACK & SEGMASK) == 0) || (GetTypeNumber(TOPOFSTACK) == TYPE_NEWATOM)) && \
@@ -306,7 +306,7 @@
 #else
 #define OPCHECKAPPLY                                              \
   do {                                                               \
-    register DefCell *defcell;                                    \
+    DefCell *defcell;                                    \
     defcell = (DefCell *)GetDEFCELL68k(TOPOFSTACK & POINTERMASK); \
     if (!(defcell->ccodep && ((TOPOFSTACK & SEGMASK) == 0)) &&    \
         ((defcell->argtype == 0) || (defcell->argtype == 2)))     \
@@ -322,7 +322,7 @@
 #define UFN_COMMON                                        \
   op_ufn:                                                 \
   use code in XC.c {                                      \
-    register UFN *entry68k;                               \
+    UFN *entry68k;                               \
     entry68k = (UFN *)GetUFNEntry(Get_BYTE_PCMAC0);       \
     fn_num_args = entry68k->arg_num;                      \
     fn_opcode_size = entry68k->byte_num + 1;              \
@@ -346,12 +346,12 @@
 #define needpush NEXTBLOCK
 #define OP_FN_COMMON                                                                           \
   op_fn_common : {                                                                             \
-    register struct fnhead *LOCFNCELL;                                                         \
-    register DefCell *defcell; /* this reg is not allocated */                                 \
+    struct fnhead *LOCFNCELL;                                                         \
+    DefCell *defcell; /* this reg is not allocated */                                 \
     CClosure *closure;                                                                         \
     LispPTR closure_env = (LispPTR)0xffffffff;                                                 \
     {                                                                                          \
-      register int NEXTBLOCK = NIL;                                                            \
+      int NEXTBLOCK = NIL;                                                            \
       defcell = fn_defcell;                                                                    \
       if (defcell->ccodep == 0) {                                                              \
         if (GetTypeNumber(defcell->defpointer) == TYPE_COMPILED_CLOSURE) { /* setup closure */ \
@@ -372,13 +372,13 @@
       FN_STACK_CHECK;                                                                          \
       APPLY_POP_PUSH_TEST;                                                                     \
       {                                                                                        \
-        register UNSIGNED newivar;                                                             \
+        UNSIGNED newivar;                                                             \
         newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR + (1 - fn_num_args - needpush)));      \
         BCE_CURRENTFX->nextblock = NEXTBLOCK = StkOffset_from_68K(newivar);                    \
       }                                                                                        \
       HARD_PUSH(TOPOFSTACK); /* save TOS */                                                    \
       if (LOCFNCELL->na >= 0) {                                                                \
-        register int RESTARGS;                                                                 \
+        int RESTARGS;                                                                 \
         RESTARGS = fn_num_args - LOCFNCELL->na;                                                \
         while (RESTARGS < 0) {                                                                 \
           HARD_PUSH(NIL_PTR);                                                                  \
@@ -394,8 +394,8 @@
     CSTKPTRL = (LispPTR *)(((DLword *)CSTKPTR) + FRAMESIZE);                                   \
     PVARL = (DLword *)CSTKPTR;                                                                 \
     {                                                                                          \
-      register int result;                                                                     \
-      register LispPTR unboundval;                                                             \
+      int result;                                                                     \
+      LispPTR unboundval;                                                             \
       unboundval = (LispPTR)0xffffffff;                                                        \
       result = LOCFNCELL->pv;                                                                  \
       HARD_PUSH(closure_env);                                                                  \
@@ -428,11 +428,11 @@
 
 #define OP_ENVCALL                                                        \
   do {                                                                    \
-    register struct fnhead *LOCFNCELL;                                    \
-    register int NEXTBLOCK;                                               \
-    register LispPTR closure_env = TOPOFSTACK;                            \
-    register int num_args;                                                \
-    register LispPTR Fn_DefCell = GET_TOS_1;                              \
+    struct fnhead *LOCFNCELL;                                    \
+    int NEXTBLOCK;                                               \
+    LispPTR closure_env = TOPOFSTACK;                            \
+    int num_args;                                                \
+    LispPTR Fn_DefCell = GET_TOS_1;                              \
     LOCFNCELL = (struct fnhead *)Addr68k_from_LADDR(Fn_DefCell);          \
     FNTPRINT(("ENVCall.\n"));                                             \
     FNCHECKER(if (quick_stack_check()) printf("In ENVCALL.\n"));          \
@@ -441,12 +441,12 @@
     FN_STACK_CHECK;                                                       \
     CSTKPTRL -= 2;                                                        \
     {                                                                     \
-      register UNSIGNED newivar;                                          \
+      UNSIGNED newivar;                                          \
       newivar = (UNSIGNED)(IVARL = (DLword *)(CSTKPTR - num_args));       \
       BCE_CURRENTFX->nextblock = NEXTBLOCK = StkOffset_from_68K(newivar); \
     }                                                                     \
     if (LOCFNCELL->na >= 0) {                                             \
-      register int RESTARGS;                                              \
+      int RESTARGS;                                              \
       RESTARGS = num_args - LOCFNCELL->na;                                \
       while (RESTARGS < 0) {                                              \
         HARD_PUSH(NIL_PTR);                                               \
@@ -461,10 +461,10 @@
     CSTKPTRL = (LispPTR *)(((DLword *)CSTKPTR) + FRAMESIZE);              \
     PVARL = (DLword *)CSTKPTR;                                            \
     {                                                                     \
-      register int result;                                                \
+      int result;                                                \
       result = LOCFNCELL->pv;                                             \
       if (result >= 0) {                                                  \
-        register LispPTR unboundval;                                      \
+        LispPTR unboundval;                                      \
         unboundval = (LispPTR)0xffffffff;                                 \
         if (closure_env == NIL_PTR)                                       \
           HARD_PUSH(unboundval);                                          \

--- a/inc/tosret.h
+++ b/inc/tosret.h
@@ -23,8 +23,8 @@
 /************************************************************************/
 
 #define OPRETURN	{						\
- register struct frameex2 *returnFX ;					\
- register int alink;							\
+ struct frameex2 *returnFX ;					\
+ int alink;							\
  FNCHECKER(struct frameex2 *old_bce_fx = (struct frameex2 *) BCE_CURRENTFX); \
  alink = ((struct frameex2 *) BCE_CURRENTFX)->alink;			\
  FNTPRINT(("RETURN = 0x%x,  ", TOPOFSTACK));						\

--- a/inc/typeofdefs.h
+++ b/inc/typeofdefs.h
@@ -1,6 +1,6 @@
 #ifndef TYPEOFDEFS_H
 #define TYPEOFDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR N_OP_dtest(register LispPTR tos, register int atom_index);
-LispPTR N_OP_instancep(register LispPTR tos, register int atom_index);
+LispPTR N_OP_dtest(LispPTR tos, int atom_index);
+LispPTR N_OP_instancep(LispPTR tos, int atom_index);
 #endif

--- a/inc/unixcommdefs.h
+++ b/inc/unixcommdefs.h
@@ -1,7 +1,7 @@
 #ifndef UNIXCOMMDEFS_H
 #define UNIXCOMMDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-int find_process_slot(register int pid);
+int find_process_slot(int pid);
 void wait_for_comm_processes(void);
 char *build_socket_pathname(int desc);
 void close_unix_descriptors(void);

--- a/inc/unwinddefs.h
+++ b/inc/unwinddefs.h
@@ -1,5 +1,5 @@
 #ifndef UNWINDDEFS_H
 #define UNWINDDEFS_H 1
 #include "lispemul.h" /* for LispPTR */
-LispPTR *N_OP_unwind(register LispPTR *cstkptr, register LispPTR tos, int n, int keep);
+LispPTR *N_OP_unwind(LispPTR *cstkptr, LispPTR tos, int n, int keep);
 #endif

--- a/inc/uutilsdefs.h
+++ b/inc/uutilsdefs.h
@@ -1,9 +1,6 @@
 #ifndef UUTILSDEFS_H
 #define UUTILSDEFS_H 1
-#include <stddef.h> /* for size_t */
 #include "lispemul.h" /* for LispPTR */
-int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length);
-int c_string_to_lisp_string(char *C, LispPTR Lisp);
 LispPTR check_unix_password(LispPTR *args);
 LispPTR unix_username(LispPTR *args);
 LispPTR unix_getparm(LispPTR *args);

--- a/inc/vars3defs.h
+++ b/inc/vars3defs.h
@@ -3,6 +3,6 @@
 #include "cell.h" /* for cadr_cell */
 #include "lispemul.h" /* for LispPTR */
 struct cadr_cell cadr(LispPTR cell_adr);
-LispPTR N_OP_arg0(register LispPTR tos);
-LispPTR N_OP_assoc(register LispPTR key, register LispPTR list);
+LispPTR N_OP_arg0(LispPTR tos);
+LispPTR N_OP_assoc(LispPTR key, LispPTR list);
 #endif

--- a/inc/xbitmaps.h
+++ b/inc/xbitmaps.h
@@ -25,7 +25,7 @@ typedef struct {
 	short cudata;		/* ?? */
 } LISP_CURSOR;
 
-const uint8_t defaultcursor_bitmap[]=
+static const uint8_t defaultcursor_bitmap[]=
   {
 	  0x80, 0, 0xc0, 0, 0xe0, 0, 0xf0, 0
 	, 0xf8, 0, 0xfc, 0, 0xfe, 0, 0xf0, 0
@@ -44,7 +44,7 @@ LISP_CURSOR default_cursor =
   };
 
 
-const uint8_t  waitcursor_bitmap[]=
+static const uint8_t  waitcursor_bitmap[]=
   {
 	  0xFF, 0xFE, 0xC0, 0x06, 0x60, 0x1C, 0x3D, 0x78
 	, 0x1F, 0xF0, 0x0F, 0xE0, 0x06, 0xC0, 0x03, 0x80
@@ -62,7 +62,7 @@ LISP_CURSOR wait_cursor =
    , 0
   };
 	
-const uint8_t horizscrollcursor_bitmap[]={
+static const uint8_t horizscrollcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -92,7 +92,7 @@ LISP_CURSOR horizscroll_cursor = {
 	
 
 
-const uint8_t horizthumbcursor_bitmap[]={
+static const uint8_t horizthumbcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -122,7 +122,7 @@ LISP_CURSOR horizthumb_cursor = {
 	
 
 
-const uint8_t scrolldowncursor_bitmap[]={
+static const uint8_t scrolldowncursor_bitmap[]={
 		  0x03, 0x80
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -152,7 +152,7 @@ LISP_CURSOR scrolldown_cursor = {
 	
 
 
-const uint8_t scrollleftcursor_bitmap[]={
+static const uint8_t scrollleftcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -182,7 +182,7 @@ LISP_CURSOR scrollleft_cursor = {
 	
 
 
-const uint8_t scrollrightcursor_bitmap[]={
+static const uint8_t scrollrightcursor_bitmap[]={
 	  0x00, 0x00
 	, 0x00, 0x00
 	, 0x00, 0x00
@@ -212,7 +212,7 @@ LISP_CURSOR scrollright_cursor = {
 	
 
 
-const uint8_t scrollupcursor_bitmap[]={
+static const uint8_t scrollupcursor_bitmap[]={
 		  0x01, 0x00
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -242,7 +242,7 @@ LISP_CURSOR scrollup_cursor = {
 	
 
 
-const uint8_t vertscrollcursor_bitmap[]={
+static const uint8_t vertscrollcursor_bitmap[]={
 		  0x01, 0x00
 		, 0x03, 0x80
 		, 0x03, 0x80
@@ -272,7 +272,7 @@ LISP_CURSOR vertscroll_cursor = {
 	
 
 
-const uint8_t vertthumbcursor_bitmap[]={
+static const uint8_t vertthumbcursor_bitmap[]={
 		 0x00,0x00
 		,0x00,0x1f
 		,0x00,0x00

--- a/inc/z2defs.h
+++ b/inc/z2defs.h
@@ -2,6 +2,6 @@
 #define Z2DEFS_H 1
 #include "lispemul.h" /* for LispPTR */
 LispPTR N_OP_classoc(LispPTR key, LispPTR list);
-LispPTR N_OP_clfmemb(register LispPTR item, register LispPTR list);
-LispPTR N_OP_restlist(register LispPTR tail, register int last, register int skip);
+LispPTR N_OP_clfmemb(LispPTR item, LispPTR list);
+LispPTR N_OP_restlist(LispPTR tail, int last, int skip);
 #endif

--- a/src/allocmds.c
+++ b/src/allocmds.c
@@ -62,7 +62,7 @@ static inline void Make_MDSentry(UNSIGNED page, DLword pattern) {
 */
 /**********************************************************************/
 
-LispPTR initmdspage(register LispPTR *base, register DLword size, register LispPTR prev)
+LispPTR initmdspage(LispPTR *base, DLword size, LispPTR prev)
 /* MDS page base */
 /* object cell size you need (WORD) */
 /* keeping top of previous MDS cell */
@@ -70,11 +70,11 @@ LispPTR initmdspage(register LispPTR *base, register DLword size, register LispP
 {
   extern DLword *MDStypetbl;
 
-  register int remain_size; /* (IREMAINDER WORDSPERPAGE SIZE) */
-  register short num_pages;
-  register int limit;
+  int remain_size; /* (IREMAINDER WORDSPERPAGE SIZE) */
+  short num_pages;
+  int limit;
   int used; /* used space in MDS page */
-  register int i;
+  int i;
 
 #ifdef TRACE2
   printf("TRACE: initmdspage()\n");
@@ -121,14 +121,14 @@ LispPTR initmdspage(register LispPTR *base, register DLword size, register LispP
 */
 /**********************************************************************/
 
-LispPTR *alloc_mdspage(register short int type) {
+LispPTR *alloc_mdspage(short int type) {
   extern LispPTR *MDS_free_page_word; /* Free MDS page number */
 
   extern DLword *Next_MDSpage; /* next vacant(new) MDS page */
   extern LispPTR *Next_MDSpage_word;
   extern LispPTR *Next_Array_word;
 
-  register LispPTR *ptr; /* points Top 32 bit of the MDS page */
+  LispPTR *ptr; /* points Top 32 bit of the MDS page */
   LispPTR next_page;
 
   /* Next_Array=(DLword *)Addr68k_from_LADDR(((*Next_Array_word)& 0xffff ) << 8); */

--- a/src/arithops.c
+++ b/src/arithops.c
@@ -331,7 +331,7 @@ LispPTR N_OP_boxiplus(LispPTR a, LispPTR tos) {
 
   if (GetTypeNumber(a) == TYPE_FIXP) {
     N_GETNUMBER(tos, arg2, bad);
-    *((LispPTR *)Addr68k_from_LADDR(a)) += arg2;
+    *((int *)Addr68k_from_LADDR(a)) += arg2;
     return (a);
   }
 bad:
@@ -354,7 +354,7 @@ LispPTR N_OP_boxidiff(LispPTR a, LispPTR tos) {
 
   if (GetTypeNumber(a) == TYPE_FIXP) {
     N_GETNUMBER(tos, arg2, bad);
-    *((LispPTR *)Addr68k_from_LADDR(a)) -= arg2;
+    *((int *)Addr68k_from_LADDR(a)) -= arg2;
     return (a);
   }
 bad:

--- a/src/arithops.c
+++ b/src/arithops.c
@@ -23,7 +23,7 @@ N_OP_plus2
         return(tos + b)
 ************************************************************/
 
-LispPTR N_OP_plus2(int tosm1, int tos) {
+LispPTR N_OP_plus2(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -58,7 +58,7 @@ doufn:
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_iplus2(int tosm1, int tos) {
+LispPTR N_OP_iplus2(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -92,7 +92,7 @@ N_OP_difference
         return(a - tos)
 ************************************************************/
 
-LispPTR N_OP_difference(int tosm1, int tos) {
+LispPTR N_OP_difference(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -119,7 +119,7 @@ doufn:
   return (N_OP_fdifference(tosm1, tos));
 }
 
-LispPTR N_OP_idifference(int tosm1, int tos) {
+LispPTR N_OP_idifference(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -150,7 +150,7 @@ N_OP_logxor
         return(tosm1 ^ tos)
 ************************************************************/
 
-LispPTR N_OP_logxor(int tosm1, int tos) {
+LispPTR N_OP_logxor(LispPTR tosm1, LispPTR tos) {
     int arg1, arg2;
 
     N_IGETNUMBER(tosm1, arg1, do_ufn);
@@ -169,7 +169,7 @@ N_OP_logand
         entry		LOGAND2		OPCODE[0345]
         return(tosm1 & tos)
 ************************************************************/
-LispPTR N_OP_logand(int tosm1, int tos) {
+LispPTR N_OP_logand(LispPTR tosm1, LispPTR tos) {
     int arg1, arg2;
 
     N_IGETNUMBER(tosm1, arg1, do_ufn);
@@ -188,7 +188,7 @@ N_OP_logor
         entry		LOGOR2		OPCODE[0344]
         return(tosm1 | tos)
 ************************************************************/
-LispPTR N_OP_logor(int tosm1, int tos) {
+LispPTR N_OP_logor(LispPTR tosm1, LispPTR tos) {
       int arg1, arg2;
 
     N_IGETNUMBER(tosm1, arg1, do_ufn);
@@ -209,7 +209,7 @@ N_OP_greaterp
         return(tosm1 > tos)
 
 ************************************************************/
-LispPTR N_OP_greaterp(int tosm1, int tos) {
+LispPTR N_OP_greaterp(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
 
   N_GETNUMBER(tosm1, arg1, do_ufn);
@@ -224,7 +224,7 @@ do_ufn:
   return (N_OP_fgreaterp(tosm1, tos));
 }
 
-LispPTR N_OP_igreaterp(int tosm1, int tos) {
+LispPTR N_OP_igreaterp(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
 
   N_IGETNUMBER(tosm1, arg1, do_ufn);
@@ -244,7 +244,7 @@ N_OP_iplusn
         entry		IPLUS.N		OPCODE[0335]
         return(tos + n)
 ************************************************************/
-LispPTR N_OP_iplusn(int tos, int n) {
+LispPTR N_OP_iplusn(LispPTR tos, int n) {
   int arg1;
   int result;
 
@@ -274,7 +274,7 @@ N_OP_idifferencen
         entry		IDIFFERENCE.N		OPCODE[0336]
         return(tos - n)
 ************************************************************/
-LispPTR N_OP_idifferencen(int tos, int n) {
+LispPTR N_OP_idifferencen(LispPTR tos, int n) {
   int arg1;
   int result;
 
@@ -308,7 +308,7 @@ do_ufn:
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_makenumber(int tosm1, int tos) {
+LispPTR N_OP_makenumber(LispPTR tosm1, LispPTR tos) {
   int result;
 
   if (((tosm1 & 0xFFFF0000) != S_POSITIVE) || ((tos & 0xFFFF0000) != S_POSITIVE)) ERROR_EXIT(tos);
@@ -326,7 +326,7 @@ LispPTR N_OP_makenumber(int tosm1, int tos) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_boxiplus(int a, int tos) {
+LispPTR N_OP_boxiplus(LispPTR a, LispPTR tos) {
   int arg2;
 
   if (GetTypeNumber(a) == TYPE_FIXP) {
@@ -349,7 +349,7 @@ bad:
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_boxidiff(int a, int tos) {
+LispPTR N_OP_boxidiff(LispPTR a, LispPTR tos) {
   int arg2;
 
   if (GetTypeNumber(a) == TYPE_FIXP) {
@@ -369,7 +369,7 @@ bad:
 
 */
 /**********************************************************************/
-LispPTR N_OP_times2(int tosm1, int tos) {
+LispPTR N_OP_times2(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -398,7 +398,7 @@ doufn:
 
 } /* end N_OP_times2 */
 
-LispPTR N_OP_itimes2(int tosm1, int tos) {
+LispPTR N_OP_itimes2(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -433,7 +433,7 @@ doufn:
 
 */
 /**********************************************************************/
-LispPTR N_OP_quot(int tosm1, int tos) {
+LispPTR N_OP_quot(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -451,7 +451,7 @@ doufn:
 
 } /* end N_OP_quot */
 
-LispPTR N_OP_iquot(int tosm1, int tos) {
+LispPTR N_OP_iquot(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 
@@ -475,7 +475,7 @@ doufn:
 */
 /**********************************************************************/
 
-LispPTR N_OP_iremainder(int tosm1, int tos) {
+LispPTR N_OP_iremainder(LispPTR tosm1, LispPTR tos) {
   int arg1, arg2;
   int result;
 

--- a/src/atom.c
+++ b/src/atom.c
@@ -44,7 +44,7 @@ N_OP_atomcellN(int tos, int n)
 }
 
 #else
-N_OP_atomcellN(register int tos, int n) {
+N_OP_atomcellN(int tos, int n) {
   if ((tos & 0xffff0000) == 0) { /* XeroxLisp traditional symbol */
     tos = (tos << 1);
     switch (n) {

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -328,16 +328,16 @@ void bitbltsub(LispPTR *argv) {
   int displayflg = 0;
 #endif
   int backwardflg = 0, sx, dx, srcbpl=2147483647, dstbpl, src_comp, op;
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   int gray = 0, num_gray = 0, curr_gray_line = 0;
   DLword grayword[4];
 
   { /* Initialization code, in a block so it optimizes independently */
-    register LispPTR *args = argv;
-    register PILOTBBT *pbt;
-    register BITMAP *srcebm, *destbm;
+    LispPTR *args = argv;
+    PILOTBBT *pbt;
+    BITMAP *srcebm, *destbm;
     BITMAP *texture68k;
-    register DLword *base;
+    DLword *base;
 
 #ifdef INIT
     init_kbd_startup;
@@ -671,8 +671,8 @@ LispPTR bitblt_bitmap(LispPTR *args) {
 
   if (clipreg != NIL_PTR) {
     /* clip the BITBLT using the clipping region supplied */
-    register LispPTR clipvalue;
-    register int temp, cr_left, cr_bot;
+    LispPTR clipvalue;
+    int temp, cr_left, cr_bot;
 
     clipvalue = car(clipreg);
     N_GETNUMBER(clipvalue, cr_left, bad_arg);
@@ -702,7 +702,7 @@ LispPTR bitblt_bitmap(LispPTR *args) {
   stodx = dleft - sleft;
 
   {
-    register int temp;
+    int temp;
     left = max(clipleft, max(0, left - stodx));
     bottom = max(clipbottom, max(0, bottom - stody));
     temp = SourceBitmap->bmwidth;
@@ -916,7 +916,7 @@ LispPTR bitshade_bitmap(LispPTR *args) {
 
   texture = args[0];
   {
-    register int temp;
+    int temp;
     temp = GetTypeNumber(texture);
     if (((temp == TYPE_LITATOM) && (texture != NIL_PTR)) || (temp == TYPE_LISTP)) {
       PUNT_TO_BLTSHADEBITMAP;
@@ -936,8 +936,8 @@ LispPTR bitshade_bitmap(LispPTR *args) {
   left = bottom = 0;
   right = DestBitmap->bmwidth;
   if (clipreg != NIL_PTR) { /* clip the BITBLT using the clipping region supplied */
-    register LispPTR clipvalue;
-    register int temp, cr_left, cr_bot;
+    LispPTR clipvalue;
+    int temp, cr_left, cr_bot;
 
     clipvalue = car(clipreg);
     N_GETNUMBER(clipvalue, cr_left, bad_arg);
@@ -1143,11 +1143,11 @@ void bltchar(LispPTR *args)
  *      args[5] :       RIGHT
  */
 {
-  register PILOTBBT *pbt;
-  register DISPLAYDATA *dspdata;
+  PILOTBBT *pbt;
+  DISPLAYDATA *dspdata;
   int base;
 #ifdef REALCURSOR
-  register int displayflg;
+  int displayflg;
 #endif
   int w, h;
   int backwardflg = 0, sx, dx, srcbpl, dstbpl, src_comp, op;
@@ -1316,7 +1316,7 @@ LispPTR TEDIT_BLTCHAR_index; /* if NIL ,TEDIT is not yet loaded */
 /************************************************************************/
 
 void newbltchar(LispPTR *args) {
-  register DISPLAYDATA *displaydata68k;
+  DISPLAYDATA *displaydata68k;
   int right, left, curx;
   PILOTBBT *pbt;
   int lmargin, rmargin, xoff;
@@ -1354,7 +1354,7 @@ void newbltchar(LispPTR *args) {
   if (((BLTARG *)args)->displaystream != *TOPWDS68k) PUNT_TO_BLTCHAR;
 
   {
-    register int newpos;
+    int newpos;
     newpos = curx +
              GETWORD((DLword *)Addr68k_from_LADDR(displaydata68k->ddwidthscache + ((BLTARG *)args)->char8code));
 
@@ -1564,7 +1564,7 @@ static LispPTR sfffixy(DISPLAYDATA *displaydata68k, CHARSETINFO *csinfo68k, PILO
   int y;
   int chartop, top;
   BITMAP *bm68k;
-  register LispPTR base, ypos, yoff;
+  LispPTR base, ypos, yoff;
 
   FGetNum2(displaydata68k->ddyoffset, yoff);
   FGetNum2(displaydata68k->ddyposition, ypos);
@@ -1596,11 +1596,11 @@ static LispPTR sfffixy(DISPLAYDATA *displaydata68k, CHARSETINFO *csinfo68k, PILO
 
 } /* sfffixy */
 
-static LispPTR changecharset_display(register DISPLAYDATA *displaydata68k, DLword charset) {
-  register PILOTBBT *pbt68k;
-  register FONTDESC *fontd68k;
+static LispPTR changecharset_display(DISPLAYDATA *displaydata68k, DLword charset) {
+  PILOTBBT *pbt68k;
+  FONTDESC *fontd68k;
   LispPTR csinfo;
-  register CHARSETINFO *csinfo68k;
+  CHARSETINFO *csinfo68k;
   BITMAP *bm68k;
   LispPTR *base68k;
 
@@ -1626,8 +1626,8 @@ static LispPTR changecharset_display(register DISPLAYDATA *displaydata68k, DLwor
     printf("CCD1\n");
     return (sfffixy(displaydata68k, csinfo68k, pbt68k));
   } else {
-    register LispPTR addr;
-    register int num;
+    LispPTR addr;
+    int num;
     FGetNum2(displaydata68k->ddcharheightdelta, num); /* if not number, return -1 */
     addr = bm68k->bmbase + (bm68k->bmrasterwidth * num);
     printf("CCD2 num=%d\n", num);
@@ -1639,14 +1639,14 @@ static LispPTR changecharset_display(register DISPLAYDATA *displaydata68k, DLwor
 #endif
 /******************************************************************/
 
-void ccfuncall(register unsigned int atom_index, register int argnum, register int bytenum)
+void ccfuncall(unsigned int atom_index, int argnum, int bytenum)
  /* Atomindex for Function you want to invoke */
  /* Number of ARGS on TOS and STK */
  /* Number of bytes of Caller's OPCODE(including multi-byte) */
 {
-  register struct definition_cell *defcell68k; /* Definition Cell PTR */
-  register short pv_num;                       /* scratch for pv */
-  register struct fnhead *tmp_fn;
+  struct definition_cell *defcell68k; /* Definition Cell PTR */
+  short pv_num;                       /* scratch for pv */
+  struct fnhead *tmp_fn;
   int rest; /* use for alignments */
 
   /* Get Next Block offset from argnum */
@@ -1739,9 +1739,9 @@ void tedit_bltchar(LispPTR *args)
 {
 #define backwardflg 0
 #define displayflg 0
-  register DISPLAYDATA *displaydata68k;
+  DISPLAYDATA *displaydata68k;
   int right;
-  register PILOTBBT *pbt;
+  PILOTBBT *pbt;
   int imagewidth, newx;
   /* for new_char_bitblt_code */
   int h, w;
@@ -1818,7 +1818,7 @@ static int old_cursorin(DLword addrhi, DLword addrlo, int x, int w, int h, int y
 /* Lisp addr hi-word, lo-word, ... */
 static int old_cursorin(DLword addrhi, DLword addrlo, int x, int w, int h, int y, int backward)
 {
-  register DLword *base68k;
+  DLword *base68k;
   extern int MonoOrColor;
   extern int displaywidth;
 #ifdef INIT

--- a/src/bin.c
+++ b/src/bin.c
@@ -31,7 +31,7 @@
 #include "lsptypes.h"  // for state, ERROR_EXIT, GetTypeNumber, Get_BYTE
 #include "stream.h"    // for Stream
 
-LispPTR N_OP_bin(register int tos) {
+LispPTR N_OP_bin(LispPTR tos) {
   register Stream *stream68k; /* stream instance on TOS */
   register char *buff68k;     /* pointer to BUFF */
 

--- a/src/bin.c
+++ b/src/bin.c
@@ -32,8 +32,8 @@
 #include "stream.h"    // for Stream
 
 LispPTR N_OP_bin(LispPTR tos) {
-  register Stream *stream68k; /* stream instance on TOS */
-  register char *buff68k;     /* pointer to BUFF */
+  Stream *stream68k; /* stream instance on TOS */
+  char *buff68k;     /* pointer to BUFF */
 
   if (GetTypeNumber(tos) == TYPE_STREAM) {
     stream68k = (Stream *)Addr68k_from_LADDR(tos);

--- a/src/binds.c
+++ b/src/binds.c
@@ -29,11 +29,11 @@ N_OP_bind(stack_pointer, tos, n1, n2)
 
 ***************************************************/
 
-LispPTR *N_OP_bind(register LispPTR *stack_pointer, register LispPTR tos, int byte1, int byte2) {
-  register int n1;         /* # slots to bind to NIL (0, 0) */
-  register int n2;         /* # slots to bind to value in stack */
-  register LispPTR *ppvar; /* pointer to argued slot in Pvar area */
-  register unsigned i;          /* temporary for control */
+LispPTR *N_OP_bind(LispPTR *stack_pointer, LispPTR tos, int byte1, int byte2) {
+  int n1;         /* # slots to bind to NIL (0, 0) */
+  int n2;         /* # slots to bind to value in stack */
+  LispPTR *ppvar; /* pointer to argued slot in Pvar area */
+  unsigned i;          /* temporary for control */
 
 #ifdef TRACE
   printPC();
@@ -69,11 +69,11 @@ LispPTR N_OP_unbind(stackpointer)
 
 ***************************************************/
 
-LispPTR *N_OP_unbind(register LispPTR *stack_pointer) {
-  register DLword num;     /* number of unbind sot */
-  register LispPTR *ppvar; /* pointer to last PVAR slot. */
-  register DLword i;       /* temporary for control */
-  register LispPTR value;
+LispPTR *N_OP_unbind(LispPTR *stack_pointer) {
+  DLword num;     /* number of unbind sot */
+  LispPTR *ppvar; /* pointer to last PVAR slot. */
+  DLword i;       /* temporary for control */
+  LispPTR value;
 
 #ifdef TRACE
   printPC();
@@ -106,11 +106,11 @@ N_OP_dunbind
 
 ***************************************************/
 
-LispPTR *N_OP_dunbind(register LispPTR *stack_pointer, register LispPTR tos) {
-  register DLword num;     /* number of unbind sot */
-  register LispPTR *ppvar; /* pointer to last PVAR slot. */
-  register DLword i;       /* temporary for control */
-  register LispPTR value;
+LispPTR *N_OP_dunbind(LispPTR *stack_pointer, LispPTR tos) {
+  DLword num;     /* number of unbind sot */
+  LispPTR *ppvar; /* pointer to last PVAR slot. */
+  DLword i;       /* temporary for control */
+  LispPTR value;
 
 #ifdef TRACE
   printPC();

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -59,7 +59,7 @@ extern int MonoOrColor;
 /**                                                                         **/
 /*****************************************************************************/
 
-LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl,int tos)
+LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl, LispPTR tos)
 {
   PILOTBBT *pbt;
   DLword *srcbase, *dstbase;

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -155,7 +155,7 @@ LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl, LispPTR tos)
 /* for MONO only */
 int cursorin(DLword addrhi, DLword addrlo, int w, int h, int backward)
 {
-  register int x, y;
+  int x, y;
   if (addrhi == DISPLAY_HI) {
     y = addrlo / DisplayRasterWidth;
     x = (addrlo - y * DisplayRasterWidth) << 4;
@@ -177,8 +177,8 @@ int cursorin(DLword addrhi, DLword addrlo, int w, int h, int backward)
 /* for COLOR & MONO */
 int cursorin(DLword addrhi, DLword addrlo, int w, int h, int backward)
 {
-  register int x, y;
-  register DLword *base68k;
+  int x, y;
+  DLword *base68k;
   extern int MonoOrColor;
   extern int displaywidth;
   extern DLword *ColorDisplayRegion68k;

--- a/src/blt.c
+++ b/src/blt.c
@@ -42,10 +42,10 @@
         TOS has number of words to be translated.
 */
 
-LispPTR N_OP_blt(LispPTR destptr, LispPTR sourceptr, register LispPTR wordcount) {
-  register DLword *source68k;
-  register DLword *dest68k;
-  register int nw;
+LispPTR N_OP_blt(LispPTR destptr, LispPTR sourceptr, LispPTR wordcount) {
+  DLword *source68k;
+  DLword *dest68k;
+  int nw;
 
   if ((wordcount & SEGMASK) != S_POSITIVE) ERROR_EXIT(wordcount);
   nw = wordcount & 0xffff;

--- a/src/byteswap.c
+++ b/src/byteswap.c
@@ -39,8 +39,8 @@ void byte_swap_page(unsigned short *page, int wordcount) {
 /*                                                              */
 /****************************************************************/
 void word_swap_page(unsigned short *page, int longwordcount) {
-  register int i;
-  register unsigned int *longpage;
+  int i;
+  unsigned int *longpage;
   longpage = (unsigned int *)page;
   for (i = 0; i < (longwordcount + longwordcount); i++) {
     *(page + i) = byte_swap_word(*(page + i));
@@ -98,8 +98,8 @@ const unsigned char reversedbits[256] = {
 #define reverse_bits(word) ((reversedbits[((word) >> 8) & 0xFF] << 8) | reversedbits[(word)&0xff])
 
 void bit_reverse_region(unsigned short *top, int width, int height, int rasterwidth) {
-  register int i, j, wordwid = ((width + 31) >> 5) << 1;
-  register unsigned short *word;
+  int i, j, wordwid = ((width + 31) >> 5) << 1;
+  unsigned short *word;
 
   for (i = 0; i < height; i++) {
     word = top;

--- a/src/car-cdr.c
+++ b/src/car-cdr.c
@@ -50,11 +50,11 @@
 /*									*/
 /************************************************************************/
 
-LispPTR car(register LispPTR datum)
+LispPTR car(LispPTR datum)
 /* datum must be LISP pointer(word offset) */
 {
-  register ConsCell *datum68k;
-  register ConsCell *temp;
+  ConsCell *datum68k;
+  ConsCell *temp;
 
   datum68k = (ConsCell *)(Addr68k_from_LADDR(datum));
   if (Listp(datum)) {
@@ -88,12 +88,12 @@ LispPTR car(register LispPTR datum)
 /*									*/
 /************************************************************************/
 
-LispPTR cdr(register LispPTR datum)
+LispPTR cdr(LispPTR datum)
 /* datum must be LISP pointer(word offset) */
 {
-  register ConsCell *datum68k;
-  register DLword cdr_code;
-  register ConsCell *temp;
+  ConsCell *datum68k;
+  DLword cdr_code;
+  ConsCell *temp;
 
   if (datum == NIL_PTR) return (NIL_PTR);
   if (!Listp(datum)) error("cdr : ARG not list");
@@ -130,12 +130,12 @@ LispPTR cdr(register LispPTR datum)
 */
 /**********************************************************************/
 
-LispPTR rplaca(register LispPTR x, register LispPTR y)
+LispPTR rplaca(LispPTR x, LispPTR y)
 /* car of x will be smashed */
 /* y is a newly car object */
 {
-  register ConsCell *x_68k;
-  register ConsCell *temp;
+  ConsCell *x_68k;
+  ConsCell *temp;
 
 #ifdef TRACE2
   printf("TRACE: rplaca()\n");
@@ -183,17 +183,17 @@ static ConsCell *find_cdrable_pair(LispPTR carpart, LispPTR cdrpart); /* below..
 static ConsCell *find_close_cell(struct conspage *page, LispPTR oldcell);
 #endif
 
-LispPTR rplacd(LispPTR x, register LispPTR y)
+LispPTR rplacd(LispPTR x, LispPTR y)
 /* cdr of x will be smashed */
 /* y is a newly cdr object */
 {
-  register ConsCell *x_68k;
-  register ConsCell *temp68k;
-  register ConsCell *cdr_cell68k;
+  ConsCell *x_68k;
+  ConsCell *temp68k;
+  ConsCell *cdr_cell68k;
   LispPTR cdr_cell;
   LispPTR rp_page;
   DLword cdr_code;
-  register struct conspage *cons68k;
+  struct conspage *cons68k;
 
   if (Listp(x) == NIL) {
     if (x == NIL_PTR) {
@@ -318,9 +318,9 @@ LispPTR rplacd(LispPTR x, register LispPTR y)
 */
 /**********************************************************************/
 
-LispPTR N_OP_car(register LispPTR tos) {
-  register ConsCell *datum68k;
-  register ConsCell *temp;
+LispPTR N_OP_car(LispPTR tos) {
+  ConsCell *datum68k;
+  ConsCell *temp;
 
   datum68k = (ConsCell *)(Addr68k_from_LADDR(tos));
   if (Listp(tos)) {
@@ -349,9 +349,9 @@ LispPTR N_OP_car(register LispPTR tos) {
 */
 /**********************************************************************/
 
-LispPTR N_OP_cdr(register LispPTR tos) {
-  register ConsCell *datum68k;
-  register DLword cdr_code;
+LispPTR N_OP_cdr(LispPTR tos) {
+  ConsCell *datum68k;
+  DLword cdr_code;
 
   if (tos == NIL_PTR) return (tos);
   if (!Listp(tos)) {
@@ -390,9 +390,9 @@ LispPTR N_OP_cdr(register LispPTR tos) {
 */
 /**********************************************************************/
 
-LispPTR N_OP_rplaca(register LispPTR tosm1, register LispPTR tos) {
-  register ConsCell *x_68k;
-  register ConsCell *temp;
+LispPTR N_OP_rplaca(LispPTR tosm1, LispPTR tos) {
+  ConsCell *x_68k;
+  ConsCell *temp;
 
   if (Listp(tosm1) == NIL) {
     if (tosm1 == NIL_PTR) {
@@ -433,7 +433,7 @@ LispPTR N_OP_rplaca(register LispPTR tosm1, register LispPTR tos) {
 */
 /**********************************************************************/
 
-LispPTR N_OP_rplacd(register LispPTR tosm1, register LispPTR tos) {
+LispPTR N_OP_rplacd(LispPTR tosm1, LispPTR tos) {
   if (Listp(tosm1) == NIL) {
     if (tosm1 == NIL_PTR) {
       if (tos != NIL_PTR)

--- a/src/chardev.c
+++ b/src/chardev.c
@@ -76,8 +76,8 @@ LispPTR CHAR_openfile(LispPTR *args)
 /* args[2]            errno */
 {
 #ifndef DOS
-  register int fd;    /* return value  of open system call. */
-  register int flags; /* open system call's argument */
+  int fd;    /* return value  of open system call. */
+  int flags; /* open system call's argument */
   /* struct stat statbuf; */
   char pathname[MAXPATHLEN];
 
@@ -128,8 +128,8 @@ LispPTR CHAR_closefile(LispPTR *args)
 /* args[1]            errno   */
 {
 #ifndef DOS
-  register int fd; /* file descriptor */
-  register int rval;
+  int fd; /* file descriptor */
+  int rval;
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[1]));
   fd = LispNumToCInt(args[0]);
   ERRSETJMP(NIL);
@@ -174,7 +174,7 @@ LispPTR CHAR_ioctl(LispPTR *args)
 #ifndef DOS
   int fd, request;
   void *data;
-  register int rval;
+  int rval;
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[3]));
   fd = LispNumToCInt(args[0]);
   request = LispNumToCInt(args[1]);
@@ -204,7 +204,7 @@ LispPTR CHAR_ioctl(LispPTR *args)
 LispPTR CHAR_bin(int fd, LispPTR errn)
 {
 #ifndef DOS
-  register int rval;
+  ssize_t rval;
   unsigned char ch[4];
   Lisp_errno = (int *)(Addr68k_from_LADDR(errn));
   ERRSETJMP(NIL);
@@ -219,7 +219,7 @@ LispPTR CHAR_bin(int fd, LispPTR errn)
     *Lisp_errno = errno;
     return (NIL);
   }
-  return (GetSmallp(ch[0]));
+  return (GetPosSmallp(ch[0]));
 #endif /* DOS */
 }
 
@@ -236,7 +236,7 @@ LispPTR CHAR_bin(int fd, LispPTR errn)
 LispPTR CHAR_bout(int fd, LispPTR ch, LispPTR errn)
 {
 #ifndef DOS
-  register int rval;
+  ssize_t rval;
   char buf[4];
   Lisp_errno = (int *)(Addr68k_from_LADDR(errn));
   ERRSETJMP(NIL);
@@ -281,7 +281,8 @@ LispPTR CHAR_bout(int fd, LispPTR ch, LispPTR errn)
 LispPTR CHAR_bins(LispPTR *args)
 {
 #ifndef DOS
-  register int fd, rval;
+  int fd;
+  ssize_t rval;
   char *buffer;
   int nbytes;
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[4]));
@@ -304,7 +305,7 @@ LispPTR CHAR_bins(LispPTR *args)
   word_swap_page((unsigned short *)buffer, (nbytes + 3) >> 2);
 #endif /* BYTESWAP */
 
-  return (GetSmallp(rval));
+  return (GetPosSmallp(rval));
 #endif /* DOS */
 }
 
@@ -332,7 +333,8 @@ LispPTR CHAR_bins(LispPTR *args)
 LispPTR CHAR_bouts(LispPTR *args)
 {
 #ifndef DOS
-  register int fd, rval;
+  int fd;
+  ssize_t rval;
   char *buffer;
   int nbytes;
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[4]));

--- a/src/conspage.c
+++ b/src/conspage.c
@@ -59,10 +59,10 @@
  * @param[in] link Lisp page number of next cons page
  */
 
-static void init_conspage(register struct conspage *base, unsigned int link)
+static void init_conspage(struct conspage *base, unsigned int link)
 {
-  register ConsCell *cell;
-  register int j; /* DL-> int */
+  ConsCell *cell;
+  int j; /* DL-> int */
 
 #ifdef TRACE2
   printf("TRACE: init_conspage()\n");
@@ -116,10 +116,10 @@ static void init_conspage(register struct conspage *base, unsigned int link)
 struct conspage *next_conspage(void) {
   extern struct dtd *ListpDTD;
 
-  register struct conspage *page1; /* Allocated 1st MDS page */
-  register struct conspage *page2; /* Allocated 2nd MDS page */
+  struct conspage *page1; /* Allocated 1st MDS page */
+  struct conspage *page2; /* Allocated 2nd MDS page */
   struct conspage *pg, *priorpg;
-  register int next, prior;
+  int next, prior;
 
 #ifdef NEWCDRCODING
   /* Allocate 2 conspages and get 1st page base */
@@ -292,15 +292,15 @@ static ConsCell *find_free_cons_cell(void) {
 */
 /**********************************************************************/
 
-LispPTR N_OP_cons(register int cons_car, register int cons_cdr) {
+LispPTR N_OP_cons(int cons_car, int cons_cdr) {
   extern struct dtd *ListpDTD;
 
-  register struct conspage *new_conspage;
-  register ConsCell *new_cell;
+  struct conspage *new_conspage;
+  ConsCell *new_cell;
 #ifndef NEWCDRCODING
-  register ConsCell *temp_cell;
+  ConsCell *temp_cell;
 #endif
-  register int new_page; /* hold the return  val of nextconspage ,DL->int */
+  int new_page; /* hold the return  val of nextconspage ,DL->int */
 
   GCLOOKUP(cons_cdr &= POINTERMASK, ADDREF);
   GCLOOKUP(cons_car, ADDREF);

--- a/src/dir.c
+++ b/src/dir.c
@@ -70,7 +70,7 @@ extern int Dummy_errno;
 
 #define SetupMatch(tname, pname, text, pext, tver)   \
   {                                                  \
-    register char *pp;                               \
+    char *pp;                               \
                                                      \
     separate_version(tname, tver, 0);                \
                                                      \
@@ -141,8 +141,8 @@ extern int Dummy_errno;
 
 static int match_pattern(char *tp, char *pp)
 {
-  register char *tsp, *psp;
-  register int inastr;
+  char *tsp, *psp;
+  int inastr;
 
 #ifdef DOS
   /* % is not allowed in DOS names for Medley. */
@@ -246,7 +246,7 @@ int MAXFINFO;
 
 #define FreeFinfo(fp)                                                      \
   {                                                                        \
-    register FINFO *lastp;                                                 \
+    FINFO *lastp;                                                 \
     for (lastp = fp; lastp->next != (FINFO *)NULL; lastp = lastp->next) {} \
     lastp->next = FreeFinfoList;                                           \
     FreeFinfoList = fp;                                                    \
@@ -293,8 +293,8 @@ void print_finfo(FINFO *fp)
  */
 
 int init_finfo() {
-  register FINFO *cp;
-  register int n;
+  FINFO *cp;
+  int n;
 
   if ((FreeFinfoList = (FINFO *)calloc(sizeof(FINFO) + sizeof(FPROP), INITFINFONUM)) ==
       (FINFO *)NULL) {
@@ -341,7 +341,7 @@ int init_finfo() {
  */
 
 static int get_finfo_id() {
-  register int i;
+  int i;
   DFINFO *dfap;
 
   for (i = 0; i < MAXFINFO; i++)
@@ -387,12 +387,12 @@ static int get_finfo_id() {
 #ifdef DOS
 static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct direct *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, len, rval, res, isslash = 0, drive = 0;
   struct find_t dirp;
-  register struct passwd *pwd;
+  struct passwd *pwd;
   struct stat sbuf;
   char namebuf[MAXPATHLEN];
   char fver[VERSIONLEN];
@@ -547,13 +547,13 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct dirent *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct dirent *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, rval;
   size_t len;
   DIR *dirp;
-  register struct passwd *pwd;
+  struct passwd *pwd;
   struct stat sbuf;
   char namebuf[MAXPATHLEN];
   char fver[VERSIONLEN];
@@ -667,9 +667,9 @@ static int enum_dsk_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #ifdef DOS
 static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct direct *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, len, rval, isslash = 0, drive = 0;
   struct find_t dirp;
   struct stat sbuf;
@@ -811,9 +811,9 @@ static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 
 static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct dirent *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct dirent *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, rval;
   size_t len;
   DIR *dirp;
@@ -920,12 +920,12 @@ static int enum_dsk(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #ifdef DOS
 static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct direct *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, len, rval;
   struct find_t dirp;
-  /* register struct passwd *pwd; -- From author support */
+  /* struct passwd *pwd; -- From author support */
   struct stat sbuf;
   char namebuf[MAXPATHLEN];
 
@@ -1006,13 +1006,13 @@ static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct dirent *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct dirent *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, rval;
   size_t len;
   DIR *dirp;
-  /* register struct passwd *pwd; -- From author support */
+  /* struct passwd *pwd; -- From author support */
   struct stat sbuf;
   char namebuf[MAXPATHLEN];
 
@@ -1120,9 +1120,9 @@ static int enum_ufs_prop(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #ifdef DOS
 static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct direct *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct direct *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, len, rval;
   struct find_t dirp;
   struct stat sbuf;
@@ -1190,9 +1190,9 @@ static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 #else  /* DOS */
 static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 {
-  register struct dirent *dp;
-  register FINFO *prevp;
-  register FINFO *nextp;
+  struct dirent *dp;
+  FINFO *prevp;
+  FINFO *nextp;
   int n, rval;
   size_t len;
   DIR *dirp;
@@ -1287,8 +1287,8 @@ static int enum_ufs(char *dir, char *name, char *ver, FINFO **finfo_buf)
 static int trim_finfo(FINFO **fp)
 {
 #ifndef DOS
-  register FINFO *tp, *sp, *mp, *cp, *pp;
-  register int num, pnum;
+  FINFO *tp, *sp, *mp, *cp, *pp;
+  int num, pnum;
   int linkp;
   char ver[VERSIONLEN];
 
@@ -1415,8 +1415,8 @@ static int trim_finfo(FINFO **fp)
 
 static int trim_finfo_highest(FINFO **fp, int highestp)
 {
-  register FINFO *tp, *sp, *mp, *cp, *pp;
-  register int num, pnum;
+  FINFO *tp, *sp, *mp, *cp, *pp;
+  int num, pnum;
   int linkp;
   char ver[VERSIONLEN];
 
@@ -1553,8 +1553,8 @@ static int trim_finfo_highest(FINFO **fp, int highestp)
 
 static int trim_finfo_version(FINFO **fp, unsigned rver)
 {
-  register FINFO *tp, *sp, *mp, *cp, *pp, *vp;
-  register int num, pnum;
+  FINFO *tp, *sp, *mp, *cp, *pp, *vp;
+  int num, pnum;
   int linkp;
   char ver[VERSIONLEN];
 
@@ -1742,10 +1742,10 @@ static int trim_finfo_version(FINFO **fp, unsigned rver)
  * Caller have to free the area after sorting done.
  */
 
-static FINFO **prepare_sort_buf(register FINFO *fp, register int n)
+static FINFO **prepare_sort_buf(FINFO *fp, int n)
 {
-  register FINFO **bp;
-  register FINFO **bufp;
+  FINFO **bp;
+  FINFO **bufp;
 
   if ((bufp = (FINFO **)malloc(sizeof(FINFO *) * n)) == NULL) {
     *Lisp_errno = errno;
@@ -1777,7 +1777,7 @@ static FINFO **prepare_sort_buf(register FINFO *fp, register int n)
 
 static int dsk_filecmp(FINFO **fp1, FINFO **fp2)
 {
-  register int res;
+  int res;
   unsigned v1, v2;
 
   if ((res = strcmp((*fp1)->no_ver_name, (*fp2)->no_ver_name)) != 0) return (res);
@@ -1807,7 +1807,7 @@ static int dsk_filecmp(FINFO **fp1, FINFO **fp2)
  * Note that the result is in the reversed order.
  */
 
-static int unix_filecmp(register FINFO **f1, register FINFO **f2)
+static int unix_filecmp(FINFO **f1, FINFO **f2)
 { return (strcmp((*f1)->lname, (*f2)->lname)); }
 
 /*
@@ -1829,10 +1829,10 @@ static int unix_filecmp(register FINFO **f1, register FINFO **f2)
  * used for {DSK} and {UNIX} device respectively as a sort function.
  */
 
-static int file_sort(register FINFO **fpp, register int n, register int (*sortfn)())
+static int file_sort(FINFO **fpp, int n, int (*sortfn)())
 {
-  register FINFO **fp;
-  register FINFO **sort_bufp;
+  FINFO **fp;
+  FINFO **sort_bufp;
 
   if ((sort_bufp = prepare_sort_buf(*fpp, n)) == (FINFO **)NULL) return (0);
 
@@ -1963,7 +1963,7 @@ typedef struct ufsgfs {
  * Enumerates files matching pattern.
  */
 
-LispPTR COM_gen_files(register LispPTR *args)
+LispPTR COM_gen_files(LispPTR *args)
 {
   char fbuf[MAXPATHLEN + 5], dir[MAXPATHLEN], pattern[MAXPATHLEN];
   char host[MAXNAMLEN], name[MAXNAMLEN], ver[VERSIONLEN];
@@ -1972,7 +1972,7 @@ LispPTR COM_gen_files(register LispPTR *args)
 #endif
   int dskp, count, highestp, fid;
   unsigned propp, version;
-  register char *cp;
+  char *cp;
   FINFO *fp;
   int dsk_filecmp(), unix_filecmp();
 
@@ -2124,14 +2124,14 @@ LispPTR COM_gen_files(register LispPTR *args)
  * name.
  */
 
-LispPTR COM_next_file(register LispPTR *args)
+LispPTR COM_next_file(LispPTR *args)
 {
-  register LispPTR laddr;
-  register FPROP *pp;
-  register FINFO *fp;
-  register char *base;
-  register DFINFO *dfp;
-  register UFSGFS *gfsp;
+  LispPTR laddr;
+  FPROP *pp;
+  FINFO *fp;
+  char *base;
+  DFINFO *dfp;
+  UFSGFS *gfsp;
   int finfoid;
   unsigned propp;
 
@@ -2196,11 +2196,11 @@ LispPTR COM_next_file(register LispPTR *args)
  * Abandon all cached information corresponding to the generator.
  */
 
-LispPTR COM_finish_finfo(register LispPTR *args)
+LispPTR COM_finish_finfo(LispPTR *args)
 {
-  register DFINFO *dfp;
-  register FINFO *fp;
-  register int finfoid;
+  DFINFO *dfp;
+  FINFO *fp;
+  int finfoid;
 
   ERRSETJMP(NIL);
 

--- a/src/dosmouse.c
+++ b/src/dosmouse.c
@@ -259,7 +259,7 @@ set_DOSmouseposition(DspInterface dsp, int x, int y)
 
 void docopy(int newx, int newy)
 {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w = 16, h = 16, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
 
@@ -284,7 +284,7 @@ dostaking_mouse_up(int newx, int newy)
 {
   /* save hidden bitmap */
 
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w = 16, h = 16, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
 
@@ -333,7 +333,7 @@ dostaking_mouse_up(int newx, int newy)
 
 dostaking_mouse_down(DspInterface dsp, IOPAGE *iop)
 {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
 

--- a/src/draw.c
+++ b/src/draw.c
@@ -116,7 +116,7 @@ plot:
 
 int N_OP_drawline(LispPTR ptr, int curbit, int xsize, int width, int ysize, int op, int delta, int numx, int numy)
 {
-  register DLword *dataptr;
+  DLword *dataptr;
   ScreenLocked = T;
 
 #ifdef COLOR

--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -108,7 +108,7 @@ void DSP_Cursor(LispPTR *args, int argnum)
  /* args[0] :	X pos
   * args[1] :	Y pos
   */
-void DSP_SetMousePos(register LispPTR *args)
+void DSP_SetMousePos(LispPTR *args)
 {
 
 #ifdef XWINDOW
@@ -149,8 +149,8 @@ extern int Current_Hot_X, Current_Hot_Y;
 #endif /* XWINDOW */
 
 void flip_cursor() {
-  register DLword *word;
-  register int cnt;
+  DLword *word;
+  int cnt;
   extern int ScreenLocked;
   extern DLword *EmCursorX68K, *EmCursorY68K;
 

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -79,8 +79,8 @@ BIGNUM  (integer that can't be represented bigger than 32 bits)
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_clequal(register int arg1, register int arg2) {
-  register int type;
+LispPTR N_OP_clequal(int arg1, int arg2) {
+  int type;
 
   if (arg2 == arg1) return (ATOM_T);
   IF_IMMEDIATE(arg1, return (NIL), return (NIL));
@@ -128,8 +128,8 @@ LispPTR N_OP_clequal(register int arg1, register int arg2) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_eqlop(register int arg1, register int arg2) {
-  register int type;
+LispPTR N_OP_eqlop(int arg1, int arg2) {
+  int type;
 
   if (arg2 == arg1) return (ATOM_T);
   IF_IMMEDIATE(arg1, return (NIL), return (NIL));
@@ -169,8 +169,8 @@ LispPTR N_OP_eqlop(register int arg1, register int arg2) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_equal(register int arg1, register int arg2) {
-  register int type, type2;
+LispPTR N_OP_equal(int arg1, int arg2) {
+  int type, type2;
 
   if (arg2 == arg1) return (ATOM_T);
 
@@ -211,7 +211,7 @@ arg2_small:
   }
 
   if ((type == TYPE_FLOATP) || (type2 == TYPE_FLOATP)) {
-    register float f1, f2;
+    float f1, f2;
     N_MakeFloat(arg1, f1, arg2);
     N_MakeFloat(arg2, f2, arg2);
     if ((f1 + 0.0f) == (f2 + 0.0f))
@@ -232,11 +232,11 @@ arg2_small:
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_eqq(register int arg1, register int arg2) /* CL:=    opcode 0377 */
+LispPTR N_OP_eqq(int arg1, int arg2) /* CL:=    opcode 0377 */
 
 {
-  register int type1, type2;
-  register float f1, f2;
+  int type1, type2;
+  float f1, f2;
 
   if (!((type1 = GetTypeEntry(arg1)) & TT_NUMBERP)) ERROR_EXIT(arg2);
   if (arg2 == arg1) return (ATOM_T);

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -23,7 +23,7 @@
 #include "lispmap.h"   // for ATOM_OFFSET, S_CHARACTER, S_NEGATIVE, S_POSITIVE
 #include "lspglob.h"
 #include "lsptypes.h"  // for TYPE_FLOATP, GetTypeNumber, TYPE_FIXP, TYPE_SM...
-#include "my.h"        // for IsNumber, N_MakeFloat
+#include "my.h"        // for N_MakeFloat
 
 /************************************************************
 op 072   N_OP_eqlop	EQL
@@ -79,7 +79,7 @@ BIGNUM  (integer that can't be represented bigger than 32 bits)
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_clequal(int arg1, int arg2) {
+LispPTR N_OP_clequal(LispPTR arg1, LispPTR arg2) {
   int type;
 
   if (arg2 == arg1) return (ATOM_T);
@@ -91,10 +91,10 @@ LispPTR N_OP_clequal(int arg1, int arg2) {
 
   /* can return NIL if one is a number and the other isn't */
 
-  if (IsNumber(arg1)) {
-    if (!IsNumber(arg2)) return (NIL);
+  if (Numberp(arg1)) {
+    if (!Numberp(arg2)) return (NIL);
   } else {
-    if (IsNumber(arg2)) {
+    if (Numberp(arg2)) {
       return (NIL);
     } else
       ERROR_EXIT(arg2);
@@ -128,7 +128,7 @@ LispPTR N_OP_clequal(int arg1, int arg2) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_eqlop(int arg1, int arg2) {
+LispPTR N_OP_eqlop(LispPTR arg1, LispPTR arg2) {
   int type;
 
   if (arg2 == arg1) return (ATOM_T);
@@ -153,7 +153,7 @@ LispPTR N_OP_eqlop(int arg1, int arg2) {
       return (NIL);
 
     default:
-      if (IsNumber(arg1)) {
+      if (Numberp(arg1)) {
         ERROR_EXIT(arg2);
       } else
         return (NIL);
@@ -169,7 +169,7 @@ LispPTR N_OP_eqlop(int arg1, int arg2) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_equal(int arg1, int arg2) {
+LispPTR N_OP_equal(LispPTR arg1, LispPTR arg2) {
   int type, type2;
 
   if (arg2 == arg1) return (ATOM_T);
@@ -183,10 +183,10 @@ arg1_small:
 
 arg2_small:
 
-  if (IsNumber(arg1)) {
-    if (!IsNumber(arg2)) return (NIL);
+  if (Numberp(arg1)) {
+    if (!Numberp(arg2)) return (NIL);
   } else {
-    if (IsNumber(arg2)) {
+    if (Numberp(arg2)) {
       return (NIL);
     } else
       ERROR_EXIT(arg2);
@@ -232,7 +232,7 @@ arg2_small:
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_eqq(int arg1, int arg2) /* CL:=    opcode 0377 */
+LispPTR N_OP_eqq(LispPTR arg1, LispPTR arg2) /* CL:=    opcode 0377 */
 
 {
   int type1, type2;

--- a/src/ether.c
+++ b/src/ether.c
@@ -708,7 +708,7 @@ LispPTR get_packet() {
 
 static int ether_addr_equal(u_char add1[], u_char add2[])
 {
-  register int i;
+  int i;
   for (i = 0; i < 6; i++)
     if (add1[i] != add2[i]) return (0);
   return (1);
@@ -1101,11 +1101,11 @@ void init_ether() {
 /*									*/
 /************************************************************************/
 
-LispPTR check_sum(register LispPTR *args)
+LispPTR check_sum(LispPTR *args)
 {
-  register LispPTR checksum;
-  register DLword *address;
-  register int nwords;
+  LispPTR checksum;
+  DLword *address;
+  int nwords;
 
   address = (DLword *)Addr68k_from_LADDR(*args++);
   nwords = *args++;

--- a/src/findkey.c
+++ b/src/findkey.c
@@ -34,7 +34,7 @@
 */
 /**********************************************************************/
 
-LispPTR N_OP_findkey(register LispPTR tos, register int byte) {
+LispPTR N_OP_findkey(LispPTR tos, int byte) {
   LispPTR *ptr;
   DLword *find_end;
   DLword arg_nth;

--- a/src/fvar.c
+++ b/src/fvar.c
@@ -60,17 +60,17 @@ nnewframe
 
 ******************************************************************************/
 
-void nnewframe(register struct frameex1 *newpfra2, register DLword *achain, register int name)
+void nnewframe(struct frameex1 *newpfra2, DLword *achain, int name)
 /* pointer to new frame extension */
 /* pointer to 1st word of the searching
    FVAR slot in CurrentFrameExtension */
 /* Atom index num. of target FVAR slot. */
 {
-  register NAMETABLE *pindex; /* '90/06/06 osamu changed from DLword *
+  NAMETABLE *pindex; /* '90/06/06 osamu changed from DLword *
                                * index to indexs of new name table */
-  register UNSIGNED i;        /* temp for control */
-  register int nametablesize; /* NameTable size of current function header. */
-  register int ph;            /* alink temp, also phase */
+  UNSIGNED i;        /* temp for control */
+  int nametablesize; /* NameTable size of current function header. */
+  int ph;            /* alink temp, also phase */
 
 newframe:
   /* assume that apframe1 points to the next frame to be scanned */
@@ -81,7 +81,7 @@ newframe:
 #ifdef BIGATOMS
     if ((name & SEGMASK) != 0) /* New symbol */
     {
-      register int result = name + NEWATOM_VALUE_OFFSET;
+      int result = name + NEWATOM_VALUE_OFFSET;
       /*    printf("NEW-SYMBOL in nnewframe, 0x%x, result = 0x%x\n", name, result); */
       GETBASEWORD(achain, 1) = result >> 16;
       GETBASEWORD(achain, 0) = result & 0xFFFF;
@@ -90,11 +90,11 @@ newframe:
 
 #ifdef BIGVM
         if (name & SEGMASK) { /* It's a big-atom, so just offset from the base to get value */
-      register int result = name + NEWATOM_VALUE_OFFSET;
+      int result = name + NEWATOM_VALUE_OFFSET;
       GETBASEWORD(achain, 1) = result >> 16;
       GETBASEWORD(achain, 0) = result & 0xFFFF;
     } else { /* It's an "old" atom, so offset into the table of atoms */
-      register int result = (ATOMS_HI << 16) + (10 * name) + NEWATOM_VALUE_OFFSET;
+      int result = (ATOMS_HI << 16) + (10 * name) + NEWATOM_VALUE_OFFSET;
       GETBASEWORD(achain, 1) = result >> 16;
       GETBASEWORD(achain, 0) = result & 0xFFFF;
     }
@@ -113,8 +113,8 @@ newframe:
   ph &= 0xFFFE; /* to mask off SLOW bit */
   newpfra2 = (struct frameex1 *)(-FRAMESIZE + Stackspace + ph);
 
-  {                                  /* open new block to try and conserve address register */
-    register struct fnhead *newpfn2; /* ptr to new fn header */
+  {                                  /* open new block to try and conserve address */
+    struct fnhead *newpfn2; /* ptr to new fn header */
 
     if (newpfra2->validnametable) /* check VALIDNAMETABLE */
 #ifdef BIGVM
@@ -197,9 +197,9 @@ newframe:
 #endif
     continue;
   foundit : {
-    register int fvartype;   /* probing fvar vartype */
-    register int fvaroffset; /* probing fvar varoffset */
-    register DLword *ppvar;  /* ptr to probing var candidate */
+    int fvartype;   /* probing fvar vartype */
+    int fvaroffset; /* probing fvar varoffset */
+    DLword *ppvar;  /* ptr to probing var candidate */
 #ifdef BIGATOMS
     fvartype = (int)*(pindex + nametablesize - 1);
 #else
@@ -258,15 +258,15 @@ endlookfor:
         2. call fvlookfor.
 
 ****************************************************************************/
-void nfvlookup(struct frameex1 *apframe1, register DLword *achain,
-               register struct fnhead *apfnhead1)
+void nfvlookup(struct frameex1 *apframe1, DLword *achain,
+               struct fnhead *apfnhead1)
 /* pointer to current frame extension */
 /* pointer to 1st word of the searching
    FVAR slot in CurrentFrameExtension */
 /* pointer to current function header */
 {
-  register DLword *pfh;  /* pointer to current function header */
-  register int paoffset; /* 2word offset in PVAR AREA */
+  DLword *pfh;  /* pointer to current function header */
+  int paoffset; /* 2word offset in PVAR AREA */
 
   pfh = (DLword *)apfnhead1;
   paoffset = ((UNSIGNED)achain - (UNSIGNED)PVar) >> 2;
@@ -290,11 +290,11 @@ void nfvlookup(struct frameex1 *apframe1, register DLword *achain,
         4. get some address by calculation of content of FVAR slot.
         5. set the address to TopOfStack.
 **************************************************************************/
-LispPTR N_OP_fvarn(register int n)
+LispPTR N_OP_fvarn(int n)
 /* n is word offset */
 
 {
-  register DLword *chain; /* keep FVAR slot2 in CurrentFrameExtension */
+  DLword *chain; /* keep FVAR slot2 in CurrentFrameExtension */
 
   chain = PVar + n;
 
@@ -340,9 +340,9 @@ N_OP_fvar_
 
 ***************************************************/
 
-LispPTR N_OP_fvar_(register LispPTR tos, register int n) {
-  register DLword *ppvar;    /* pointer to argued Fvar slot in pvar area */
-  register DLword *pfreeval; /* pointer to argued free value */
+LispPTR N_OP_fvar_(LispPTR tos, int n) {
+  DLword *ppvar;    /* pointer to argued Fvar slot in pvar area */
+  DLword *pfreeval; /* pointer to argued free value */
 
   ppvar = PVar + n;
 
@@ -396,15 +396,15 @@ native_newframe
 LispPTR native_newframe(int slot)
 /* index of FVAR slot. */
 {
-  register struct frameex2 *newpfra2; /* pointer to new frame extension */
-  register DLword *achain;            /* pointer to 1st word of the searching
+  struct frameex2 *newpfra2; /* pointer to new frame extension */
+  DLword *achain;            /* pointer to 1st word of the searching
                                        FVAR slot in CurrentFrameExtension */
-  register int name;                  /* Atom# of target FVAR slot. */
+  int name;                  /* Atom# of target FVAR slot. */
 
   { /* LOCAL temp regs */
-    register int rslot = slot;
-    register struct fnhead *fnobj = FuncObj;
-    register LispPTR *pvar = (LispPTR *)PVar;
+    int rslot = slot;
+    struct fnhead *fnobj = FuncObj;
+    LispPTR *pvar = (LispPTR *)PVar;
 
 #ifdef BIGATOMS
     name = (int)*((LispPTR *)((DLword *)fnobj + fnobj->fvaroffset) + rslot - fnobj->nlocals);
@@ -417,10 +417,10 @@ LispPTR native_newframe(int slot)
   }
 
   {
-    register NAMETABLE *pindex; /* index to indexs of new name table */
-    register int i;             /* temp for control */
-    register int nametablesize; /* NameTable size of current fnhdr */
-    register int alink;
+    NAMETABLE *pindex; /* index to indexs of new name table */
+    int i;             /* temp for control */
+    int nametablesize; /* NameTable size of current fnhdr */
+    int alink;
 
   natnewframe:
     /* assume that apframe1 points to the next frame to be scanned */
@@ -435,8 +435,8 @@ LispPTR native_newframe(int slot)
     }
     newpfra2 = (struct frameex2 *)(-FRAMESIZE + Stackspace + (alink & 0xFFFE));
 
-    {                                  /* open new block to try and conserve address register */
-      register struct fnhead *newpfn2; /* ptr to new fn header */
+    {                                  /* open new block to try and conserve address */
+      struct fnhead *newpfn2; /* ptr to new fn header */
 
       newpfn2 = GETNAMETABLE(newpfra2);
 
@@ -459,9 +459,9 @@ LispPTR native_newframe(int slot)
 #endif /* BIGATOMS    */
 
 
-        register int fvartype;   /* probing fvar vartype */
-        register int fvaroffset; /* probing fvar varoffset */
-        register DLword *ppvar;  /* ptr to probing var candidate */
+        int fvartype;   /* probing fvar vartype */
+        int fvaroffset; /* probing fvar varoffset */
+        DLword *ppvar;  /* ptr to probing var candidate */
 #ifdef BIGATOMS
         fvartype = (int)*(pindex + nametablesize - 1);
 #else

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -97,10 +97,10 @@ struct hashtable {
 /************************************************************************/
 
 LispPTR aref1(LispPTR array, int index) {
-  register LispPTR retval = 0;
-  register LispPTR base;
-  register short typenumber;
-  register struct arrayheader *actarray;
+  LispPTR retval = 0;
+  LispPTR base;
+  short typenumber;
+  struct arrayheader *actarray;
 
   actarray = (struct arrayheader *)Addr68k_from_LADDR(array);
   if (index >= actarray->totalsize) {

--- a/src/gccode.c
+++ b/src/gccode.c
@@ -122,8 +122,8 @@ typedef ByteCode *InstPtr;
 
 LispPTR map_code_pointers(LispPTR codeblock, short int casep) {
   InstPtr codeptr;
-  register unsigned int opnum;
-  register unsigned int len;
+  unsigned int opnum;
+  unsigned int len;
   struct fnhead *fnbase;
   fnbase = (struct fnhead *)Addr68k_from_LADDR(codeblock);
   codeptr = ((InstPtr)fnbase) + fnbase->startpc;
@@ -252,8 +252,8 @@ LispPTR reclaimcodeblock(LispPTR codebase) {
 
 int code_block_size(long unsigned int codeblock68k) {
   InstPtr codeptr, initcodeptr;
-  register unsigned int opnum;
-  register unsigned int len;
+  unsigned int opnum;
+  unsigned int len;
   struct fnhead *fnbase;
   fnbase = (struct fnhead *)codeblock68k;
   initcodeptr = codeptr = ((InstPtr)fnbase) + fnbase->startpc;

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -162,8 +162,8 @@ LispPTR findptrsbuffer(LispPTR ptr) {
 /************************************************************************/
 
 LispPTR releasingvmempage(LispPTR ptr) {
-  register struct buf *bptr;
-  register LispPTR bufferptr = findptrsbuffer(ptr);
+  struct buf *bptr;
+  LispPTR bufferptr = findptrsbuffer(ptr);
 
   if (bufferptr == NIL) return (NIL); /* Not in use, OK to reclaim it */
 
@@ -494,8 +494,8 @@ LispPTR reclaimarrayblock(LispPTR ptr) {
 LispPTR reclaimstackp(LispPTR ptr) /* This is the entry function */
                                    /*  in stack reclaiming */
 {
-  register STACKP *stkp;
-  register FX *fxp;
+  STACKP *stkp;
+  FX *fxp;
   stkp = (STACKP *)Addr68k_from_LADDR(ptr);
   fxp = (FX *)Addr68k_from_StkOffset(stkp->edfxp);
   decusecount68k(fxp); /* decrement the use-count for the frame it uses */

--- a/src/gchtfind.c
+++ b/src/gchtfind.c
@@ -33,7 +33,7 @@
 /* GetLink gets a new entry from the GC collision table */
 #define GetLink(var)                                               \
   {                                                                \
-    register GCENTRY linkoff;                                      \
+    GCENTRY linkoff;                                      \
     linkoff = GETGC(HTcoll);                                       \
     if (linkoff == 0) {                                            \
       if ((linkoff = GETGC((GCENTRY *)HTcoll + 1)) >= HTCOLLMAX) { \
@@ -213,7 +213,7 @@
 
 void enter_big_reference_count(LispPTR ptr) {
   struct gc_ovfl *oventry;
-  register LispPTR tmp;
+  LispPTR tmp;
 
   /* this kludge is apparently necessary. Odd pointers are
   illegal, but apparently some are reference counted. If you
@@ -308,8 +308,8 @@ void modify_big_reference_count(LispPTR *entry, DLword casep, LispPTR ptr) {
 /************************************************************************/
 
 LispPTR htfind(LispPTR ptr, int casep) {
-  register GCENTRY *entry, *link, *prev;
-  register GCENTRY entry_contents, hiptr;
+  GCENTRY *entry, *link, *prev;
+  GCENTRY entry_contents, hiptr;
 
   /* if the NOREF bit is on in the type table entry, do
   not reference count this pointer. Used for non-reference
@@ -429,8 +429,8 @@ nolink: /* no match */
 /************************************************************************/
 
 LispPTR rec_htfind(LispPTR ptr, int casep) {
-  register GCENTRY *entry, *link, *prev;
-  register GCENTRY entry_contents, hiptr;
+  GCENTRY *entry, *link, *prev;
+  GCENTRY entry_contents, hiptr;
 
   /* if the NOREF bit is on in the type table entry, do
   not reference count this pointer. Used for non-reference

--- a/src/gcmain3.c
+++ b/src/gcmain3.c
@@ -94,10 +94,10 @@
 
 
 LispPTR gcmapscan(void) {
-  register GCENTRY probe;
-  register GCENTRY *entry;
+  GCENTRY probe;
+  GCENTRY *entry;
   GCENTRY offset, dbgcontents;
-  register LispPTR ptr;
+  LispPTR ptr;
 
   probe = HTMAIN_ENTRY_COUNT;
 nextentry:
@@ -105,8 +105,8 @@ nextentry:
     entry = (GCENTRY *)HTmain + probe;
   retry:
     if (HENTRY->collision) {
-      register GCENTRY *prev;
-      register GCENTRY *link;
+      GCENTRY *prev;
+      GCENTRY *link;
       LispPTR content;
 
       prev = (GCENTRY *)0;
@@ -140,8 +140,8 @@ nextentry:
 }
 
 LispPTR gcmapunscan(void) {
-  register GCENTRY probe;
-  register GCENTRY *entry;
+  GCENTRY probe;
+  GCENTRY *entry;
   GCENTRY offset;
 
   probe = HTMAIN_ENTRY_COUNT;
@@ -149,8 +149,8 @@ LispPTR gcmapunscan(void) {
     entry = (GCENTRY *)HTmain + probe;
   retry:
     if (HENTRY->collision) {
-      register GCENTRY *prev;
-      register GCENTRY *link;
+      GCENTRY *prev;
+      GCENTRY *link;
 
       prev = (GCENTRY *)0;
       link = (GCENTRY *)(HTcoll + GetLinkptr(HTLPTR->contents));
@@ -181,7 +181,7 @@ LispPTR gcmapunscan(void) {
 }
 
 LispPTR gcscanstack(void) {
-  register Bframe *basicframe;
+  Bframe *basicframe;
   Bframe *obasicframe;
   LispPTR scanptr, scanend;
   UNSIGNED scanend68K;
@@ -207,11 +207,11 @@ LispPTR gcscanstack(void) {
     switch (ftyp) {
       case STK_FX: {
         {
-          register struct frameex1 *frameex;
-          register struct fnhead *fnheader;
+          struct frameex1 *frameex;
+          struct fnhead *fnheader;
           frameex = (struct frameex1 *)basicframe;
           {
-            register LispPTR fn_head;
+            LispPTR fn_head;
 #ifdef BIGVM
             fn_head = (LispPTR)(frameex->fnheader);
 #else
@@ -221,34 +221,34 @@ LispPTR gcscanstack(void) {
             fnheader = (struct fnhead *)Addr68k_from_LADDR(fn_head);
           };
           {
-            register int pcou;
-            register LispPTR *pvars;
+            int pcou;
+            LispPTR *pvars;
             pvars = (LispPTR *)((DLword *)basicframe + FRAMESIZE);
             for (pcou = fnheader->nlocals; pcou-- != 0;) {
-              register LispPTR value;
+              LispPTR value;
               value = *pvars;
               if
                 Boundp(BIND_BITS(value)) Stkref(value);
               ++pvars;
             }; /* for */
-          };   /* register int pcou */
+          };   /* int pcou */
 
           {
-            register UNSIGNED qtemp;
-            register UNSIGNED next;
-            register UNSIGNED ntend;
+            UNSIGNED qtemp;
+            UNSIGNED next;
+            UNSIGNED ntend;
 
             next = qtemp = (UNSIGNED)Addr68k_from_StkOffset(frameex->nextblock);
             /* this is offset */
             ntend = 0; /* init flag */
             if (frameex->validnametable) {
-              register LispPTR nametable;
+              LispPTR nametable;
 #ifdef BIGVM
               nametable = frameex->nametable;
 #define hi2nametable (nametable >> 16)
 #else
-              register unsigned int hi2nametable;
-              register unsigned int lonametable;
+              unsigned int hi2nametable;
+              unsigned int lonametable;
               lonametable = frameex->lonametable;
               hi2nametable = frameex->hi2nametable;
               nametable = VAG2(hi2nametable, lonametable);
@@ -281,7 +281,7 @@ LispPTR gcscanstack(void) {
 
           scantemps:
             while ((UNSIGNED)basicframe < (UNSIGNED)qtemp) {
-              register LispPTR value;
+              LispPTR value;
               value = *((LispPTR *)basicframe);
               if
                 Boundp(BIND_BITS(value)) Stkref(value);
@@ -356,7 +356,7 @@ LispPTR gcscanstack(void) {
       };
       default: /* must be basic frame !! */
       {
-        register LispPTR bf_word;
+        LispPTR bf_word;
         while (STK_BF != BF_FLAGS(bf_word = *((LispPTR *)basicframe))) {
           Stkref(PTR_BITS(bf_word));
           basicframe++;
@@ -365,7 +365,7 @@ LispPTR gcscanstack(void) {
       };
 
         /* **** NOTE THIS CODE DOES NOT COMPILE CORRECTLY ON THE SUN 4
-           {register LispPTR bf_word;
+           {LispPTR bf_word;
            while(STK_BF != BF_FLAGS(
            bf_word = *((LispPTR *)basicframe++)))
            { Stkref(PTR_BITS(bf_word));

--- a/src/gcrcell.c
+++ b/src/gcrcell.c
@@ -111,10 +111,10 @@ unsigned todo_reads = 0;
 /************************************************************************/
 
 LispPTR gcreccell(LispPTR cell) {
-  register ConsCell *ptr;
+  ConsCell *ptr;
   struct dtd *typdtd;
   DLword typ;
-  register LispPTR tmpptr, donext, tmpcell, val;
+  LispPTR tmpptr, donext, tmpcell, val;
   LispPTR ptrfield, carfield;
   int index, code;
   LispPTR *field;
@@ -314,7 +314,7 @@ trynext:
 
 void freelistcell(LispPTR cell) {
   struct conspage *pbase;
-  register ConsCell *cell68k;
+  ConsCell *cell68k;
   unsigned int offset, prior, celloffset;
 
   cell68k = (ConsCell *)Addr68k_from_LADDR(cell);

--- a/src/gcscan.c
+++ b/src/gcscan.c
@@ -63,11 +63,11 @@
 #define GetStkCnt(entry1) (entry1 >> 9)
 #endif /* BIGVM */
 
-DLword gcscan1(register int probe)
+DLword gcscan1(int probe)
 /* probe is offset */
 {
-  register struct htlinkptr *htlptr; /* overlay access method */
-  register int contents;
+  struct htlinkptr *htlptr; /* overlay access method */
+  int contents;
   while (--probe >= 0) /* End of HTmain Table ? */
   {
     /* Start addr. of scanning */
@@ -79,10 +79,10 @@ DLword gcscan1(register int probe)
   return (NIL);
 }
 
-DLword gcscan2(register int probe)
+DLword gcscan2(int probe)
 /* probe is offset */
 {
-  register struct htlinkptr *htlptr; /* overlay access method */
+  struct htlinkptr *htlptr; /* overlay access method */
   while (--probe >= 0)               /* End of HTmain Table ? */
   {
     htlptr = (struct htlinkptr *)(HTmain + probe);

--- a/src/gvar2.c
+++ b/src/gvar2.c
@@ -36,8 +36,8 @@
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_gvar_(register LispPTR tos, unsigned int atom_index) {
-  register LispPTR *pslot; /* pointer to argued GVAR slot */
+LispPTR N_OP_gvar_(LispPTR tos, unsigned int atom_index) {
+  LispPTR *pslot; /* pointer to argued GVAR slot */
 
 #ifdef BIGATOMS
   if (0 != (atom_index & SEGMASK))
@@ -69,8 +69,8 @@ LispPTR N_OP_gvar_(register LispPTR tos, unsigned int atom_index) {
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_rplptr(register LispPTR tos_m_1, register LispPTR tos, unsigned int alpha) {
-  register DLword *pslot; /* pointer to argued slot (68 address) */
+LispPTR N_OP_rplptr(LispPTR tos_m_1, LispPTR tos, unsigned int alpha) {
+  DLword *pslot; /* pointer to argued slot (68 address) */
 
   pslot = Addr68k_from_LADDR(tos_m_1 + alpha);
   FRPLPTR(((struct xpointer *)pslot)->addr, tos);

--- a/src/hardrtn.c
+++ b/src/hardrtn.c
@@ -42,11 +42,11 @@
     AFTER_CONTEXTSW;                                                                         \
     CHECK_FX(fx68k);                                                                         \
   }
-static FX *make_FXcopy(register FX *fx68k) {
-  register int size;
+static FX *make_FXcopy(FX *fx68k) {
+  int size;
   int nametbl_on_stk = NIL;
-  register DLword *new68k;
-  register Bframe *retbf68k;
+  DLword *new68k;
+  Bframe *retbf68k;
 
 #ifdef FLIPCURSOR
   flip_cursorbar(5);
@@ -141,10 +141,10 @@ static FX *make_FXcopy(register FX *fx68k) {
 /********************************************************************/
 
 int slowreturn(void) {
-  register DLword *next68k;
-  register DLword *freeptr;
-  register Bframe *currentBF;
-  register FX *returnFX;
+  DLword *next68k;
+  DLword *freeptr;
+  Bframe *currentBF;
+  FX *returnFX;
 
   S_CHECK(SLOWP(CURRENTFX), "CURRENTFX not SLOWP");
 

--- a/src/initdsp.c
+++ b/src/initdsp.c
@@ -134,8 +134,8 @@ void clear_display() {
 #else /* COLOR */
 
 void clear_display() {
-  register short *word;
-  register int w, h;
+  short *word;
+  int w, h;
   if (MonoOrColor == MONO_SCREEN) {
 #ifndef DISPLAYBUFFER
     word = DisplayRegion68k;
@@ -238,7 +238,7 @@ void display_before_exit() {
 /*  Change as MACRO by osamu '90/02/08
  *  new macro definition is in display.h
 in_display_segment(baseaddr)
-  register DLword *baseaddr;
+  DLword *baseaddr;
   {
     if ((DisplayRegion68k <= baseaddr) &&
         (baseaddr <=DISP_MAX_Address))   return(T);
@@ -298,7 +298,7 @@ void flush_display_region(int x, int y, int w, int h)
 #ifdef BYTESWAP
 void byte_swapped_displayregion(int x, int y, int w, int h)
 {
-  register unsigned int *longptr;
+  unsigned int *longptr;
 
   /* Get QUAD byte aligned pointer */
   longptr = (unsigned int *)(((UNSIGNED)((DLword *)DisplayRegion68k + (DLWORD_PERLINE * y)) +

--- a/src/intcall.c
+++ b/src/intcall.c
@@ -21,12 +21,12 @@
 #include "stack.h"        // for state, CurrentStackPTR, DLword, FX, FuncObj
 #include "tosfns.h"       // for SWAPPED_FN_CHECK
 
-void cause_interruptcall(register unsigned int atom_index)
+void cause_interruptcall(unsigned int atom_index)
 /* Atomindex for Function you want to invoke */
 {
-  register struct definition_cell *defcell68k; /* Definition Cell PTR */
-  register short pv_num;                       /* scratch for pv */
-  register struct fnhead *tmp_fn;
+  struct definition_cell *defcell68k; /* Definition Cell PTR */
+  short pv_num;                       /* scratch for pv */
+  struct fnhead *tmp_fn;
   int rest; /* use for alignments */
 
   CURRENTFX->nopush = T;

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -366,7 +366,7 @@ void cursor_hidden_bitmap(int, int);
 #ifndef COLOR
 /* FOR MONO ONLY */
 void taking_mouse_down() {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
 
@@ -397,7 +397,7 @@ void taking_mouse_down() {
 extern DLword *ColorDisplayRegion68k;
 /* It assumes that MONO screen size and COLOR screen size are identical */
 void taking_mouse_down() {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
 
@@ -437,7 +437,7 @@ void taking_mouse_down() {
 /* FOR MONO ONLY */
 void copy_cursor(int newx, int newy)
 {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
   extern DLword *EmCursorBitMap68K;
@@ -461,7 +461,7 @@ void copy_cursor(int newx, int newy)
 /* store bitmap image inside rect. which specified by x,y */
 void cursor_hidden_bitmap(int x, int y)
 {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
   /* save image */
@@ -482,8 +482,8 @@ void cursor_hidden_bitmap(int x, int y)
 #define IMIN(x, y) (((x) > (y)) ? (y) : (x))
 void copy_cursor(int newx, int newy)
 {
-  register DLword *srcbase, *dstbase;
-  register int offsetx, offsety;
+  DLword *srcbase, *dstbase;
+  int offsetx, offsety;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
   CURSOR *cursor68k;
@@ -541,7 +541,7 @@ void taking_mouse_up(int newx, int newy)
 /* store bitmap image inside rect. which specified by x,y */
 void cursor_hidden_bitmap(int x, int y)
 {
-  register DLword *srcbase, *dstbase;
+  DLword *srcbase, *dstbase;
   static int sx, dx, w, h, srcbpl, dstbpl, backwardflg = 0;
   static int src_comp = 0, op = 0, gray = 0, num_gray = 0, curr_gray_line = 0;
   /* save image */

--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -26,6 +26,12 @@
 
 #ifdef USESUNSCREEN
 #include <sys/fbio.h>
+
+#define LDEMONO "ldesingle"
+#define LDECOLOR "ldemulti"
+#define LDETRUECOLOR "ldetruecolor"
+
+#define FBTYPE_SUNFAST_COLOR 12
 #endif /* USESUNSCREEN */
 
 #include "unixfork.h"
@@ -36,13 +42,7 @@
 #define LDEX "ldex"
 #endif /* XWINDOW */
 
-#define LDEMONO "ldesingle"
-#define LDECOLOR "ldemulti"
-#define LDETRUECOLOR "ldetruecolor"
 
-#define FBTYPE_SUNFAST_COLOR 12
-
-char filetorun[30];
 
 /************************************************************************/
 /*									*/
@@ -55,6 +55,7 @@ char filetorun[30];
 int main(int argc, char *argv[])
 {
   int i;
+  char filetorun[30];
 #ifdef USESUNSCREEN
   int FrameBufferFd;
   struct fbtype my_screen;

--- a/src/lineblt8.c
+++ b/src/lineblt8.c
@@ -33,8 +33,8 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
 **************************************************************/
 #define WriteLongW(srcpattern, destptr, op1, op2)                                      \
   {                                                                                    \
-    register int cnt;                                                                  \
-    register u_char *des, *src;                                                        \
+    int cnt;                                                                  \
+    u_char *des, *src;                                                        \
     for (cnt = 0, des = (u_char *)(destptr), src = (u_char *)(&(srcpattern)); cnt < 4; \
          cnt++, des++, src++)                                                          \
       (*des) op1(*src);                                                                \
@@ -57,8 +57,8 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
 
 #define LineBLT8(srcWptr, offset, width, dstLptr, op1, op2)                                \
   {                                                                                        \
-    register DLword *srcw;                                                                 \
-    register u_int temp1;                                                                  \
+    DLword *srcw;                                                                 \
+    u_int temp1;                                                                  \
     for (srcw = (srcWptr) + (offset) / BITSPERDLWORD; ((width)-BITSPERNIBBLE) >= 0;        \
          (width) -= BITSPERNIBBLE, (dstLptr) = (u_char *)((u_int *)(dstLptr) + 1),         \
         (offset) += BITSPERNIBBLE) {                                                       \
@@ -98,8 +98,8 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
     }   /* for end */                                                                      \
     /* process for the rest bits (0~3)*/                                                   \
     switch (width) {                                                                       \
-      register u_char *destc;                                                              \
-      register int mod;                                                                    \
+      u_char *destc;                                                              \
+      int mod;                                                                    \
       case 0: /* already finished */ break;                                                \
       case 1:                                                                              \
       case 2:                                                                              \
@@ -130,10 +130,10 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
 
 /* I don't care sourcetype & operation NOW */
 
-void lineBlt8(DLword *srcbase, register int offset, register u_char *destl, register int width,
+void lineBlt8(DLword *srcbase, int offset, u_char *destl, int width,
               u_char color0, u_char color1, LispPTR sourcetype, LispPTR operation)
 
-/* register u_int *destl;*/
+/* u_int *destl;*/
 /* for SPARC */
 
 /* Background color */
@@ -153,15 +153,15 @@ void lineBlt8(DLword *srcbase, register int offset, register u_char *destl, regi
   extern DLword ERASE_atom;
 
   if (sourcetype == INVERT_atom) {
-    register int tempcol;
+    int tempcol;
     tempcol = color0;
     color0 = color1;
     color1 = tempcol;
   }
   if ((beforecolor0 != color0) || (beforecolor1 != color1)) {
     /* making color-mapped array */
-    register int i;
-    register u_int longcol0, longcol1;
+    int i;
+    u_int longcol0, longcol1;
 
     beforecolor0 = color0;
     beforecolor1 = color1;

--- a/src/lisp2c.c
+++ b/src/lisp2c.c
@@ -85,7 +85,7 @@ int LispIntToCInt(LispPTR lispint) {
 
 LispPTR CIntToLispInt(int cint) {
   if (abs(cint) > 0xFFFF) { /* its a fixp! */
-    register LispPTR *wordp;
+    LispPTR *wordp;
     wordp = (LispPTR *)createcell68k(TYPE_FIXP);
     *((int *)wordp) = cint;
     return (LADDR_from_68k(wordp));

--- a/src/lisp2c.c
+++ b/src/lisp2c.c
@@ -17,7 +17,7 @@
 #include "adr68k.h"      // for Addr68k_from_LADDR, LADDR_from_68k
 #include "commondefs.h"  // for error
 #include "emlglob.h"
-#include "lisp2cdefs.h"  // for CIntToLispInt, LispIntToCInt, LispStringLength
+#include "lisp2cdefs.h"  // for CIntToLispInt, LispIntToCInt, LispStringSimpleLength
 #include "lispemul.h"    // for LispPTR
 #include "lispmap.h"     // for S_NEGATIVE, S_POSITIVE
 #include "lspglob.h"
@@ -31,7 +31,7 @@ int LispStringP(LispPTR object) {
   return ((type == THIN_CHAR_TYPENUMBER) || (type == FAT_CHAR_TYPENUMBER));
 }
 
-int LispStringLength(LispPTR lispstring) {
+int LispStringSimpleLength(LispPTR lispstring) {
   OneDArray *arrayp;
 
   arrayp = (OneDArray *)(Addr68k_from_LADDR(lispstring));

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -50,8 +50,8 @@ extern int extended_frame;
 */
 /******************************************************************/
 static DLword *extendstack(void) {
-  register LispPTR easp;
-  register LispPTR scanptr;
+  LispPTR easp;
+  LispPTR scanptr;
 
   easp = InterfacePage->endofstack;
 
@@ -80,10 +80,10 @@ static DLword *extendstack(void) {
         Edited by :     Take(March 14, 1988)
 */
 /******************************************************************/
-static LispPTR moveframe(register FX *oldfx68k) {
-  register int size;
-  register DLword *next68k;
-  register DLword *new68k;
+static LispPTR moveframe(FX *oldfx68k) {
+  int size;
+  DLword *next68k;
+  DLword *new68k;
   int nametbl_on_stk = NIL;
   int at_eos = NIL;
 
@@ -287,11 +287,11 @@ DLword *freestackblock(DLword n, StackWord *start68k, int align)
 /* searching will start68k at here */
 /* if Negative,it needn't align */
 {
-  register int wantedsize;
-  register StackWord *scanptr68k;
-  register STKBLK *freeptr68k;
-  register StackWord *easp68k;
-  register DLword freesize;
+  int wantedsize;
+  StackWord *scanptr68k;
+  STKBLK *freeptr68k;
+  StackWord *easp68k;
+  DLword freesize;
 
   DLword *extendstack(void);
 
@@ -420,12 +420,12 @@ FREE:
 /******************************************************************/
 #define BF_size(ptr68k) ((StkOffset_from_68K(ptr68k)) - ((Bframe *)(ptr68k))->ivar + 2)
 
-void decusecount68k(register FX *frame68k) {
+void decusecount68k(FX *frame68k) {
   DLword *alink68k;
-  register Bframe *blink68k;
+  Bframe *blink68k;
   DLword *clink68k;
-  /*** register DLword *ivar68k; */
-  register int size;
+  /*** DLword *ivar68k; */
+  int size;
 
   if (FX_INVALIDP(frame68k)) return;
   CHECK_FX(frame68k);
@@ -488,7 +488,7 @@ extern short *DisplayRegion68k;
 extern int DisplayRasterWidth;
 
 void flip_cursorbar(int n) {
-  register short *word;
+  short *word;
   word = DisplayRegion68k + (n * DisplayRasterWidth);
   GETWORD(word) ^= 0xFFFF;
 }
@@ -499,9 +499,9 @@ void flip_cursorbar(int n) {
                 blt(dest,source,size)
 */
 /**************************************************************/
-void blt(register DLword *dest68k, register DLword *source68k, int nw) {
+void blt(DLword *dest68k, DLword *source68k, int nw) {
   /******* OLD def ,
-   Due to C compiler's bug, we can't use pre-decrement for register val
+   Due to C compiler's bug, we can't use pre-decrement for val
     source68k += nw;
     dest68k += nw;
     while(nw)

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -71,7 +71,7 @@ static const char il_string[] = "INTERLISP";
 
 #define INSTANCE_CLASS_OR_PUNT(obj, fn, argnum)                         \
   {                                                                     \
-    register LispPTR tmp = DTD_FROM_LADDR(obj);                         \
+    LispPTR tmp = DTD_FROM_LADDR(obj);                         \
     if (tmp != atom_instance && tmp != atom_class) RETCALL(fn, argnum); \
   }
 
@@ -80,8 +80,8 @@ static const char il_string[] = "INTERLISP";
 
 #define GET_IV_INDEX(objptr, iv, dest, otherwise)                 \
   {                                                               \
-    register struct LCIVCacheEntry *ce;                           \
-    register LispPTR iNames = (objptr)->iNames;                   \
+    struct LCIVCacheEntry *ce;                           \
+    LispPTR iNames = (objptr)->iNames;                   \
                                                                   \
     ce = &(LCIVCache[IV_CACHE_INDEX(iNames, iv)]);                \
     if (ce->iNames == iNames && ce->iv == (iv)) {                 \
@@ -90,7 +90,7 @@ static const char il_string[] = "INTERLISP";
       if (!Listp(iNames)) {                                       \
         otherwise;                                                \
       } else {                                                    \
-        register int i = 0;                                       \
+        int i = 0;                                       \
         while (1) {                                               \
           if (car(iNames) == (iv)) {                              \
             ce->iNames = (objptr)->iNames;                        \
@@ -151,7 +151,7 @@ LispPTR LCinit(void) {
 #ifdef NEVER
 int LCTypeOf(LispPTR thing, LispPTR typename)
 {
-  register struct dtd *dtd68k;
+  struct dtd *dtd68k;
 #ifdef BIGVM
   for (dtd68k = (struct dtd *)GetDTD(GetTypeNumber(thing)); typename != (dtd68k->dtd_name);
        dtd68k = (struct dtd *)GetDTD(dtd68k->dtd_supertype)) {
@@ -170,10 +170,10 @@ int LCTypeOf(LispPTR thing, LispPTR typename)
 
 /* Method lookup using global cache */
 
-LispPTR LCFetchMethodOrHelp(register LispPTR object, register LispPTR selector) {
-  register struct LCInstance *objptr;
-  register struct LCMethodCacheEntry *ce;
-  register LispPTR cur_class;
+LispPTR LCFetchMethodOrHelp(LispPTR object, LispPTR selector) {
+  struct LCInstance *objptr;
+  struct LCMethodCacheEntry *ce;
+  LispPTR cur_class;
 
   LC_INIT;
 
@@ -188,10 +188,10 @@ LispPTR LCFetchMethodOrHelp(register LispPTR object, register LispPTR selector) 
     LispPTR supers = ((struct LCClass *)Addr68k_from_LADDR(cur_class))->supers;
 
     for (;;) {
-      register int i = 0;
-      register LispPTR val;
-      register LispPTR *selectorptr;
-      register struct LCClass *classptr;
+      int i = 0;
+      LispPTR val;
+      LispPTR *selectorptr;
+      struct LCClass *classptr;
 
       classptr = (struct LCClass *)Addr68k_from_LADDR(cur_class);
       if (classptr->selectors == NIL_PTR) {
@@ -221,8 +221,8 @@ LispPTR LCFetchMethodOrHelp(register LispPTR object, register LispPTR selector) 
   /*  return PUNT;*/
 }
 
-LispPTR LCFetchMethod(register LispPTR class, register LispPTR selector) {
-  register struct LCMethodCacheEntry *ce;
+LispPTR LCFetchMethod(LispPTR class, LispPTR selector) {
+  struct LCMethodCacheEntry *ce;
 
   LC_INIT;
 
@@ -234,14 +234,14 @@ LispPTR LCFetchMethod(register LispPTR class, register LispPTR selector) {
 
   if (!LC_TYPEP(class, atom_class)) RETCALL(atom_FetchMethod_LCUFN, 2);
   {
-    register LispPTR cur_class = class;
+    LispPTR cur_class = class;
     LispPTR supers = ((struct LCClass *)Addr68k_from_LADDR(cur_class))->supers;
 
     for (;;) {
-      register int i = 0;
-      register LispPTR val;
-      register struct LCClass *classptr;
-      register LispPTR *selectorptr;
+      int i = 0;
+      LispPTR val;
+      struct LCClass *classptr;
+      LispPTR *selectorptr;
 
       classptr = (struct LCClass *)Addr68k_from_LADDR(cur_class);
       if (classptr->selectors == NIL_PTR)
@@ -267,10 +267,10 @@ LispPTR LCFetchMethod(register LispPTR class, register LispPTR selector) {
   return NIL_PTR;
 }
 
-LispPTR LCFindVarIndex(register LispPTR iv, register LispPTR object) {
-  register struct LCInstance *objptr;
-  register struct LCIVCacheEntry *ce;
-  register LispPTR iNames;
+LispPTR LCFindVarIndex(LispPTR iv, LispPTR object) {
+  struct LCInstance *objptr;
+  struct LCIVCacheEntry *ce;
+  LispPTR iNames;
 
   LC_INIT;
 
@@ -283,7 +283,7 @@ LispPTR LCFindVarIndex(register LispPTR iv, register LispPTR object) {
   if (!Listp(iNames)) return NIL_PTR; /* FastFindIndex lisp macro (& others?) */
                                       /* needs this check too ! */
   {
-    register int i;
+    int i;
 
     for (i = 0; (iNames = cdr(iNames)) != NIL_PTR; i++) {
       if (car(iNames) == iv) {
@@ -298,10 +298,10 @@ LispPTR LCFindVarIndex(register LispPTR iv, register LispPTR object) {
 
 #if 01
 
-LispPTR LCGetIVValue(register LispPTR object, register LispPTR iv) {
-  register struct LCInstance *objptr;
-  register LispPTR val;
-  register int index;
+LispPTR LCGetIVValue(LispPTR object, LispPTR iv) {
+  struct LCInstance *objptr;
+  LispPTR val;
+  int index;
 
   LC_INIT;
   INSTANCE_OR_PUNT(object, atom_GetIVValue_LCUFN, 2);
@@ -317,10 +317,10 @@ pnut:
   */
 }
 
-LispPTR LCPutIVValue(register LispPTR object, register LispPTR iv, register LispPTR val) {
-  register struct LCInstance *objptr;
-  register LispPTR *valptr;
-  register int index;
+LispPTR LCPutIVValue(LispPTR object, LispPTR iv, LispPTR val) {
+  struct LCInstance *objptr;
+  LispPTR *valptr;
+  int index;
 
   LC_INIT;
   INSTANCE_OR_PUNT(object, atom_PutIVValue_LCUFN, 3);
@@ -341,15 +341,15 @@ pnut:
 
 #endif
 
-LispPTR lcfuncall(register unsigned int atom_index, register int argnum, register int bytenum)
+LispPTR lcfuncall(unsigned int atom_index, int argnum, int bytenum)
 /* Atomindex for Function to invoke */
 /* Number of ARGS on TOS and STK */
 /* Number of bytes of Caller's
    OPCODE(including multi-byte) */
 {
-  register struct definition_cell *defcell68k; /* Definition Cell PTR */
-  register short pv_num;                       /* scratch for pv */
-  register struct fnhead *tmp_fn;
+  struct definition_cell *defcell68k; /* Definition Cell PTR */
+  short pv_num;                       /* scratch for pv */
+  struct fnhead *tmp_fn;
   int rest; /* use for alignments */
 
   if (atom_index == 0xffffffff) error("Loops punt to nonexistent fn");

--- a/src/lowlev1.c
+++ b/src/lowlev1.c
@@ -40,10 +40,10 @@ static const int mask_array[16] = {
                 return:	??
 
 ***********************************************************/
-LispPTR N_OP_putbitsnfd(register LispPTR base, register LispPTR data, int word_offset,
-                        register int beta) {
-  register DLword *pword;
-  register int shift_size, field_size, fmask;
+LispPTR N_OP_putbitsnfd(LispPTR base, LispPTR data, int word_offset,
+                        int beta) {
+  DLword *pword;
+  int shift_size, field_size, fmask;
 
 #ifdef CHECK
   if (base > POINTERMASK) { error("getbits: base out of range"); }
@@ -77,10 +77,10 @@ LispPTR N_OP_putbitsnfd(register LispPTR base, register LispPTR data, int word_o
                                 lo - mask & shifted data
 
 ***********************************************************/
-LispPTR N_OP_getbitsnfd(int base_addr, register int word_offset, int beta) {
-  register DLword *pword;
-  register short first;
-  register short size;
+LispPTR N_OP_getbitsnfd(int base_addr, int word_offset, int beta) {
+  DLword *pword;
+  short first;
+  short size;
 
   pword = Addr68k_from_LADDR(base_addr + word_offset);
   size = 0xF & beta;
@@ -111,7 +111,7 @@ LispPTR N_OP_getbitsnfd(int base_addr, register int word_offset, int beta) {
                 (Called only by Native code)
 ***********************************************************/
 
-LispPTR N_OP_putbasen(register LispPTR base, register LispPTR tos, int n) {
+LispPTR N_OP_putbasen(LispPTR base, LispPTR tos, int n) {
   base = POINTERMASK & base;
   if ((SEGMASK & tos) != S_POSITIVE) {
     ERROR_EXIT(tos);
@@ -137,7 +137,7 @@ LispPTR N_OP_putbasen(register LispPTR base, register LispPTR tos, int n) {
                 (Called only by Native code)
 ***********************************************************/
 
-LispPTR N_OP_putbaseptrn(register LispPTR base, register LispPTR tos, int n) {
+LispPTR N_OP_putbaseptrn(LispPTR base, LispPTR tos, int n) {
   base = POINTERMASK & base;
   *((LispPTR *)Addr68k_from_LADDR(base + n)) = tos & POINTERMASK;
   return (base);

--- a/src/lowlev2.c
+++ b/src/lowlev2.c
@@ -35,7 +35,7 @@
 
 ***********************************************************/
 
-LispPTR N_OP_addbase(register int base, register int offset) {
+LispPTR N_OP_addbase(LispPTR base, LispPTR offset) {
   base = POINTERMASK & base;
   switch ((SEGMASK & offset)) {
     case S_POSITIVE: return (base + (offset & 0x0000FFFF));
@@ -65,7 +65,7 @@ LispPTR N_OP_addbase(register int base, register int offset) {
 
 ***********************************************************/
 
-LispPTR N_OP_getbasebyte(register LispPTR base_addr, register int byteoffset) {
+LispPTR N_OP_getbasebyte(LispPTR base_addr, LispPTR byteoffset) {
   switch ((SEGMASK & byteoffset)) {
     case S_POSITIVE: byteoffset = byteoffset & 0x0000FFFF; break;
     case S_NEGATIVE: byteoffset = byteoffset | 0xFFFF0000; break;
@@ -93,7 +93,7 @@ LispPTR N_OP_getbasebyte(register LispPTR base_addr, register int byteoffset) {
 
 ***********************************************************/
 
-LispPTR N_OP_putbasebyte(register LispPTR base_addr, register int byteoffset, register int tos) {
+LispPTR N_OP_putbasebyte(register LispPTR base_addr, LispPTR byteoffset, LispPTR tos) {
   if (((SEGMASK & tos) != S_POSITIVE) || ((unsigned short)tos >= 256)) ERROR_EXIT(tos);
   switch ((SEGMASK & byteoffset)) {
     case S_POSITIVE: byteoffset &= 0x0000FFFF; break;

--- a/src/lowlev2.c
+++ b/src/lowlev2.c
@@ -93,7 +93,7 @@ LispPTR N_OP_getbasebyte(LispPTR base_addr, LispPTR byteoffset) {
 
 ***********************************************************/
 
-LispPTR N_OP_putbasebyte(register LispPTR base_addr, LispPTR byteoffset, LispPTR tos) {
+LispPTR N_OP_putbasebyte(LispPTR base_addr, LispPTR byteoffset, LispPTR tos) {
   if (((SEGMASK & tos) != S_POSITIVE) || ((unsigned short)tos >= 256)) ERROR_EXIT(tos);
   switch ((SEGMASK & byteoffset)) {
     case S_POSITIVE: byteoffset &= 0x0000FFFF; break;

--- a/src/lplexyy.c
+++ b/src/lplexyy.c
@@ -494,8 +494,8 @@ void yyoutput(int c) { output(c); }
 void yyunput(int c) { unput(c); }
 
 int yylook() {
-  register struct yysvf *yystate, **lsp;
-  register struct yywork *yyt;
+  struct yysvf *yystate, **lsp;
+  struct yywork *yyt;
   struct yysvf *yyz;
   int yych, yyfirst;
   struct yywork *yyr;

--- a/src/lpytab.c
+++ b/src/lpytab.c
@@ -215,7 +215,7 @@ int yychar;    /* current input token number */
 ** yyparse - return 0 if worked, 1 if syntax error not recovered from
 */
 int yyparse() {
-  register YYSTYPE *yypvt; /* top of value stack for $vars */
+  YYSTYPE *yypvt; /* top of value stack for $vars */
 
   /*
   ** Initialize externals - yyparse may be called more than once
@@ -230,10 +230,10 @@ int yyparse() {
 
   goto yystack;
   {
-    register YYSTYPE *yy_pv; /* top of value stack */
-    register int *yy_ps;     /* top of state stack */
-    register int yy_state;   /* current state */
-    register int yy_n;       /* internal state number info */
+    YYSTYPE *yy_pv; /* top of value stack */
+    int *yy_ps;     /* top of state stack */
+    int yy_state;   /* current state */
+    int yy_n;       /* internal state number info */
 
   /*
   ** get globals into registers.
@@ -269,7 +269,7 @@ int yyparse() {
     ** consideration while debugging.
     */
     if (yydebug) {
-      register int yy_i;
+      int yy_i;
 
       printf("State %d, token ", yy_state);
       if (yychar == 0)
@@ -306,7 +306,7 @@ int yyparse() {
     if ((yychar < 0) && ((yychar = yylex()) < 0)) yychar = 0; /* reached EOF */
 #if YYDEBUG
     if (yydebug && yytmp) {
-      register int yy_i;
+      int yy_i;
 
       printf("Received token ");
       if (yychar == 0)
@@ -339,7 +339,7 @@ int yyparse() {
       if ((yychar < 0) && ((yychar = yylex()) < 0)) yychar = 0; /* reached EOF */
 #if YYDEBUG
       if (yydebug && yytmp) {
-        register int yy_i;
+        int yy_i;
 
         printf("Received token ");
         if (yychar == 0)
@@ -358,7 +358,7 @@ int yyparse() {
       ** look through exception table
       */
       {
-        register int *yyxi = yyexca;
+        int *yyxi = yyexca;
 
         while ((*yyxi != -1) || (yyxi[1] != yy_state)) { yyxi += 2; }
         while ((*(yyxi += 2) >= 0) && (*yyxi != yychar))
@@ -431,7 +431,7 @@ int yyparse() {
           ** tests here.
           */
           if (yydebug) {
-            register int yy_i;
+            int yy_i;
 
             printf("Error recovery discards ");
             if (yychar == 0)
@@ -469,7 +469,7 @@ int yyparse() {
     /*
     ** Look in goto table for next state
     ** Sorry about using yy_state here as temporary
-    ** register variable, but why not, if it works...
+    ** variable, but why not, if it works...
     ** If yyr2[ yy_n ] doesn't have the low order bit
     ** set, then there is no action to be done for
     ** this reduction.  So, no saving & unsaving of
@@ -480,7 +480,7 @@ int yyparse() {
     */
     {
       /* length of production doubled with extra bit */
-      register int yy_len = yyr2[yy_n];
+      int yy_len = yyr2[yy_n];
 
       if (!(yy_len & 01)) {
         yy_len >>= 1;

--- a/src/lsthandl.c
+++ b/src/lsthandl.c
@@ -31,7 +31,7 @@
 /*	 N_OP_fmemb							*/
 /**********************************************************************/
 
-LispPTR N_OP_fmemb(register LispPTR item, register LispPTR tos) { /* OP 34Q */
+LispPTR N_OP_fmemb(LispPTR item, LispPTR tos) { /* OP 34Q */
 
   while (Listp(tos)) {
     if (item == car(tos)) return tos;
@@ -54,7 +54,7 @@ LispPTR N_OP_fmemb(register LispPTR item, register LispPTR tos) { /* OP 34Q */
 */
 /**********************************************************************/
 
-LispPTR fmemb(register LispPTR item, register LispPTR list) {
+LispPTR fmemb(LispPTR item, LispPTR list) {
   while (Listp(list)) {
     if (item == car(list)) return (list);
     list = cdr(list);
@@ -80,14 +80,14 @@ LispPTR fmemb(register LispPTR item, register LispPTR list) {
 
 #define S_N_CHECKANDCADR2(sour, dest, tos, tcstk) \
   {                                               \
-    register LispPTR parm = sour;                 \
+    LispPTR parm = sour;                 \
     if (GetTypeNumber(parm) != TYPE_LISTP) {      \
       SAVE_ERROR_EXIT2(tcstk, tos);               \
     } else                                        \
       (dest) = cadr(parm);                        \
   }
 
-LispPTR N_OP_listget(register LispPTR plist, register LispPTR tos) {
+LispPTR N_OP_listget(LispPTR plist, LispPTR tos) {
   struct cadr_cell cadrobj;
 
   while (plist != NIL_PTR) {

--- a/src/miscn.c
+++ b/src/miscn.c
@@ -41,8 +41,8 @@
 /***********************************************************/
 
 int OP_miscn(int misc_index, int arg_count) {
-  register LispPTR *stk;
-  register int result;
+  LispPTR *stk;
+  int result;
   static LispPTR args[255];
 
   /* Put the Args into a Vector */
@@ -51,7 +51,7 @@ int OP_miscn(int misc_index, int arg_count) {
   stk = ((LispPTR *)CurrentStackPTR) + 1;
 
   {
-    register int arg_num = arg_count;
+    int arg_num = arg_count;
     if (arg_num > 0) {
       *stk++ = (LispPTR)TopOfStack;
       while (arg_num > 0) args[--arg_num] = *--stk;
@@ -62,7 +62,7 @@ int OP_miscn(int misc_index, int arg_count) {
 
   switch (misc_index) {
     case miscn_USER_SUBR: {
-      register LispPTR user_subr;
+      LispPTR user_subr;
       N_GETNUMBER(args[0], user_subr, do_ufn);
       if ((result = UserSubr(user_subr, arg_count - 1, &args[1])) < 0) goto do_ufn;
     } break;

--- a/src/mkatom.c
+++ b/src/mkatom.c
@@ -156,7 +156,7 @@ static int bytecmp(const char *char1, const char *char2, int len)
 */
 /**********************************************************************/
 
-LispPTR compare_chars(register const char *char1, register const char *char2, register DLword length) {
+LispPTR compare_chars(const char *char1, const char *char2, DLword length) {
 #ifndef BYTESWAP
   if (memcmp(char1, char2, length) == 0)
 #else
@@ -196,7 +196,7 @@ int lispcmp(const DLword *char1, const char *char2, int len) {
 */
 /**********************************************************************/
 
-LispPTR compare_lisp_chars(register const char *char1, register const char *char2, register DLword length,
+LispPTR compare_lisp_chars(const char *char1, const char *char2, DLword length,
                            DLword fat1, DLword fat2) {
   if ((!fat1) == (!fat2)) { /* both fat or both non-fat. */
 #ifdef BYTESWAP

--- a/src/mkcell.c
+++ b/src/mkcell.c
@@ -44,11 +44,11 @@
 static LispPTR oldoldfree;
 static LispPTR oldfree;
 
-LispPTR N_OP_createcell(register LispPTR tos) {
-  register struct dtd *dtd68k;
-  register DLword *ptr, *lastptr;
-  register LispPTR newcell;
-  register unsigned int type;
+LispPTR N_OP_createcell(LispPTR tos) {
+  struct dtd *dtd68k;
+  DLword *ptr, *lastptr;
+  LispPTR newcell;
+  unsigned int type;
 
   if ((tos & SEGMASK) != S_POSITIVE) ERROR_EXIT(tos);
   type = tos & 0xffff;
@@ -91,9 +91,9 @@ retry:
 } /* N_OP_createcell end */
 
 DLword *createcell68k(unsigned int type) {
-  register struct dtd *dtd68k;
-  register DLword *ptr, *lastptr;
-  register LispPTR newcell;
+  struct dtd *dtd68k;
+  DLword *ptr, *lastptr;
+  LispPTR newcell;
 #ifdef DTDDEBUG
   if (type == TYPE_LISTP) error("createcell : Can't create Listp cell with CREATECELL");
   if (type == TYPE_STREAM) stab();

--- a/src/mnxmeth.c
+++ b/src/mnxmeth.c
@@ -146,7 +146,7 @@ char *gettitlestring(LispPTR medleywin)
   if (((MedleyWindow)Cptr(medleywin))->WTITLE == NIL)
     titlestring = NULL;
   else {
-    strlen = LispStringLength(((MedleyWindow)Cptr(medleywin))->WTITLE);
+    strlen = LispStringSimpleLength(((MedleyWindow)Cptr(medleywin))->WTITLE);
     titlestring = (char *)malloc(strlen + 1);
     LispStringToCStr(((MedleyWindow)Cptr(medleywin))->WTITLE, titlestring);
   }
@@ -200,7 +200,7 @@ void setlineattributes(Display *display, DspInterface dspif, WindowInterface wif
   }
 
   if (mdash != NIL) {
-    l = LispStringLength(mdash);
+    l = LispStringSimpleLength(mdash);
     dash_list = (unsigned char *)malloc(l + 1);
     LispStringToCStr(mdash, dash_list);
 
@@ -2797,7 +2797,7 @@ InitDsp(LispArgs args) /* arg[0] = LispPTR to MedleyScreen */
   /* if NATIVE_INFO has a string use it for the hostname */
   /* else use the environment var DISPLAY or "unix:0.0" */
   if (LispStringP(SCREEN->NATIVE_INFO)) {
-    strlen = LispStringLength(SCREEN->NATIVE_INFO);
+    strlen = LispStringSimpleLength(SCREEN->NATIVE_INFO);
     tmpstring = (char *)alloca(strlen + 1);
     LispStringToCStr(SCREEN->NATIVE_INFO, tmpstring);
     dspif->handle =

--- a/src/mvs.c
+++ b/src/mvs.c
@@ -48,7 +48,7 @@ LispPTR MVLIST_index;
 /*								*/
 /****************************************************************/
 
-LispPTR values(int arg_count, register LispPTR *args) {
+LispPTR values(int arg_count, LispPTR *args) {
   FX2 *caller, *prevcaller = 0, *immediate_caller = 0;
   ByteCode *pc;
   int unbind_count = 0;
@@ -105,7 +105,7 @@ newpc:
       goto newpc;
 
     case opc_JUMPX: {
-      register short displacement;
+      short displacement;
       displacement = (short)(GETBYTE((char *)pc + 1));
       if (displacement >= 128) displacement -= 256;
       pc += displacement;
@@ -113,7 +113,7 @@ newpc:
     }
 
     case opc_JUMPXX: {
-      register int displacement;
+      int displacement;
       displacement = (int)Get_code_DLword(pc + 1);
       if (displacement >= 32768) displacement -= 65536;
       pc += displacement;
@@ -144,7 +144,7 @@ newpc:
 /*								*/
 /****************************************************************/
 
-LispPTR values_list(int arg_count, register LispPTR *args) {
+LispPTR values_list(int arg_count, LispPTR *args) {
   FX2 *caller, *prevcaller = 0, *immediate_caller = 0;
   ByteCode *pc;
   int unbind_count = 0;
@@ -202,7 +202,7 @@ newpc:
       goto newpc;
 
     case opc_JUMPX: {
-      register short displacement;
+      short displacement;
       displacement = (short)(GETBYTE((char *)pc + 1));
       if (displacement >= 128) displacement -= 256;
       pc += displacement;
@@ -210,7 +210,7 @@ newpc:
     }
 
     case opc_JUMPXX: {
-      register int displacement;
+      int displacement;
       displacement = (int)Get_code_DLword(pc + 1);
       if (displacement >= 32768) displacement -= 65536;
       pc += displacement;
@@ -245,8 +245,8 @@ newpc:
 /************************************************************************/
 
 LispPTR make_value_list(int argcount, LispPTR *argarray) {
-  register LispPTR result = NIL_PTR;
-  register int i;
+  LispPTR result = NIL_PTR;
+  int i;
   if (argcount == 0) return (NIL_PTR);
   for (i = argcount - 1; i >= 0; i--) { result = cons(argarray[i], result); }
   return (result);
@@ -267,8 +267,8 @@ void simulate_unbind(FX2 *frame, int unbind_count, FX2 *returner) {
   int unbind;
   LispPTR *stackptr = (LispPTR *)(Stackspace + frame->nextblock);
   for (unbind = 0; unbind < unbind_count; unbind++) {
-    register int value;
-    register LispPTR *lastpvar;
+    int value;
+    LispPTR *lastpvar;
     int bindnvalues;
     for (; ((int)*--stackptr >= 0);)
       ; /* find the binding mark */

--- a/src/rawcolor.c
+++ b/src/rawcolor.c
@@ -139,7 +139,7 @@ C_slowbltchar(LispPTR *args)
   DLword src_w, src_h, src_x, src_y, dst_x, dst_y, w, h;
 
   u_char forecolor, backcolor;
-  register int displayflg;
+  int displayflg;
 
   extern LispPTR *TOPWDS68k;
 
@@ -193,11 +193,11 @@ C_slowbltchar(LispPTR *args)
     cury += yoff;
 
     {
-      register PILOTBBT *pbt;
-      register BITMAP *n_destBM, *n_srcBM;
-      register BIGBM *n_destBIGBM;
-      register int destYOffset;
-      register int width, sourceBitOffset;
+      PILOTBBT *pbt;
+      BITMAP *n_destBM, *n_srcBM;
+      BIGBM *n_destBIGBM;
+      int destYOffset;
+      int width, sourceBitOffset;
       extern int ScreenLocked;
       extern int displayheight;
 
@@ -300,9 +300,9 @@ u_int ColorizedFont8CACHE[MAXFONTHEIGHT / BITSPERNIBBLE * MAXFONTWIDTH / BITSPER
 void ColorizeFont8(BITMAP *sBM, DLword sXOffset, DLword sYOffset, BITMAP *dBM, DLword dXOffset, DLword dYOffset, DLword width, DLword height, u_char col0, u_char col1,
               LispPTR sourcetype, LispPTR operation)
 {
-  register DLword *nbase;
-  register u_char *dbase;
-  register int i;
+  DLword *nbase;
+  u_char *dbase;
+  int i;
 
   sYOffset = sBM->bmheight - (sYOffset + height);
   dYOffset = dBM->bmheight - (dYOffset + height);
@@ -330,9 +330,9 @@ void ColorizeFont8(BITMAP *sBM, DLword sXOffset, DLword sYOffset, BITMAP *dBM, D
 void ColorizeFont8_BIGBM(BITMAP *sBM, DLword sXOffset, DLword sYOffset, BIGBM *dBM, DLword dXOffset, DLword dYOffset, DLword width, DLword height, u_char col0, u_char col1,
               LispPTR sourcetype, LispPTR operation)
 {
-  register DLword *nbase;
-  register u_char *dbase;
-  register int i;
+  DLword *nbase;
+  u_char *dbase;
+  int i;
   int dest_bottom, dest_bigbmheight, dest_fragtop, dest_fragbottom, dest_yoffset, dest_h;
 
   LispPTR dest_bmlist;
@@ -406,9 +406,9 @@ loop:
 
 void newColorizeFont8(PILOTBBT *pbt, u_char backcolor, u_char forecolor, LispPTR srctype, LispPTR ope)
 {
-  register DLword *nbase;
-  register u_char *dbase;
-  register int i;
+  DLword *nbase;
+  u_char *dbase;
+  int i;
 
   nbase = (DLword *)Addr68k_from_LADDR((pbt->pbtsourcehi << 16) | (pbt->pbtsourcelo));
   (DLword *)dbase = (DLword *)Addr68k_from_LADDR((pbt->pbtdesthi << 16) | (pbt->pbtdestlo));
@@ -430,11 +430,11 @@ void newColorizeFont8(PILOTBBT *pbt, u_char backcolor, u_char forecolor, LispPTR
 void Uncolorize_Bitmap(LispPTR args[])
 {
   BITMAP *s_bitmap, *d_bitmap;
-  register DLword *OnOff;
+  DLword *OnOff;
 
-  register u_char *s_base;
-  register DLword *d_base;
-  register int y;
+  u_char *s_base;
+  DLword *d_base;
+  int y;
   int s_height, s_width, s_bitsperpixel, s_rasterwidth, d_rasterwidth;
 
   s_bitmap = (BITMAP *)Addr68k_from_LADDR(args[0]);
@@ -453,8 +453,8 @@ void Uncolorize_Bitmap(LispPTR args[])
   d_rasterwidth = d_bitmap->bmrasterwidth;
 
   for (y = 0; y < s_height; y++) {
-    register int x;
-    register DLword word;
+    int x;
+    DLword word;
     word = 0;
     for (x = 0; x < s_width; x++) {
       if (OnOff[*(s_base + x)]) {
@@ -509,9 +509,9 @@ LispPTR Colorize_Bitmap(LispPTR args[])
 {
   BITMAP *s_bitmap, *d_bitmap;
   int s_left, s_bottom, d_left, d_bottom, width, height, color0, color1, d_nbits;
-  register DLword *s_base;
-  register u_char *d_base;
-  register int i;
+  DLword *s_base;
+  u_char *d_base;
+  int i;
 
   N_GETNUMBER(args[10], d_nbits, bad_arg);
   if (d_nbits != 8) return (NIL); /* do nothing. */
@@ -587,9 +587,9 @@ void Draw_8BppColorLine(LispPTR *args)
   extern DLword REPLACE_atom, INVERT_atom, PAINT_atom, ERASE_atom;
   extern int ScreenLocked;
 
-  register u_char color;
-  register u_char *base;
-  register short x0, y0, xlimit, ylimit, dx, dy, cdl, yinc, raster_width;
+  u_char color;
+  u_char *base;
+  short x0, y0, xlimit, ylimit, dx, dy, cdl, yinc, raster_width;
   int mode, displayflg;
   u_char *n_bmbase;
 

--- a/src/return.c
+++ b/src/return.c
@@ -80,7 +80,7 @@ void OP_contextsw(void) {
 /*									*/
 /************************************************************************/
 
-void contextsw(register DLword fxnum, register DLword bytenum, register DLword flags)
+void contextsw(DLword fxnum, DLword bytenum, DLword flags)
 
 /* BYTEnum that you want increment PC
       after CONTEXTSW */
@@ -89,8 +89,8 @@ void contextsw(register DLword fxnum, register DLword bytenum, register DLword f
 /* I don't know that it is the possible case that
        flags is 3 . */
 {
-  register DLword *next68k;
-  register DLword *freeptr; /* point to STK to be FSB */
+  DLword *next68k;
+  DLword *freeptr; /* point to STK to be FSB */
 
 #ifdef TRACE
   printf("contextsw : %d \n", fxnum);

--- a/src/rpc.c
+++ b/src/rpc.c
@@ -62,9 +62,9 @@ LispPTR rpc(LispPTR *args)
   struct hostent *hp;
   struct sockaddr_in sin, sin1, from;
   char *outbuf, *inbuf, *destaddr;
-  register int s, msec_until_timeout, msec_between_tries, out_length;
-  register int received;
-  register int port;
+  int s, msec_until_timeout, msec_between_tries, out_length;
+  int received;
+  int port;
   int dest;
   unsigned fromlen;
   fd_set read_descriptors;

--- a/src/rplcons.c
+++ b/src/rplcons.c
@@ -32,12 +32,12 @@
 
 /***************************************************/
 
-LispPTR N_OP_rplcons(register LispPTR list, register LispPTR item) {
+LispPTR N_OP_rplcons(LispPTR list, LispPTR item) {
 #ifndef NEWCDRCODING
-  register struct conspage *conspage;
-  register ConsCell *new_cell;
-  register ConsCell *list68k;
-  LispPTR register page;
+  struct conspage *conspage;
+  ConsCell *new_cell;
+  ConsCell *list68k;
+  LispPTR page;
 #endif
 
   if (!Listp(list)) ERROR_EXIT(item);

--- a/src/rs232c.c
+++ b/src/rs232c.c
@@ -215,8 +215,8 @@ rs232c_lisp_is_ready() { return (RS232CGetFlag->busy); }
 static struct timeval sel_tv = {0, 0};
 
 rs232c_read() {
-  register DLRS232C_IOCB *iocb;
-  register int count;
+  DLRS232C_IOCB *iocb;
+  int count;
   fd_set readfds;
 
   if (RS232C_Fd >= 0) {
@@ -266,9 +266,9 @@ rs232c_read() {
 #define MAX_WRITE_TRY 5
 
 RS232C_write() {
-  register int size, count, trynum;
-  register char *buf;
-  register DLRS232C_IOCB *iocb;
+  int size, count, trynum;
+  char *buf;
+  DLRS232C_IOCB *iocb;
 
   iocb = (DLRS232C_IOCB *)Addr68k_from_LADDR(((*(RS232CPutCSB + 1) & 0xff) << 16) + *RS232CPutCSB);
 
@@ -414,7 +414,7 @@ void rs_sbit(u_int sbit)
 }
 
 void rs232c_majorparam() {
-  register int baud, csize, sbit;
+  int baud, csize, sbit;
 
   if (RS232C_Fd >= 0) {
     baud = rs_baud((u_int)((DLRS232C_PARAMETER_CSB *)RS232CParameterCSB)->line_speed);

--- a/src/shift.c
+++ b/src/shift.c
@@ -93,8 +93,8 @@ N_OP_lsh
         return(a <?> b)
 ************************************************************/
 LispPTR N_OP_lsh(int a, int b) {
-  register int arg, arg2;
-  register int size;
+  int arg, arg2;
+  int size;
   /*DLword	*wordp;*/
 
   N_GETNUMBER(b, size, do_ufn);

--- a/src/shift.c
+++ b/src/shift.c
@@ -19,7 +19,7 @@
 /*
  * XXX: it feels as though something is not clean here, looks like the
  * "int a" arguments are really LispPTR types, though perhaps it doesn't
- * matter.  NBriggs, May 2017
+ * matter.  NBriggs, May 2017 -- Yes. Replaced. NBriggs, Aug 2022
  */
 
 /************************************************************
@@ -27,7 +27,7 @@ N_OP_llsh1
         entry		LLSH1		OPCODE[0340]
         return(a << 1)
 ************************************************************/
-LispPTR N_OP_llsh1(int a) {
+LispPTR N_OP_llsh1(LispPTR a) {
   int arg1;
 
   N_GETNUMBER(a, arg1, du_ufn);
@@ -43,7 +43,7 @@ N_OP_llsh8
         entry		LLSH8		OPCODE[0341]
         return(a << 8)
 ************************************************************/
-LispPTR N_OP_llsh8(int a) {
+LispPTR N_OP_llsh8(LispPTR a) {
   int arg1;
 
   N_GETNUMBER(a, arg1, du_ufn);
@@ -59,7 +59,7 @@ N_OP_lrsh1
         entry		LRSH1		OPCODE[0342]
         return(a >> 1)
 ************************************************************/
-LispPTR N_OP_lrsh1(int a) {
+LispPTR N_OP_lrsh1(LispPTR a) {
   int arg1;
 
   N_GETNUMBER(a, arg1, du_ufn);
@@ -76,7 +76,7 @@ N_OP_lrsh8
         entry		LRSH8		OPCODE[0343]
         return(a >> 8)
 ************************************************************/
-LispPTR N_OP_lrsh8(int a) {
+LispPTR N_OP_lrsh8(LispPTR a) {
   int arg1;
 
   N_GETNUMBER(a, arg1, du_ufn);
@@ -92,7 +92,7 @@ N_OP_lsh
         entry		LSH		OPCODE[0347]
         return(a <?> b)
 ************************************************************/
-LispPTR N_OP_lsh(int a, int b) {
+LispPTR N_OP_lsh(LispPTR a, LispPTR b) {
   int arg, arg2;
   int size;
   /*DLword	*wordp;*/

--- a/src/storage.c
+++ b/src/storage.c
@@ -37,7 +37,7 @@
 #define GUARDVMEMFULL 500
 #define IFPVALID_KEY 5603
 
-static void advance_array_seg(register unsigned int nxtpage);
+static void advance_array_seg(unsigned int nxtpage);
 static void advance_storagestate(DLword flg);
 static LispPTR dremove(LispPTR x, LispPTR l);
 static void set_storage_state(void);
@@ -53,9 +53,9 @@ static void set_storage_state(void);
 */
 /*****************************************************************/
 
-void checkfor_storagefull(register unsigned int npages) {
-  register int pagesleft;
-  register INTSTAT *int_state;
+void checkfor_storagefull(unsigned int npages) {
+  int pagesleft;
+  INTSTAT *int_state;
 
 #ifdef BIGVM
   pagesleft = (*Next_MDSpage_word) - (*Next_Array_word) - PAGESPER_MDSUNIT;
@@ -147,7 +147,7 @@ void checkfor_storagefull(register unsigned int npages) {
 */
 /*****************************************************************/
 
-static void advance_array_seg(register unsigned int nxtpage)
+static void advance_array_seg(unsigned int nxtpage)
 /* rare page num */
 {
   unsigned int ncellsleft;
@@ -281,12 +281,12 @@ static LispPTR dremove(LispPTR x, LispPTR l) {
 
 LispPTR newpage(LispPTR base) {
 #ifdef BIGVM
-  register unsigned int vp; /* Virtual Page we're creating */
+  unsigned int vp; /* Virtual Page we're creating */
 #else
-  register DLword vp;        /* (built from base)           */
+  DLword vp;        /* (built from base)           */
 #endif /* BIGVM */
 
-  register INTSTAT *int_state;
+  INTSTAT *int_state;
 
   extern LispPTR *LASTVMEMFILEPAGE_word;
   extern LispPTR *VMEM_FULL_STATE_word;

--- a/src/subr.c
+++ b/src/subr.c
@@ -447,7 +447,7 @@ void OP_subrcall(int subr_no, int argnum) {
 
       switch (args[0] & 0xffff) {
         case 00: {
-          register UNSIGNED iarg;
+          UNSIGNED iarg;
           if (argnum != 2) goto ret_nil;
           N_GETNUMBER(args[1], iarg, ret_nil);
           ARITH_SWITCH(*((LispPTR *)iarg), TopOfStack);
@@ -455,7 +455,7 @@ void OP_subrcall(int subr_no, int argnum) {
         }
 
         case 01: {
-          register UNSIGNED iarg, iarg2;
+          UNSIGNED iarg, iarg2;
           if (argnum != 3) goto ret_nil;
           N_GETNUMBER(args[1], iarg, ret_nil);
           N_GETNUMBER(args[2], iarg2, ret_nil);
@@ -494,7 +494,7 @@ void OP_subrcall(int subr_no, int argnum) {
          a Lisp FIXP
 
       {
-        register UNSIGNED iarg;
+        UNSIGNED iarg;
         N_GETNUMBER(args[0], iarg, ret_nil);
         ARITH_SWITCH(LADDR_from_68k(iarg), TopOfStack);
         break;
@@ -533,7 +533,7 @@ void OP_subrcall(int subr_no, int argnum) {
     /*
             case 0166: POP_SUBR_ARGS;
                              error("called SUBR 0166, not defined!!");
-                                  {register int temp;
+                                  {int temp;
                              N_GETNUMBER(TopOfStack, temp, badarg);
                              temp = (UNSIGNED) Addr68k_from_LADDR(temp);
                              ARITH_SWITCH(temp, TopOfStack);

--- a/src/sxhash.c
+++ b/src/sxhash.c
@@ -111,20 +111,20 @@ static unsigned short sxhash_rotate(short unsigned int value) {
 
 static unsigned short sxhash_string(OneDArray *obj) {
   unsigned len, offset;
-  register unsigned short hash = 0;
+  unsigned short hash = 0;
   len = (unsigned)obj->fillpointer;
   if (len > 13) len = 13;
   offset = (unsigned)obj->offset;
   switch (obj->typenumber) {
     case THIN_CHAR_TYPENUMBER: {
-      register char *thin;
-      register unsigned i;
+      char *thin;
+      unsigned i;
       thin = ((char *)(Addr68k_from_LADDR(obj->base))) + offset;
       for (i = 0; i < len; i++) hash = sxhash_rotate(hash ^ GETBYTE(thin++));
     } break;
     case FAT_CHAR_TYPENUMBER: {
-      register unsigned short *fat;
-      register unsigned i;
+      unsigned short *fat;
+      unsigned i;
       fat = ((unsigned short *)(Addr68k_from_LADDR(obj->base))) + offset;
       for (i = 0; i < len; i++) hash = sxhash_rotate(hash ^ GETWORD(fat++));
     } break;
@@ -189,7 +189,7 @@ LispPTR STRING_EQUAL_HASHBITS(LispPTR object) {
 
 static unsigned short stringequalhash(LispPTR obj) {
   unsigned len, offset, fatp, ind;
-  register unsigned short hash = 0;
+  unsigned short hash = 0;
   PNCell *pnptr;
   DLword *base;
   PLCell *Prop;
@@ -223,16 +223,16 @@ static unsigned short stringequalhash(LispPTR obj) {
   };
 
   if (fatp) {
-    register unsigned short *fat;
-    register unsigned i;
+    unsigned short *fat;
+    unsigned i;
     fat = ((unsigned short *)base) + offset;
     for (i = 0; i < len; i++) {
       hash = hash + ((hash & 0xFFF) << 2);
       hash = hash + (0x20 | GETWORD(fat++)) + ((hash & 0xFF) << 8);
     }
   } else {
-    register char *thin;
-    register unsigned i;
+    char *thin;
+    unsigned i;
     thin = ((char *)base) + offset;
     for (i = 0; i < len; i++) {
       hash = hash + ((hash & 0xFFF) << 2);
@@ -257,7 +257,7 @@ LispPTR STRING_HASHBITS(LispPTR object) {
 
 static unsigned short stringhash(LispPTR obj) {
   unsigned len, offset, fatp, ind;
-  register unsigned short hash = 0;
+  unsigned short hash = 0;
   PNCell *pnptr;
   DLword *base;
   PLCell *Prop;
@@ -291,16 +291,16 @@ static unsigned short stringhash(LispPTR obj) {
   }; /* switch */
 
   if (fatp) {
-    register unsigned short *fat;
-    register unsigned i;
+    unsigned short *fat;
+    unsigned i;
     fat = ((unsigned short *)base) + offset;
     for (i = 0; i < len; i++) {
       hash = hash + ((hash & 0xFFF) << 2);
       hash = hash + GETWORD(fat++) + ((hash & 0xFF) << 8);
     }
   } else {
-    register char *thin;
-    register unsigned i;
+    char *thin;
+    unsigned i;
     thin = ((char *)base) + offset;
     for (i = 0; i < len; i++) {
       hash = hash + ((hash & 0xFFF) << 2);

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -1236,7 +1236,7 @@ void dtd_chain(DLword type) {
 
 void check_dtd_chain(DLword type)
 {
-  register LispPTR next, onext;
+  LispPTR next, onext;
   LispPTR before;
 
   onext = 0;

--- a/src/timer.c
+++ b/src/timer.c
@@ -87,7 +87,7 @@ extern DspInterface currentdsp;
  *	to get Alto time.
  */
 
-int TIMEOUT_TIME = 10; /* For file system timeout, seconds, default 10 */
+unsigned int TIMEOUT_TIME = 10; /* For file system timeout, seconds, default 10 */
 
 volatile sig_atomic_t IO_Signalled = FALSE;
 

--- a/src/typeof.c
+++ b/src/typeof.c
@@ -33,8 +33,8 @@
 /*									*/
 /************************************************************************/
 
-LispPTR N_OP_instancep(register LispPTR tos, register int atom_index) {
-  register struct dtd *dtd68k;
+LispPTR N_OP_instancep(LispPTR tos, int atom_index) {
+  struct dtd *dtd68k;
 
   for (dtd68k = (struct dtd *)GetDTD(GetTypeNumber(tos));
 #ifdef BIGVM

--- a/src/ubf1.c
+++ b/src/ubf1.c
@@ -31,7 +31,7 @@ LispPTR N_OP_ubfloat1(int arg, int alpha) {
   switch (alpha) {
     case 0: /* box */
     {
-      register DLword *wordp;
+      DLword *wordp;
       wordp = createcell68k(TYPE_FLOATP);
       *((int *)wordp) = arg;
       return (LADDR_from_68k(wordp));
@@ -48,7 +48,7 @@ LispPTR N_OP_ubfloat1(int arg, int alpha) {
     case 3: /* neg */ return (0x80000000 ^ arg);
     case 4: /* ufix */
     {
-      register float temp;
+      float temp;
       int val;
       temp = *(float *)&arg;
       if ((temp > ((float)0x7fffffff)) || (temp < ((float)0x80000000))) ERROR_EXIT(arg);

--- a/src/ufn.c
+++ b/src/ufn.c
@@ -55,12 +55,12 @@
 
 void ufn(DLword bytecode)
 {
-  register DefCell *defcell68k; /* Definition Cell PTR */
-  register int pv_num;          /* scratch for pv */
-  register UFN *entry68k;
-  register struct fnhead *tmp_fn;
-  register unsigned int arg_num; /* Num of args */
-  register int rest;             /* use for alignments */
+  DefCell *defcell68k; /* Definition Cell PTR */
+  int pv_num;          /* scratch for pv */
+  UFN *entry68k;
+  struct fnhead *tmp_fn;
+  unsigned int arg_num; /* Num of args */
+  int rest;             /* use for alignments */
 
 #ifdef TRACE
   printPC();

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -155,9 +155,9 @@ exit_host_filesystem() {
 
 LispPTR UFS_getfilename(LispPTR *args)
 {
-  register char *base;
+  char *base;
   size_t len;
-  register int rval;
+  int rval;
   char lfname[MAXPATHLEN], file[MAXPATHLEN];
 
   ERRSETJMP(NIL);
@@ -245,7 +245,7 @@ LispPTR UFS_deletefile(LispPTR *args)
 {
   char file[MAXPATHLEN], fbuf[MAXPATHLEN];
   struct stat sbuf;
-  register int len, rval;
+  int len, rval;
 
   ERRSETJMP(NIL);
   Lisp_errno = (int *)(Addr68k_from_LADDR(args[1]));
@@ -382,8 +382,8 @@ LispPTR UFS_directorynamep(LispPTR *args)
   char dirname[MAXPATHLEN];
   char fullname[MAXPATHLEN];
   size_t len;
-  register int rval;
-  register char *base;
+  int rval;
+  char *base;
   struct stat sbuf;
 
   ERRSETJMP(NIL);
@@ -466,8 +466,8 @@ int unixpathname(char *src, char *dst, int versionp, int genp, char *drive, int 
 int unixpathname(char *src, char *dst, int versionp, int genp)
 #endif /* DOS */
 {
-  register char *cp, *dp, *np;
-  register int newdirflg;
+  char *cp, *dp, *np;
+  int newdirflg;
   char name[64];
   char lfname[MAXPATHLEN], fbuf1[MAXPATHLEN], fbuf2[MAXPATHLEN];
   char ver1[VERSIONLEN], ver2[VERSIONLEN];
@@ -871,9 +871,9 @@ int unixpathname(char *src, char *dst, int versionp, int genp)
 
 int lisppathname(char *fullname, char *lispname, int dirp, int versionp)
 {
-  register char *cp, *dp, *lnamep, *cnamep;
+  char *cp, *dp, *lnamep, *cnamep;
   char namebuf[MAXPATHLEN], fbuf[MAXPATHLEN], ver[VERSIONLEN];
-  register int i, mask, extensionp;
+  int i, mask, extensionp;
 
   if (strcmp(fullname, DIRSEPSTR) == 0) {
     strcpy(lispname, "<");
@@ -1129,8 +1129,8 @@ int lisppathname(char *fullname, char *lispname, int dirp, int versionp)
 
 int quote_fname(char *file)
 {
-  register char *cp, *dp;
-  register int extensionp;
+  char *cp, *dp;
+  int extensionp;
   char fbuf[MAXNAMLEN + 1], namebuf[MAXNAMLEN + 1], ver[VERSIONLEN];
 
   cp = file;
@@ -1214,8 +1214,8 @@ int quote_fname(char *file)
 
 int quote_fname_ufs(char *file)
 {
-  register char *cp, *dp;
-  register int extensionp;
+  char *cp, *dp;
+  int extensionp;
   char fbuf[MAXNAMLEN + 1];
 
   cp = file;
@@ -1290,7 +1290,7 @@ int quote_fname_ufs(char *file)
 
 int quote_dname(char *dir)
 {
-  register char *cp, *dp;
+  char *cp, *dp;
   char fbuf[MAXNAMLEN + 1];
 
   cp = dir;

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -365,7 +365,7 @@ static int FindAvailablePty(char *Slave) {
 /************************************************************************/
 
 LispPTR Unix_handlecomm(LispPTR *args) {
-  int command, dest, i, slot, sock;
+  int command, dest, slot;
   unsigned char d[6];
   unsigned char ch;
   unsigned char buf[1];
@@ -852,6 +852,7 @@ LispPTR Unix_handlecomm(LispPTR *args) {
     case 15: /* Write buffer */
     {
       DLword *bufp;
+      int i;
       N_GETNUMBER(args[1], slot, bad);              /* Get job # */
       bufp = (Addr68k_from_LADDR(args[2])); /* User buffer */
       N_GETNUMBER(args[3], i, bad);                 /* # to write */

--- a/src/unixcomm.c
+++ b/src/unixcomm.c
@@ -113,7 +113,7 @@ char shcom[2048]; /* Here because I'm suspicious of */
 /*									*/
 /************************************************************************/
 
-int find_process_slot(register int pid)
+int find_process_slot(int pid)
 /* Find a slot with the specified pid */
 
 {

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -45,13 +45,11 @@
 int flushing = 0;
 #endif
 
-/* The following globals are used to communicate between Unix
-   subprocesses and LISP */
+/* Used to communicate between Unix subprocesses and LISP */
 
-long StartTime; /* Time, for creating pipe filenames */
-
-char shcom[512]; /* Here because I'm suspicious of */
-                 /* large allocations on the stack */
+static long StartTime;  /* Time, for creating pipe filenames */
+static char shcom[512]; /* Here because I'm suspicious of */
+                        /* large allocations on the stack */
 
 
 static inline ssize_t SAFEREAD(int f, char *b, int c)

--- a/src/unixfork.c
+++ b/src/unixfork.c
@@ -52,7 +52,7 @@ static char shcom[512]; /* Here because I'm suspicious of */
                         /* large allocations on the stack */
 
 
-static inline ssize_t SAFEREAD(int f, char *b, int c)
+static inline ssize_t SAFEREAD(int f, char *b, size_t c)
 {
   ssize_t res;
   do {

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -26,10 +26,10 @@
 #include "lspglob.h"
 #include "unwinddefs.h"  // for N_OP_unwind
 
-LispPTR *N_OP_unwind(register LispPTR *cstkptr, register LispPTR tos, int n, int keep) {
-  register int num;           /* number of UNBOUND slot */
-  register LispPTR *endptr;   /* unwind limit */
-  register LispPTR *lastpvar; /* points PVar slot that is unbounded. */
+LispPTR *N_OP_unwind(LispPTR *cstkptr, LispPTR tos, int n, int keep) {
+  int num;           /* number of UNBOUND slot */
+  LispPTR *endptr;   /* unwind limit */
+  LispPTR *lastpvar; /* points PVar slot that is unbounded. */
 
   /* Slots:
           -----------------
@@ -107,9 +107,9 @@ LispPTR *N_OP_unwind(register LispPTR *cstkptr, register LispPTR tos, int n, int
 
 LispPTR find_the_blip(LispPTR blip, LispPTR throwp, FX *unwinder)
 {
-  register LispPTR target;
-  register FX *target_addr;
-  register LispPTR pc = NIL_PTR;
+  LispPTR target;
+  FX *target_addr;
+  LispPTR pc = NIL_PTR;
 
   LispPTR CATCH_RETURN_PC_ATOM = parse_atomstring("SI::*CATCH-RETURN-PC*");
   LispPTR CATCH_RETURN_TO_ATOM = parse_atomstring("SI::*CATCH-RETURN-TO*");
@@ -118,7 +118,7 @@ LispPTR find_the_blip(LispPTR blip, LispPTR throwp, FX *unwinder)
   for (target = (LispPTR)unwinder; FX_INVALIDP(target); GETCLINK(target_addr)) {
     target_addr = (FX *)Addr68k_from_StkOffset(target);
     if (blip == *target_addr) {
-      register LispPTR var_name_in_frame = variable_name_in_frame(target_addr, (FVPVAR << 8) + 1);
+      LispPTR var_name_in_frame = variable_name_in_frame(target_addr, (FVPVAR << 8) + 1);
       if (var_name_in_frame == CATCH_RETURN_TO_ATOM) {
         if (throwp) {
           pc = pvar_value_in_frame(target_addr, CATCH_RETURN_PC_ATOM);
@@ -141,10 +141,10 @@ cons_result:
 
 LispPTR variable_name_in_frame(FX *fx_addr, LispPTR code)
 {
-  register DLword *name_ptr;
-  register DLword *name_bind_ptr;
-  register DLword *name_table_base;
-  register DLword value;
+  DLword *name_ptr;
+  DLword *name_bind_ptr;
+  DLword *name_table_base;
+  DLword value;
 
   name_table_base = Addr68k_from_LADDR(GETNAMETABLE(fx_addr));
   name_ptr = name_table_base + FNHEADSIZE;
@@ -168,10 +168,10 @@ LispPTR variable_name_in_frame(FX *fx_addr, LispPTR code)
 LispPTR pvar_value_in_frame(FX *frame_addr, LispPTR atom_index)
 
 {
-  register DLword *name_ptr;
-  register DLword *name_bind_ptr;
-  register DLword *name_table_base;
-  register DLword value;
+  DLword *name_ptr;
+  DLword *name_bind_ptr;
+  DLword *name_table_base;
+  DLword value;
 
   name_table_base = Addr68k_from_LADDR(GETNAMETABLE(frame_addr));
   name_ptr = name_table_base + FNHEADSIZE;
@@ -179,9 +179,9 @@ LispPTR pvar_value_in_frame(FX *frame_addr, LispPTR atom_index)
 
   while (value = GETWORD(name_ptr++)) do {
       if (value == atom_index) {
-        register DLword bind_info = GETWORD(name_bind_ptr);
+        DLword bind_info = GETWORD(name_bind_ptr);
         if ((bind_info >> 8) == FVPVAR) {
-          register LispPTR slot_value = *((LispPTR *)(FRAMESIZE + (DLword *)frame_addr) +
+          LispPTR slot_value = *((LispPTR *)(FRAMESIZE + (DLword *)frame_addr) +
                                           (bind_info - (FVPVAR << 8))) if (slot_value > 0) {
             return (slot_value & POINTERMASK);
           };

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -321,7 +321,7 @@ void uraid_commclear() {
 
 void copy_region(const DLword *src, DLword *dst, int width, int h)
 {
-  register int w;
+  int w;
 
   for (; (h--);) {
     for (w = width; (w--);) { GETWORD(dst++) = GETWORD(src++); }

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -22,6 +22,7 @@
 #include <pwd.h>         // for getpwuid, passwd
 #endif
 #include <signal.h>      // for killpg, SIGTSTP
+#include <stddef.h>      // for size_t
 #include <stdio.h>       // for printf, NULL, snprintf, size_t
 #include <stdlib.h>      // for getenv
 #include <string.h>      // for strcmp, strcpy, strlen, strncpy
@@ -45,9 +46,9 @@
 /*									*/
 /************************************************************************/
 
-int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length) {
-  register OneDArray *arrayp;
-  register char *base;
+static int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length) {
+  OneDArray *arrayp;
+  char *base;
 
   if (GetTypeNumber(Lisp) != TYPE_ONED_ARRAY) { return (-1); }
 
@@ -61,9 +62,9 @@ int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length) {
       strncpy(C, base, arrayp->fillpointer);
 #else
       {
-        register int i, length;
-        register char *dp;
-        for (i = 0, dp = C, length = arrayp->fillpointer; i < length; i++) {
+        size_t l = arrayp->fillpointer;
+        char *dp = C;
+        for (size_t i = 0; i < l; i++) {
           *dp++ = (char)(GETBYTE(base++));
         }
       }
@@ -87,10 +88,10 @@ int lisp_string_to_c_string(LispPTR Lisp, char *C, size_t length) {
 /*									*/
 /************************************************************************/
 
-int c_string_to_lisp_string(char *C, LispPTR Lisp) {
-  register OneDArray *arrayp;
+static int c_string_to_lisp_string(char *C, LispPTR Lisp) {
+  OneDArray *arrayp;
   char *base;
-  register size_t length;
+  size_t length;
 
   length = strlen(C);
   if (GetTypeNumber(Lisp) != TYPE_ONED_ARRAY) { return (-1); }
@@ -106,9 +107,8 @@ int c_string_to_lisp_string(char *C, LispPTR Lisp) {
       strcpy(base, C);
 #else
       {
-        register size_t i;
-        register char *dp;
-        for (i = 0, dp = C; i < length + 1; i++) {
+        char *dp = C;
+        for (size_t i = 0; i < length + 1; i++) {
           char ch = *dp++;
 #ifdef DOS
           if (ch == '\\') dp++; /* skip 2nd \ in \\ in C strings */

--- a/src/vars3.c
+++ b/src/vars3.c
@@ -101,10 +101,10 @@ N_OP_arg0
 
 ************************************************************/
 
-LispPTR N_OP_arg0(register LispPTR tos) {
-  register int num;
-  register DLword *bf; /* index of Basic frame */
-  register int nargs;
+LispPTR N_OP_arg0(LispPTR tos) {
+  int num;
+  DLword *bf; /* index of Basic frame */
+  int nargs;
 
   if ((SEGMASK & tos) != S_POSITIVE) {
     /* error("OP_arg0: Bad TopOfStack\n"); */
@@ -140,9 +140,9 @@ N_OP_assoc
 
 *******************************************/
 
-LispPTR N_OP_assoc(register LispPTR key, register LispPTR list) {
+LispPTR N_OP_assoc(LispPTR key, LispPTR list) {
   struct cadr_cell cadr1;
-  register LispPTR cdr; /* address of (cdr A-list); Lisp address */
+  LispPTR cdr; /* address of (cdr A-list); Lisp address */
 
   if (list == NIL_PTR) { return (NIL_PTR); }
 

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -410,7 +410,7 @@ LispPTR vmem_save(char *sysout_file_name)
 
       /* Now, let's see how many pages we can dump */
       while (GETFPTOVP(fptovp, i) == oldfptovp && i < vmemsize) {
-        contig_pages++, oldfptovp++, i++;
+        contig_pages++; oldfptovp++; i++;
       }
       i--; /* Previous loop always overbumps i */
       DBPRINT(("%4d: writing %d pages from %tx (%d)\n", i, contig_pages, base_addr - (char *)Lisp_world, saveoldfptovp));

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -20,6 +20,7 @@
 #include <fcntl.h>
 #include <setjmp.h>
 #include <signal.h>
+#include <stddef.h>	// for ptrdiff_t
 #include <stdio.h>
 #include <stdlib.h>
 #ifndef DOS
@@ -103,8 +104,6 @@ int lispstringP(LispPTR Lisp)
   }
 }
 
-LispPTR vmem_save(register char *sysout_file_name);
-
 /************************************************************************/
 /*									*/
 /*			v m e m _ s a v e 0				*/
@@ -143,7 +142,7 @@ LispPTR vmem_save(register char *sysout_file_name);
 
 LispPTR vmem_save0(LispPTR *args)
 {
-  register char *def;
+  char *def;
   char pathname[MAXPATHLEN], sysout[MAXPATHLEN], host[MAXNAMLEN];
 #ifdef DOS
   char pwd[MAXNAMLEN];
@@ -212,7 +211,8 @@ int twowords(const void *i, const void *j) /* the difference between two  DLword
 
 void sort_fptovp(DLword *fptovp, int size)
 {
-  int oldloc, newloc, oldsize, i;
+  int oldsize, i;
+  ptrdiff_t oldloc, newloc;
   DLword *fptr;
 
   for (fptr = fptovp, i = 0; GETWORD(fptr) != FPTOVP_ENTRY && i < size; fptr++, i++)
@@ -299,20 +299,21 @@ ONE_MORE_TIME: /* Tacky, but why repeat code? */
  */
 
 /* diagnostic flag value to limit the size of write() s */
+extern int maxpages;
 int maxpages = 65536;
 
 LispPTR vmem_save(char *sysout_file_name)
 {
   int sysout; /* SysoutFile descriptor */
 #ifdef BIGVM
-  register unsigned int *fptovp;
+  unsigned int *fptovp;
 #else
-  register DLword *fptovp; /* FPTOVP */
+  DLword *fptovp; /* FPTOVP */
 #endif          /* BIGVM */
   int vmemsize; /* VMEMSIZE */
-  register int i;
+  int i;
   char tempname[MAXPATHLEN];
-  register int rval;
+  ssize_t rval;
 #ifndef DOS
   extern int ScreenLocked;
   extern DLword *EmCursorX68K;
@@ -323,7 +324,7 @@ LispPTR vmem_save(char *sysout_file_name)
 
 /* remove cursor image from screen */
 
-#if   DOS
+#ifdef   DOS
   /*  For DOS, must also take the mouse cursor away (it's  */
   /*  written into the display-region bitmap).	     */
   currentdsp->device.locked++;
@@ -396,10 +397,10 @@ LispPTR vmem_save(char *sysout_file_name)
 
   for (i = 0; i < vmemsize; i++) {
     if (GETPAGEOK(fptovp, i) != 0177777) {
-      int oldfptovp = GETFPTOVP(fptovp, i);
-      int saveoldfptovp = oldfptovp;
-      int contig_pages = 0;
-      register char *base_addr;
+      unsigned int oldfptovp = GETFPTOVP(fptovp, i);
+      unsigned int saveoldfptovp = oldfptovp;
+      unsigned int contig_pages = 0;
+      char *base_addr;
 
       TIMEOUT(rval = lseek(sysout, i * BYTESPER_PAGE, SEEK_SET));
       if (rval == -1) {
@@ -421,7 +422,7 @@ LispPTR vmem_save(char *sysout_file_name)
 
       if (contig_pages > maxpages) {
         char *ba = base_addr;
-        int pc = contig_pages;
+        unsigned int pc = contig_pages;
         while (pc > maxpages) {
           TIMEOUT(rval = write(sysout, ba, maxpages * BYTESPER_PAGE));
           if (rval == -1) {
@@ -433,7 +434,7 @@ LispPTR vmem_save(char *sysout_file_name)
         }
         if (pc > 0) TIMEOUT(rval = write(sysout, ba, pc * BYTESPER_PAGE));
       } else {
-        int oldTT = TIMEOUT_TIME;
+        unsigned int oldTT = TIMEOUT_TIME;
         /* As we can spend longer than TIMEOUT_TIME doing a big
            write, we adjust the timeout temporarily here */
         TIMEOUT_TIME += contig_pages >> 3;
@@ -494,7 +495,7 @@ LispPTR vmem_save(char *sysout_file_name)
   }
 
 /* restore cursor image to screen */
-#if   DOS
+#ifdef DOS
   /* Must also put the mouse back. */
   (currentdsp->mouse_visible)(IOPage68K->dlmousex, IOPage68K->dlmousey);
   currentdsp->device.locked--;

--- a/src/xc.c
+++ b/src/xc.c
@@ -114,9 +114,9 @@ typedef ByteCode *InstPtr;
 
 #if   (DOS && OPDISP)
 #include "inlndos.h"
-register InstPtr pccache asm("si");
-register LispPTR *cspcache asm("di");
-register LispPTR tscache asm("bx");
+InstPtr pccache asm("si");
+LispPTR *cspcache asm("di");
+LispPTR tscache asm("bx");
 #endif /* DOS */
 
 /* This used to be here for including optimized dispatch
@@ -163,7 +163,7 @@ static const int n_mask_array[16] = {
 extern int TIMER_INTERVAL;
 
 void dispatch(void) {
-  register InstPtr pccache;
+  InstPtr pccache;
 
 #if defined(OPDISP)
   static const void* optable[256] = {
@@ -204,8 +204,8 @@ void dispatch(void) {
 
 #if (DOS && OPDISP)
 #else
-  register LispPTR *cspcache;
-  register LispPTR tscache;
+  LispPTR *cspcache;
+  LispPTR tscache;
 #endif
 
   /* OP_FN_COMMON arguments */
@@ -1062,7 +1062,7 @@ check_interrupt:
   /* Check for an IRQ request */
 
   {
-    register int need_irq;
+    int need_irq;
     static int period_cnt = 60;
     extern int KBDEventFlg;
     extern int ETHEREventCount;

--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -85,9 +85,9 @@ void Init_XCursor() {
 void Set_XCursor(int x, int y)
 {
   /* compare cursor in IOPage memory with cursors we've seen before */
-  register struct MXCURSOR *clp, *clbp;
-  register DLword *newbm = ((DLword *)(IOPage->dlcursorbitmap));
-  register int i;
+  struct MXCURSOR *clp, *clbp;
+  DLword *newbm = ((DLword *)(IOPage->dlcursorbitmap));
+  int i;
 
   XLOCK; /* No signals while setting the cursor */
   for (clp = cursorlist; clp != NULL; clbp = clp, clp = clp->next) {

--- a/src/z2.c
+++ b/src/z2.c
@@ -38,7 +38,7 @@
 /*   N_OP_classoc()  OP 33Q  */
 LispPTR N_OP_classoc(LispPTR key, LispPTR list) {
   struct cadr_cell cadr1;
-  register LispPTR cdrcell; /* address of (cdr A-list); Lisp address */
+  LispPTR cdrcell; /* address of (cdr A-list); Lisp address */
 
   switch (key & SEGMASK) {
     case S_POSITIVE: break;
@@ -78,7 +78,7 @@ LispPTR N_OP_classoc(LispPTR key, LispPTR list) {
 } /* end N_OP_classoc() */
 
 /*   (CL:FMEMB item list)  OP 35Q  */
-LispPTR N_OP_clfmemb(register LispPTR item, register LispPTR list) { /* OP 35Q */
+LispPTR N_OP_clfmemb(LispPTR item, LispPTR list) { /* OP 35Q */
 
   switch (item & SEGMASK) {
     case S_POSITIVE: break;
@@ -151,7 +151,7 @@ fin:	DelRef tail
 
 ***********************************************************/
 
-LispPTR N_OP_restlist(register LispPTR tail, register int last, register int skip) {
+LispPTR N_OP_restlist(LispPTR tail, int last, int skip) {
   last &= 0xFFFF;
   while (skip <= last) { tail = cons(GetLongWord(IVar + (--last << 1)), tail); }
   return (tail);


### PR DESCRIPTION
Before and after warning counts --

```
1337 [-Wcast-align]                	1337 [-Wcast-align]
1051 [-Wsign-conversion]           	 667 [-Wsign-conversion]
 519 [-Wstrict-prototypes]         	 514 [-Wstrict-prototypes]
 232 [-Wmissing-variable-declarations]	 218 [-Wmissing-variable-declarations]
 197 [-Wimplicit-int-conversion]   	 186 [-Wimplicit-int-conversion]
 147 [-Wshorten-64-to-32]          	 131 [-Wshorten-64-to-32]
  84 [-Wpadded]                    	  84 [-Wpadded]
  79 [-Wconditional-uninitialized] 	  79 [-Wconditional-uninitialized]
  52 [-Wunused-macros]             	  48 [-Wunused-macros]
  41 [-Wunused-parameter]          	  41 [-Wunused-parameter]
  36 [-Wsign-compare]              	  25 [-Wsign-compare]
  35 [-Wunreachable-code-break]    	  35 [-Wunreachable-code-break]
  15 [-Wmissing-prototypes]        	  14 [-Wmissing-prototypes]
   9 [-Wundef]                     	   7 [-Wundef]
   9 [-Wredundant-parens]          	   9 [-Wredundant-parens]
   9 [-Wcast-qual]                 	   9 [-Wcast-qual]
   7 [-Wtautological-value-range-compare]	
   7 [-Wshadow]                    	
   7 [-Wfloat-equal]               	   7 [-Wfloat-equal]
   5 [-Wmissing-noreturn]          	   5 [-Wmissing-noreturn]
   5 [-Wdouble-promotion]          	   5 [-Wdouble-promotion]
   4 [-Wswitch-enum]               	   4 [-Wswitch-enum]
   4 [-Wdocumentation-unknown-command]	   4 [-Wdocumentation-unknown-command]
   2 [-Wunused-variable]           	   1 [-Wunused-variable]
   2 [-Wcomma]                     	
   1 [-Wpointer-arith]             	   1 [-Wpointer-arith]
```