### PR TITLE
Run the 'mkvdate' script relative to CMAKE_CURRENT_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -377,7 +377,7 @@ SET(MAIKO_HDRS
 )
 
 ADD_CUSTOM_TARGET(gen-vdate
-  COMMAND ../bin/mkvdate > vdate.c
+  COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/mkvdate > vdate.c
   BYPRODUCTS vdate.c
 )
 


### PR DESCRIPTION
This removes the limitation that the build directory has to be in the source tree and can instead be located anywhere.

Fixes issue Interlisp/medley#921.