### PR TITLE
Remove extra semicolons, convert #define x() {...} to do {...} while (0) style

### DIFF
--- a/inc/bb.h
+++ b/inc/bb.h
@@ -738,7 +738,7 @@ int srcRshift;
 /************************************************************************/
 
 #define  new_bitblt_code			\
-{						\
+do {						\
 variables					\
 some_init					\
 while (num_lines_remaining-- > 0)		\
@@ -778,7 +778,7 @@ next_line:					\
     continue;					\
   }						\
 } /* end line loop */				\
-}
+} while (0)
 
 
 
@@ -791,7 +791,7 @@ next_line:					\
 /************************************************************************/
 
 #define  new_gray_bitblt_code			\
-{						\
+do {						\
 variables					\
 some_init					\
 while (num_lines_remaining-- > 0)		\
@@ -803,7 +803,7 @@ do_fpt:						\
 next_line:					\
   do_gray_advance				\
 } /* end line loop */				\
-}
+} while (0)
 
 
 
@@ -816,7 +816,7 @@ next_line:					\
 /************************************************************************/
 
 #define  new_char_bitblt_code			\
-{						\
+do {						\
 variables					\
 some_init					\
 while (num_lines_remaining-- > 0)		\
@@ -828,7 +828,7 @@ do_fpt:						\
 next_line:					\
   F_do_advance					\
 } /* end line loop */				\
-}
+} while (0)
 
 
 

--- a/inc/bitblt.h
+++ b/inc/bitblt.h
@@ -76,13 +76,13 @@ extern DLword *EmCursorX68K,*EmCursorY68K;
 /* Macro for locking and unlocking screen to prevent multiple updates */
 
 #ifdef DOS
-#define LOCKSCREEN currentdsp->device.locked++;
-#define UNLOCKSCREEN currentdsp->device.locked--;
+#define LOCKSCREEN currentdsp->device.locked++
+#define UNLOCKSCREEN currentdsp->device.locked--
 
 #else
 
-#define LOCKSCREEN ScreenLocked = T;
-#define UNLOCKSCREEN ScreenLocked = NIL;
+#define LOCKSCREEN ScreenLocked = T
+#define UNLOCKSCREEN ScreenLocked = NIL
 
 #endif /* DOS */
 #endif /* BITBLT_H */

--- a/inc/cell.h
+++ b/inc/cell.h
@@ -416,11 +416,11 @@ struct cadr_cell {
 /* When cadr() function is called, type check should be done. */
 
 #define S_N_CHECKANDCADR(sour, dest, tos)    \
-  {                                          \
+  do {                                        \
     LispPTR parm = sour;            \
     if (GetTypeNumber(parm) != TYPE_LISTP) { \
       ERROR_EXIT(tos);                       \
     } else                                   \
       (dest) = cadr(parm);                   \
-  }
+  } while (0)
 #endif

--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -48,23 +48,23 @@
 
    /* IncAllocCnt is called only when *Reclaim_cnt_word != NIL */
 
-#define IncAllocCnt(n) {\
+#define IncAllocCnt(n) do { \
 	if ((*Reclaim_cnt_word -= (n)) <= S_POSITIVE) { \
-		/* time for GC */\
-		Irq_Stk_Check = Irq_Stk_End = 0;\
-		*Reclaim_cnt_word = S_POSITIVE;\
-	};\
-}
+		/* time for GC */ \
+		Irq_Stk_Check = Irq_Stk_End = 0; \
+		*Reclaim_cnt_word = S_POSITIVE; \
+	} \
+  } while (0)
 
    /* DecAllocCnt only called when *Reclaim_cnt_word != NIL */
 
-#define DecAllocCnt(n) { *Reclaim_cnt_word += (n); }
+#define DecAllocCnt(n) do { *Reclaim_cnt_word += (n); } while (0)
 
-#define FreeLink(link) {                        \
+#define FreeLink(link) do {                        \
 	GETGC(link) = 0;                        \
 	GETGC((link)+1) = GETGC(HTcoll);        \
 	GETGC(HTcoll) = ((link) - HTcoll);      \
-}
+  } while (0)
 
 
   /* Given the contents of an HTMAIN or HTCOLL entry,
@@ -72,7 +72,7 @@
 #define GetLinkptr(entry)       ((entry) & 0x0fffffffe)
 
 
-#define DelLink(link, prev, entry) {                                    \
+#define DelLink(link, prev, entry) do {                                    \
   if ((prev) != (GCENTRY *)0)                                           \
     {                                                                   \
       GETGC((GCENTRY *)(prev) + 1) = GETGC((GCENTRY *)(link) + 1);      \
@@ -88,41 +88,41 @@
       GETGC((GCENTRY *)(entry)) = GETGC((GCENTRY *)(link));             \
       FreeLink((GCENTRY *)(link));                                      \
     }                                                                   \
-}
+  } while (0)
 
 #define RefCntP(ptr) (!(GetTypeEntry((ptr)) & TT_NOREF) &&              \
 		      (*GcDisabled_word != ATOM_T))
 
-#define GCLOOKUP(ptr, case) {                                                \
+#define GCLOOKUP(ptr, case) do {                                                \
 	if (RefCntP(ptr)) {                                                  \
 		if (*Reclaim_cnt_word != NIL)                                \
 		  htfind(ptr, case);                                         \
 		else                                                         \
 		  rec_htfind(ptr, case);                                     \
 	}                                                                    \
-}
+  } while (0)
 
-#define GCLOOKUPV(ptr, case, val) {                                          \
+#define GCLOOKUPV(ptr, case, val) do {                                          \
 	if (RefCntP(ptr)) {                                                  \
 		if (*Reclaim_cnt_word != NIL)                                \
                   (val) = htfind((ptr), (case));                             \
 		else                                                         \
                   (val) = rec_htfind((ptr), (case));                         \
 	} else (val) = NIL;                                                  \
-}
+  } while (0)
 
-#define REC_GCLOOKUP(ptr, case) { if (RefCntP(ptr)) rec_htfind(ptr, case); }
-#define REC_GCLOOKUPV(ptr, case, val) {                                      \
+#define REC_GCLOOKUP(ptr, case) do { if (RefCntP(ptr)) rec_htfind(ptr, case); } while (0)
+#define REC_GCLOOKUPV(ptr, case, val) do {                                      \
 	if (RefCntP(ptr))                                                    \
           (val) = rec_htfind((ptr), (case));                                 \
 	else                                                                 \
           (val) = NIL;                                                       \
-}
+  } while (0)
 
-#define FRPLPTR(old , new) { \
+#define FRPLPTR(old , new) do { \
 		GCLOOKUP(new, ADDREF); \
 		GCLOOKUP(old, DELREF); \
-		(old) = (new) ; }
+		(old) = (new) ; } while (0)
 
 
 #ifndef BYTESWAP

--- a/inc/lispver1.h
+++ b/inc/lispver1.h
@@ -4,7 +4,7 @@
 
 /* DOS version of LispVersionToUnixVersion */
 #define LispVersionToUnixVersion(pathname, ver)				\
-  {									\
+  do {									\
 									\
     char	*cp;						\
     char	*vp;						\
@@ -43,5 +43,5 @@
 	else ver = -1;							\
       }									\
       else ver = -1;							\
-  }
+    } while (0)
 #endif /* LISPVER1_H */

--- a/inc/lispver2.h
+++ b/inc/lispver2.h
@@ -4,7 +4,7 @@
 
 /* non-DOS version of LispVersionToUnixVersion */
 
-#define LispVersionToUnixVersion(pathname){				\
+#define LispVersionToUnixVersion(pathname) do {				\
 									\
 	char	*lv_cp;						\
 	char	*lv_vp;						\
@@ -70,5 +70,5 @@
 			lv_vp--;	/* Just for label */		\
 		}							\
 	}								\
-}
+} while (0)
 #endif /* LISPVER2_H */

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -45,24 +45,24 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			/* For getfileinfo. For WDATE&RDATE */
 			/* 29969152 == (timer.c)LISP_UNIX_TIME_DIFF */
 
-#define StrNCpyFromCToLisp(lispbuf, cbuf ,len)	{	\
+#define StrNCpyFromCToLisp(lispbuf, cbuf ,len)	do {	\
 			char *lf_sptr = (cbuf);		\
                         char *lf_dptr = (lispbuf);                      \
 			for(size_t lf_i=0;lf_i<(len);lf_i++)\
 				GETBYTE(lf_dptr++) = *lf_sptr++;		\
-		}
+  } while (0)
 
-#define StrNCpyFromLispToC(cbuf , lispbuf, len)	{	\
+#define StrNCpyFromLispToC(cbuf , lispbuf, len)	do {	\
 			char *lf_sptr = (lispbuf);                                          \
 			char *lf_dptr = (cbuf);                       \
 			for(size_t lf_i=0;lf_i<(len);lf_i++)\
 				*lf_dptr++ = GETBYTE(lf_sptr++);		\
-		}
+  } while (0)
 
-#define FGetNum(ptr, place) { \
+#define FGetNum(ptr, place) do { \
              if(((ptr) & SEGMASK)== S_POSITIVE) {(place) = ((ptr) & 0xffff);}\
         else if(((ptr) & SEGMASK)== S_NEGATIVE) {(place) = (int)((ptr)| 0xffff0000);}\
-        else {return(NIL);}}
+        else {return(NIL);}} while (0)
 
 
 /************************************************************************/
@@ -81,7 +81,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 /************************************************************************/
 #ifndef BYTESWAP
 #define	LispStringToCString(Lisp, C, MaxLen)				\
-  {									\
+  do {									\
     OneDArray	*lf_arrayp;						\
     char	*lf_base, *lf_dp;						\
     short	*lf_sbase;							\
@@ -108,10 +108,10 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	default:							\
 		error("LispStringToCString: Not a character array.\n");	\
       }									\
-  }
+ } while (0)
 #else  /* BYTESWAP == T CHANGED-BY-TAKE */
 #define	LispStringToCString(Lisp, C, MaxLen)				\
-  {									\
+  do {									\
     OneDArray	*lf_arrayp;						\
     char	*lf_base, *lf_dp;						\
     short	*lf_sbase;							\
@@ -138,7 +138,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	default:							\
 		error("LispStringToCString: Not a character array.\n");	\
       }									\
-  }
+  } while (0)
 
 #endif /* BYTESWAP */
 
@@ -154,7 +154,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 /*									*/
 /************************************************************************/
 #define	LispStringLength(LispString, Length, FatP)			\
-  {									\
+  do {									\
     OneDArray	*lf_arrayp;						\
     lf_arrayp = (OneDArray *)(NativeAligned4FromLAddr(LispString));		\
     switch(lf_arrayp->typenumber)					\
@@ -171,7 +171,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	default:							\
 		error("LispStringLength: Not a character array.\n");	\
       }									\
-  }
+    } while (0)
 
 
 
@@ -184,11 +184,11 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 /*									*/
 /************************************************************************/
 #define STRING_BASE(lstringp, cstringp) \
-  {				\
+do  {				\
 	LispPTR	*lf_naddress;				  \
 	lf_naddress = (LispPTR *)(NativeAligned4FromLAddr(lstringp));		  \
 	(cstringp) = (char *)(NativeAligned2FromLAddr(((OneDArray *)lf_naddress)->base)); \
-  }
+ } while (0)
 
 #ifndef min
 #define min(a, b) (((a) <= (b))?(a):(b))
@@ -200,23 +200,23 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 #define	UPLOWDIFF	0x20
 
-#define	DOWNCASE(name){						\
+#define	DOWNCASE(name) do {						\
 								\
 	char	*lf_cp;						\
 								\
 	for(lf_cp = (name); *lf_cp!='\0'; ++lf_cp)                      \
 	  if((*lf_cp >= 'A') && (*lf_cp <= 'Z')) *lf_cp += UPLOWDIFF;	\
-}
+  } while (0)
 
-#define	UPCASE(name){						\
+#define	UPCASE(name) do {						\
 								\
 	char	*lf_cp;					\
 								\
 	for(lf_cp = (name); *lf_cp!='\0'; ++lf_cp)                      \
 	  if((*lf_cp >= 'a') && (*lf_cp <= 'z')) *lf_cp -= UPLOWDIFF;	\
-}
+  } while (0)
 
-#define DIR_OR_FILE_P(name, type){				\
+#define DIR_OR_FILE_P(name, type) do {				\
 	int	lf_result;				\
 	struct stat	lf_statbuf;				\
 								\
@@ -244,9 +244,9 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			break;					\
 		}						\
 	}							\
-}
+  } while (0)
 
-#define	DIRP(path, dir, buf){				\
+#define	DIRP(path, dir, buf) do {				\
 	int lf_rval;					\
 	struct	stat	lf_statbuf;			\
 		strcpy(buf, path);			\
@@ -262,9 +262,9 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			*Lisp_errno = 60;		\
 			return(0);			\
 		}					\
-		}
+  } while (0)
 
-#define	FILEP(path, file, buf){				\
+#define	FILEP(path, file, buf) do {				\
 	int lf_rval;					\
 		strcpy(buf, path);			\
 		strcat(buf, file);			\
@@ -273,7 +273,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 			strcat(path, file);		\
 			return(1);			\
 		}					\
-		}
+  } while (0)
 
 #define	STREQ(name1, name2)(	\
                 (*(name1) == *(name2)) && (strcmp(name1, name2) == 0)   \
@@ -281,7 +281,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 
 #define	SPECIALFILEMARK		(-1)
 
-#define NumericStringP(str, truetag, falsetag) {			\
+#define NumericStringP(str, truetag, falsetag) do {			\
 	char	*lfn_cp;						\
 									\
         /* NOLINTNEXTLINE(bugprone-macro-parentheses) */		\
@@ -291,7 +291,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	  if(*lfn_cp < '0' || '9' < *lfn_cp)				\
 	    goto falsetag; /* NOLINT(bugprone-macro-parentheses) */	\
 	goto truetag;	/* NOLINT(bugprone-macro-parentheses) */	\
-}
+  } while (0)
 
 /*		
  * Name:	LispVersionToUnixVersion
@@ -353,7 +353,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
  * dealt with as version 1. 
  */
 
-#define UnixVersionToLispVersion(pathname, vlessp){				\
+#define UnixVersionToLispVersion(pathname, vlessp) do {				\
 										\
 	char	*start;							\
 	char	*end;							\
@@ -408,7 +408,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		/* Dealt with as version 1 unless vlessp. */			\
                 if (!(vlessp)) strcat(pathname, ";1");                          \
 	}									\
-}
+  } while (0)
 
 /*		
  * Name:	ConcDirAndName
@@ -428,7 +428,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
  *
  */
 
-#define ConcDirAndName(dir, name, fname){					\
+#define ConcDirAndName(dir, name, fname) do {					\
 									\
 	char	*lf_cp1, *lf_cp2;					\
 									\
@@ -464,7 +464,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 		strcat(fname, "/");					\
 		strcat(fname, name);					\
 	}								\
-}
+  } while (0)
 
 /*		
  * Name:	ConcNameAndVersion
@@ -483,7 +483,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
  *
  */
 
-#define ConcNameAndVersion(name, ver, rname){				\
+#define ConcNameAndVersion(name, ver, rname) do {				\
 	if (*(ver) != '\0') {						\
 		strcpy(rname, name);					\
 		strcat(rname, ".~");					\
@@ -492,7 +492,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 	} else {							\
 		strcpy(rname, name);					\
 	}								\
-}
+} while (0)
 
 #define	 VERSIONLEN		16
 
@@ -517,7 +517,7 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 /* Like "foo/fee.fee;3" or "/foo/foo;3" */
 /* AddDotNoExtension must be put after UnixVersionToLispVersion */
 
-#define	AddDotNoExtension(file){			\
+#define	AddDotNoExtension(file) do {			\
 		char	*lf_cp;			\
 		char	*lf_cp1;			\
 		if( (strrchr(file,'.')== 0) && ((lf_cp=strrchr(file,';'))!=0) ){	\
@@ -527,41 +527,41 @@ extern	DLword	*Lisp_world;	/* To access LispSysout area */
 				*lf_cp1 = *(lf_cp1-1);	\
 			*lf_cp = '.';			\
 		}					\
-		}
+  } while (0)
 
 /* An argument of RemoveDotNoExtension must be LispVersion convention */
 /* Like "foo/fee.fee;3" or "/foo/foo.;3" */
 /* RemoveDotNoExtension must be put before LispVersionToUnixVersion */
 
-#define RemoveDotNoExtension(file){					\
+#define RemoveDotNoExtension(file) do {					\
 		char	*lf_cp;					\
 		if( ((lf_cp=strrchr(file, ';'))!=0) && (*(lf_cp-1)=='.') ){	\
 			for(;*lf_cp!='\0';++lf_cp)				\
 				*(lf_cp-1) = *lf_cp;				\
 			*(lf_cp-1) = '\0';					\
 		}							\
-		}
+  } while (0)
 		
 
 extern	int	errno;
 
-#define	ChangeToVersionless(pathname){			\
+#define	ChangeToVersionless(pathname) do {			\
 		char	*lf_cp;			\
 		if( (lf_cp=strrchr(pathname, ';')) != 0)	\
 			*lf_cp = '\0';			\
-		}
+  } while (0)
 
 
-#define	UNLINK(x){					\
+#define	UNLINK(x) do {					\
 		TIMEOUT(lf_rval=unlink(x));		\
 		if(lf_rval == -1){				\
 			err_mess("unlink", errno);	\
 			*Lisp_errno = errno;		\
 			return(0);			\
 		}					\
-		}
+  } while (0)
 
-#define LINK(x,y){					\
+#define LINK(x,y) do {					\
 		TIMEOUT(lf_rval=link(x, y));		\
 		if(lf_rval == -1){				\
 			if(errno == 2)			\
@@ -572,9 +572,9 @@ extern	int	errno;
 				return(0);		\
 			}				\
 		}					\
-		}
+  } while (0)
 
-#define RENAME(x,y){					\
+#define RENAME(x,y) do {					\
 		TIMEOUT(lf_rval=rename(x, y));		\
 		if(lf_rval == -1){				\
 			switch(errno){			\
@@ -589,26 +589,26 @@ extern	int	errno;
 				return(0);		\
 			}				\
 		}					\
-		}
+  } while (0)
 
-#define	STAT(x,y){					\
+#define	STAT(x,y) do {					\
 		TIMEOUT(lf_rval=stat(x, y));		\
 		if(lf_rval != 0){				\
 			err_mess("stat", errno);	\
 			*Lisp_errno = errno;		\
 			return(-1);			\
 		}					\
-		}
+  } while (0)
 
 /*
  * For file name length check
  */
 #define FNAMETOOLONG	200
 
-#define FileNameTooLong(val) {				\
+#define FileNameTooLong(val) do {				\
 	*Lisp_errno = FNAMETOOLONG;			\
 	return((val));					\
-}
+  } while (0)
 
 
 

--- a/inc/my.h
+++ b/inc/my.h
@@ -34,7 +34,7 @@
 /*	from SMALLP or FIXP, if necessary.				*/
 /*									*/
 /************************************************************************/
-#define	N_MakeFloat(arg, dest, tos){					\
+#define	N_MakeFloat(arg, dest, tos) do {				\
 	switch (SEGMASK & (LispPTR)(arg)) {				\
 	case S_POSITIVE:						\
 		(dest) = (float)(0xFFFF & (LispPTR)(arg));		\
@@ -53,11 +53,11 @@
 		  default: ERROR_EXIT(tos);				\
 		}							\
 	}								\
-}
+} while (0)
 
 
 
-#define	N_GetPos(arg, dest, tos){					\
+#define	N_GetPos(arg, dest, tos) do {					\
 	if (((arg) & SEGMASK) == S_POSITIVE)				\
 		(dest) = (arg) & 0xFFFF;				\
 	else	{							\
@@ -65,7 +65,7 @@
 	if (((dest) = *((int *)NativeAligned4FromLAddr(arg))) & 0x80000000)	\
 		ERROR_EXIT(tos);					\
 		}							\
-	}
+} while (0)
 
 static inline LispPTR
 aref_switch(unsigned type, LispPTR tos, LispPTR baseL, int index)
@@ -117,7 +117,7 @@ aref_switch(unsigned type, LispPTR tos, LispPTR baseL, int index)
 }
 
 #define aset_switch(type, tos)						\
-{									\
+do {									\
    switch (type) {							\
       case 38: /* pointer : 32 bits */					\
 	GCLOOKUP(*(((int *)NativeAligned4FromLAddr(base)) + index), DELREF); \
@@ -178,5 +178,5 @@ aref_switch(unsigned type, LispPTR tos, LispPTR baseL, int index)
       default: /* Illegal or Unimplemented */				\
         ERROR_EXIT(tos);						\
     }/* end switch typenumber */					\
-}
+} while (0)
 #endif /* MY_H */

--- a/inc/osmsg.h
+++ b/inc/osmsg.h
@@ -18,9 +18,9 @@
 #include "osmsgdefs.h"   // for flush_pty
 
 #define	OSMESSAGE_PRINT(print_exp)		\
-  {						\
+  do {						\
     flush_pty();				\
     print_exp;					\
-  }
+  } while (0)
 
 #endif /* OSMSG_H */

--- a/inc/return.h
+++ b/inc/return.h
@@ -65,21 +65,22 @@
 /** in CONTEXTSW , for exchanging context **/
 
 #define Midpunt(fxnum) 							\
-  { DLword midpunt; 					\
+  do { DLword midpunt; 					\
     midpunt = LOLOC(LAddrFromNative(CURRENTFX));			\
     PVar=(DLword *)							\
 	    NativeAligned2FromStackOffset(					\
                         (GETWORD(((DLword *)InterfacePage) + (fxnum)))) \
 		+ FRAMESIZE; 						\
     GETWORD(((DLword *)InterfacePage) + (fxnum)) = midpunt ;		\
-  }
+  } while (0)
 
 
 #define CHECKFX							\
-  if (((UNSIGNED)PVar -(UNSIGNED)CURRENTFX) != 20)			\
+  do { if (((UNSIGNED)PVar -(UNSIGNED)CURRENTFX) != 20)          \
     { printf("Invalid FX(0x%x) and PV(0x%x) \n",		\
 	     LAddrFromNative(CURRENTFX),LAddrFromNative(PVar));	\
-    }
+    }                                                           \
+  } while (0)
 
 
 
@@ -87,16 +88,16 @@
 	that it is called by CONTEXTSW in original LISP code **/
 
 #define BEFORE_CONTEXTSW						\
-  { CurrentStackPTR += 2; 						\
+  do { CurrentStackPTR += 2; 						\
     CURRENTFX->nextblock=StackOffsetFromNative(CurrentStackPTR); 		\
     GETWORD(CurrentStackPTR)=STK_FSB_WORD; 				\
     GETWORD(CurrentStackPTR+1)= (((UNSIGNED)EndSTKP-(UNSIGNED)(CurrentStackPTR))>>1); \
     if (GETWORD(CurrentStackPTR+1) == 0) error("0-long free block."); \
-  }
+  } while (0)
 
 
 #define AFTER_CONTEXTSW							\
-  { DLword *ac_ptr68k,*ac_freeptr;					\
+  do { DLword *ac_ptr68k,*ac_freeptr;					\
     ac_ptr68k = (DLword*)NativeAligned2FromStackOffset(CURRENTFX->nextblock);	\
     if(GETWORD(ac_ptr68k) != STK_FSB_WORD) error("pre_moveframe: MP9316");	\
     CHECK_FX(CURRENTFX);						\
@@ -109,5 +110,5 @@
     CHECK_FX(CURRENTFX);						\
     S_CHECK( EndSTKP > CurrentStackPTR, 				\
 		"End of stack isn't beyond current stk pointer."); 	\
-  }
+  } while (0)
 #endif /* RETURN_H */

--- a/inc/stack.h
+++ b/inc/stack.h
@@ -305,51 +305,51 @@ typedef struct stackp {
 #define SLOWP(fx) (((FXBLOCK *)(fx))->slowp)
 #define FASTP(fx) (!SLOWP(fx))
 #define SET_FASTP_NIL(fx68k)                                       \
-  {                                                                \
+  do {                                                             \
     if (FASTP(fx68k)) {                                            \
       ((FX *)(fx68k))->blink = StackOffsetFromNative(DUMMYBF(fx68k)); \
       ((FX *)(fx68k))->clink = ((FX *)(fx68k))->alink;             \
       SLOWP(fx68k) = T;                                            \
     }                                                              \
-  }
+  } while (0)
 
 #define GETALINK(fx) ((((fx)->alink) & 0xfffe) - FRAMESIZE)
 #define SETALINK(fx, val)                                \
-  {                                                      \
+  do {                                                   \
     if (FASTP(fx)) {                                     \
       ((FX *)(fx))->blink = LAddrFromNative(DUMMYBF(fx)); \
       ((FX *)(fx))->clink = ((FX *)(fx))->alink;         \
     }                                                    \
     ((FX *)(fx))->alink = (val) + FRAMESIZE + 1;         \
-  }
+  } while (0)
 
 #define GETBLINK(fx) (SLOWP(fx) ? ((FX *)(fx))->blink : LOLOC(LAddrFromNative(DUMMYBF(fx))))
 #define SETBLINK(fx, val)                        \
-  {                                              \
+  do {                                           \
     ((FX *)(fx))->blink = (val);                 \
     if (FASTP(fx)) {                             \
       ((FX *)(fx))->clink = ((FX *)(fx))->alink; \
       SLOWP(fx) = 1;                             \
     }                                            \
-  }
+  } while (0)
 
 #define GETCLINK(fx) \
   (SLOWP(fx) ? (((FX *)(fx))->clink - FRAMESIZE) : (((FX *)(fx))->alink - FRAMESIZE))
 #define SETCLINK(fx, val)                                \
-  {                                                      \
+  do {                                                   \
     ((FX *)(fx))->clink = (val) + FRAMESIZE;             \
     if (FASTP((fx))) {                                   \
       ((FX *)(fx))->blink = LAddrFromNative(DUMMYBF(fx)); \
       SLOWP(fx) = 1;                                     \
     }                                                    \
-  }
+  } while (0)
 
 #define SETACLINK(fx, val)                                                \
-  {                                                                       \
+  do {                                                                    \
     if (FASTP(fx)) { ((FX *)(fx))->blink = LAddrFromNative(DUMMYBF(fx)); } \
     ((FX *)(fx))->clink = (val) + FRAMESIZE;                              \
     ((FX *)(fx))->alink = ((FX *)(fx))->clink + 1;                        \
-  }
+  } while (0)
 
 #ifdef BIGVM
 #define SWAP_FNHEAD
@@ -364,16 +364,16 @@ typedef struct stackp {
       POINTERMASK))
 
 #define MAKEFREEBLOCK(ptr68k, size)                                   \
-  {                                                                   \
+  do {                                                                \
     if ((size) <= 0) error("creating 0 long FSP");                    \
     *((LispPTR *)(ptr68k)) = (STK_FSB_WORD << 16) | ((DLword)(size)); \
-  }
+  } while (0)
 
 #define SETUPGUARDBLOCK(ptr68k, size)                                     \
-  {                                                                       \
+  do {                                                                    \
     if ((size) <= 0) error("creating 0 long Guard block");                \
     (*((LispPTR *)(ptr68k)) = (STK_GUARD_WORD << 16) | ((DLword)(size))); \
-  }
+  } while (0)
 
 /************************************************************************/
 /*									*/
@@ -389,24 +389,24 @@ typedef struct stackp {
 #include "testtooldefs.h"
 
 #define S_CHECK(condition, msg)                          \
-  {                                                      \
+  do {                                                   \
     if (!(condition)) {                                  \
       printf("\n\nStack check failed:  %s.\n\n", (msg)); \
       error("S_Check..");                                \
     }                                                    \
-  }
+  } while (0)
 
 #define S_WARN(condition, msg, scanptr)                                                       \
-  {                                                                                           \
+  do {                                                                                           \
     if (!(condition)) { printf("\n\nStack check failed at %p:  %s.\n\n", (scanptr), (msg)); } \
-  }
+  } while (0)
 
 #define CHECK_BF(bf68k) check_BF(bf68k)
 
 #define CHECK_FX(fx68k) check_FX(fx68k)
 
 #define PreMoveFrameCheck(fx68k)                                                \
-  {                                                                             \
+  do {                                                                          \
     LispPTR *tos_on_stack;                                                      \
     if (check_stack_rooms(fx68k) > 1000) {                                      \
       warn("moveframe:there is more than 100 words SPACE for FX");              \
@@ -416,20 +416,20 @@ typedef struct stackp {
       printf("\n");                                                             \
       stack_check(0);                                                           \
     }                                                                           \
-  }
+    } while (0)
 
 #else /* STACKCHECK */
 
 #define S_CHECK(condition, msg) \
-  {}
+  do {} while (0)
 #define S_WARN(condition, msg, scanptr) \
-  {}
+  do {} while (0)
 #define PreMoveFrameCheck(fx68k) \
-  {}
+  do {} while (0)
 #define CHECK_BF(bf68k) \
-  {}
+  do {} while (0)
 #define CHECK_FX(fx68k) \
-  {}
+  do {} while (0)
 
 #endif /* STACKCHECK */
 

--- a/inc/timeout.h
+++ b/inc/timeout.h
@@ -19,37 +19,37 @@ extern jmp_buf jmpbuf;
 extern	unsigned int TIMEOUT_TIME;
 
 #define	SETJMP(x)	\
-  {				\
+  do {				\
     if(setjmp(jmpbuf) != 0) return(x);		\
-  }
+  } while (0)
 
 #define	TIMEOUT(exp)			\
-  {			\
+  do {			\
     alarm(TIMEOUT_TIME);	\
     INTRSAFE(exp);			\
     alarm(0);		\
-  }
+  } while (0)
 
 #define	TIMEOUT0(exp)			\
-  {			\
+  do {			\
     alarm(TIMEOUT_TIME);	\
     INTRSAFE0(exp);			\
     alarm(0);		\
-  }
+  } while (0)
 
 #define	S_TOUT(exp)	\
-		alarm(TIMEOUT_TIME),\
-		(exp),			\
-		alarm(0)
+  alarm(TIMEOUT_TIME),                  \
+    (exp),                              \
+    alarm(0)
 
 #define	ERRSETJMP(rval)					\
-  {							\
+  do {							\
     if(setjmp(jmpbuf) != 0)				\
       {							\
 	*Lisp_errno = 100;				\
 	return(rval);					\
       }							\
-  }
+  } while (0)
 
 
 /************************************************************************/

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -79,6 +79,7 @@ extern int  kbd_for_makeinit;
     if (!kbd_for_makeinit) { \
     init_keyboard(0);      \
     kbd_for_makeinit = 1;  \
+    }                      \
   } while (0)
 #endif
 

--- a/src/bbtsub.c
+++ b/src/bbtsub.c
@@ -75,10 +75,11 @@ extern IOPAGE *IOPage68K;
 extern int  kbd_for_makeinit;
 
 #define init_kbd_startup   \
-  if (!kbd_for_makeinit) { \
+  do {			   \
+    if (!kbd_for_makeinit) { \
     init_keyboard(0);      \
     kbd_for_makeinit = 1;  \
-  };
+  } while (0)
 #endif
 
 #include "devif.h"
@@ -579,7 +580,7 @@ LispPTR n_new_cursorin(DLword *baseaddr, int dx, int dy, int w, int h) {
 
 #define BITBLTBITMAP_argnum 14
 #define PUNT_TO_BITBLTBITMAP                                                                  \
-  {                                                                                           \
+  do {                                                                                           \
     if (BITBLTBITMAP_index == 0xffffffff) {                                                   \
       BITBLTBITMAP_index = get_package_atom("\\PUNT.BITBLT.BITMAP", 19, "INTERLISP", 9, NIL); \
       if (BITBLTBITMAP_index == 0xffffffff) {                                                 \
@@ -590,7 +591,7 @@ LispPTR n_new_cursorin(DLword *baseaddr, int dx, int dy, int w, int h) {
     CurrentStackPTR += (BITBLTBITMAP_argnum - 1) * DLWORDSPER_CELL;                           \
     ccfuncall(BITBLTBITMAP_index, BITBLTBITMAP_argnum, 3);                                    \
     return (ATOM_T);                                                                               \
-  }
+  } while (0)
 
 LispPTR BITBLTBITMAP_index;
 /************************************************************************/
@@ -856,7 +857,7 @@ bad_arg:
 
 #define BLTSHADEBITMAP_argnum 8
 #define PUNT_TO_BLTSHADEBITMAP                                                                    \
-  {                                                                                               \
+  do {                                                                                               \
     if (BLTSHADEBITMAP_index == 0xffffffff) {                                                     \
       BLTSHADEBITMAP_index = get_package_atom("\\PUNT.BLTSHADE.BITMAP", 21, "INTERLISP", 9, NIL); \
       if (BLTSHADEBITMAP_index == 0xffffffff) {                                                   \
@@ -867,7 +868,7 @@ bad_arg:
     CurrentStackPTR += (BLTSHADEBITMAP_argnum - 1) * DLWORDSPER_CELL;                             \
     ccfuncall(BLTSHADEBITMAP_index, BLTSHADEBITMAP_argnum, 3);                                    \
     return (ATOM_T);                                                                                   \
-  }
+  } while (0)
 
 LispPTR BLTSHADEBITMAP_index;
 
@@ -1195,7 +1196,7 @@ void bltchar(LispPTR *args)
   bitblt(srcbase, dstbase, sx, dx, w, h, srcbpl, dstbpl, backwardflg, src_comp, op, gray, num_gray,
          curr_gray_line);
 #else
-  new_char_bitblt_code
+  new_char_bitblt_code;
 #endif
 
 #ifdef DISPLAYBUFFER
@@ -1238,7 +1239,7 @@ void bltchar(LispPTR *args)
 #define BLTCHAR_argnum 3
 #ifndef INIT
 #define PUNT_TO_BLTCHAR                                                                 \
-  {                                                                                     \
+  do {                                                                                     \
     if ((BLTCHAR_index == 0)) {                                                         \
       BLTCHAR_index = get_package_atom("\\MAIKO.PUNTBLTCHAR", 18, "INTERLISP", 9, NIL); \
       if (BLTCHAR_index == 0xffffffff) {                                                \
@@ -1249,10 +1250,10 @@ void bltchar(LispPTR *args)
     CurrentStackPTR += (BLTCHAR_argnum - 1) * DLWORDSPER_CELL;                          \
     ccfuncall(BLTCHAR_index, BLTCHAR_argnum, 3);                                        \
     return;                                                                             \
-  }
+  } while (0)
 #else
 #define PUNT_TO_BLTCHAR                                                                 \
-  { /* Version that is silent instead of erroring for init */                           \
+  do { /* Version that is silent instead of erroring for init */                           \
     if ((BLTCHAR_index == 0)) {                                                         \
       BLTCHAR_index = get_package_atom("\\MAIKO.PUNTBLTCHAR", 18, "INTERLISP", 9, NIL); \
       if (BLTCHAR_index == 0xffffffff) {                                                \
@@ -1263,12 +1264,12 @@ void bltchar(LispPTR *args)
     CurrentStackPTR += (BLTCHAR_argnum - 1) * DLWORDSPER_CELL;                          \
     ccfuncall(BLTCHAR_index, BLTCHAR_argnum, 3);                                        \
     return;                                                                             \
-  }
+  } while (0)
 #endif /* INIT */
 
 #define TEDIT_BLTCHAR_argnum 6
 #define PUNT_TO_TEDIT_BLTCHAR                                                             \
-  {                                                                                       \
+  do {                                                                                       \
     if (TEDIT_BLTCHAR_index == 0xffffffff) {                                              \
       TEDIT_BLTCHAR_index = get_package_atom("\\TEDIT.BLTCHAR", 14, "INTERLISP", 9, NIL); \
       if (TEDIT_BLTCHAR_index == 0xffffffff) {                                            \
@@ -1279,10 +1280,10 @@ void bltchar(LispPTR *args)
     CurrentStackPTR += (TEDIT_BLTCHAR_argnum - 1) * DLWORDSPER_CELL;                      \
     ccfuncall(TEDIT_BLTCHAR_index, TEDIT_BLTCHAR_argnum, 3);                              \
     return;                                                                               \
-  }
+  } while (0)
 
 #define FGetNum(ptr, place)                     \
-  {                                             \
+  do {                                          \
     if (((ptr)&SEGMASK) == S_POSITIVE) {        \
       (place) = ((ptr)&0xffff);                 \
     } else if (((ptr)&SEGMASK) == S_NEGATIVE) { \
@@ -1290,9 +1291,9 @@ void bltchar(LispPTR *args)
     } else {                                    \
       PUNT_TO_BLTCHAR;                          \
     }                                           \
-  }
+  } while (0)
 #define FGetNum2(ptr, place)                    \
-  {                                             \
+  do {                                          \
     if (((ptr)&SEGMASK) == S_POSITIVE) {        \
       (place) = ((ptr)&0xffff);                 \
     } else if (((ptr)&SEGMASK) == S_NEGATIVE) { \
@@ -1300,7 +1301,7 @@ void bltchar(LispPTR *args)
     } else {                                    \
       return (-1);                              \
     }                                           \
-  }
+  } while (0)
 
 LispPTR *TOPWDS68k;          /* Top of window stack's DS */
 LispPTR BLTCHAR_index;       /* Atom # for \PUNTBLTCHAR punt fn */
@@ -1406,7 +1407,7 @@ void newbltchar(LispPTR *args) {
   bitblt(srcbase, dstbase, sx, dx, w, h, srcbpl, dstbpl, backwardflg, src_comp, op, gray, num_gray,
          curr_gray_line);
 #else
-  new_char_bitblt_code
+  new_char_bitblt_code;
 #endif
 
 #ifdef DISPLAYBUFFER

--- a/src/bitblt.c
+++ b/src/bitblt.c
@@ -82,7 +82,7 @@ LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl, LispPTR tos)
   if (!kbd_for_makeinit) {
     init_keyboard(0);
     kbd_for_makeinit = 1;
-  };
+  }
 
 #endif
 
@@ -122,7 +122,7 @@ LispPTR N_OP_pilotbitblt(LispPTR pilot_bt_tbl, LispPTR tos)
   ;
 #endif /* SUNDISPLAY / DOS */
 
-  new_bitblt_code
+  new_bitblt_code;
 
 #if   DOS
       flush_display_lineregion(dx, dstbase, w, h);

--- a/src/dbgtool.c
+++ b/src/dbgtool.c
@@ -65,23 +65,27 @@ jmp_buf BT_jumpbuf;
 #define BTMAXLINE 24
 /* DOS has a 25-line screen, and getchar discards ESC for some reason */
 #define BT_morep                                              \
-  if ((BT_temp != '!') && (++BT_lines > BTMAXLINE)) {         \
-    printf("Press Return(Esc & Ret to quit, ! don't stop):"); \
-    BT_temp = getch();                                        \
-    fflush(stdin);                                            \
-    BT_lines = 0;                                             \
-    if (BT_temp == 27) longjmp(BT_jumpbuf, 1);                \
-  }
+  do {                                              	      \
+    if ((BT_temp != '!') && (++BT_lines > BTMAXLINE)) {         \
+      printf("Press Return(Esc & Ret to quit, ! don't stop):"); \
+      BT_temp = getch();                                        \
+      fflush(stdin);                                            \
+      BT_lines = 0;                                             \
+      if (BT_temp == 27) longjmp(BT_jumpbuf, 1);                \
+    }                                                           \
+  } while (0)
 #else /* DOS */
 #define BTMAXLINE 30
 #define BT_morep                                  \
-  if (++BT_lines > BTMAXLINE) {                   \
-    printf("Press Return(to quit Esc and Ret):"); \
-    BT_temp = getchar();                          \
-    fflush(stdin);                                \
-    BT_lines = 0;                                 \
-    if (BT_temp == 27) longjmp(BT_jumpbuf, 1);    \
-  }
+  do {                                            \
+    if (++BT_lines > BTMAXLINE) {                   \
+      printf("Press Return(to quit Esc and Ret):"); \
+      BT_temp = getchar();                          \
+      fflush(stdin);                                \
+      BT_lines = 0;                                 \
+      if (BT_temp == 27) longjmp(BT_jumpbuf, 1);    \
+    }                                               \
+  } while (0)
 #endif /* DOS */
 
 /***************************************************************/

--- a/src/dir.c
+++ b/src/dir.c
@@ -69,7 +69,7 @@ extern int Dummy_errno;
  */
 
 #define SetupMatch(tname, pname, text, pext, tver)   \
-  {                                                  \
+  do {                                                  \
     char *pp;                               \
                                                      \
     separate_version(tname, tver, 0);                \
@@ -87,10 +87,10 @@ extern int Dummy_errno;
       *pp = '\0';                                    \
       strcpy(pext, pp + 1);                          \
     }                                                \
-  }
+  } while (0)
 
 #define MatchP(target, name, ver, matchtag, unmatchtag)                                       \
-  {                                                                                           \
+  do {                                                                                           \
     char tname[MAXNAMLEN], text[MAXNAMLEN], tver[VERSIONLEN];                                 \
     char pname[MAXNAMLEN], pext[MAXNAMLEN];                                                   \
                                                                                               \
@@ -105,10 +105,10 @@ extern int Dummy_errno;
       goto matchtag; /* NOLINT(bugprone-macro-parentheses) */                                 \
     else                                                                                      \
       goto unmatchtag; /* NOLINT(bugprone-macro-parentheses) */                               \
-  }
+  } while (0)
 
 #define MatchP_Case(target, name, ver, matchtag, unmatchtag)                                  \
-  {                                                                                           \
+  do {                                                                                           \
     char tname[MAXNAMLEN], text[MAXNAMLEN], tver[VERSIONLEN];                                 \
     char pname[MAXNAMLEN], pext[MAXNAMLEN];                                                   \
                                                                                               \
@@ -121,7 +121,7 @@ extern int Dummy_errno;
       goto matchtag; /* NOLINT(bugprone-macro-parentheses) */                                 \
     else                                                                                      \
       goto unmatchtag; /* NOLINT(bugprone-macro-parentheses) */                               \
-  }
+  } while (0)
 
 /*
  * Name:	match_pattern
@@ -232,7 +232,7 @@ int MAXFINFO;
 #define FINFOARRAYRSIZE 16
 
 #define AllocFinfo(fp)                                                   \
-  {                                                                      \
+  do {                                                                      \
     if (FreeFinfoList != (FINFO *)NULL) {                                \
       (fp) = FreeFinfoList;                                                \
       FreeFinfoList = (fp)->next;                                          \
@@ -242,15 +242,15 @@ int MAXFINFO;
       free(fp);                                                          \
       (fp) = (FINFO *)NULL;                                                \
     }                                                                    \
-  }
+  } while (0)
 
 #define FreeFinfo(fp)                                                      \
-  {                                                                        \
+  do {                                                                        \
     FINFO *lastp;                                                 \
     for (lastp = fp; lastp->next != (FINFO *)NULL; lastp = lastp->next) {} \
     lastp->next = FreeFinfoList;                                           \
     FreeFinfoList = fp;                                                    \
-  }
+  } while (0)
 
 
 /*

--- a/src/doskbd.c
+++ b/src/doskbd.c
@@ -85,10 +85,10 @@ extern LispPTR *KEYBUFFERING68k;
 /*  of the handler, so let's do it once, correctly.)  */
 /******************************************************/
 #define ENABLE_KBD                                               \
-  {                                                              \
+  do {                                                              \
     outp(INTA00, ENDOFINTERRUPT);                                \
     outp(KBD_COMMAND_PORT, KBD_ENABLE); /* Turn kbd on again. */ \
-  }
+  } while (0)
 
 /************************************************************************/
 /*                                                                      */

--- a/src/dosmouse.c
+++ b/src/dosmouse.c
@@ -302,13 +302,13 @@ dostaking_mouse_up(int newx, int newy)
     currentmouse->Cursor.Last.width = w = currentdsp->Display.width - newx;
   } else {
     currentmouse->Cursor.Last.width = w = 16;
-  };
+  }
 
   if (currentdsp->Display.height < (newy + 16)) {
     currentmouse->Cursor.Last.height = h = currentdsp->Display.height - newy;
   } else {
     currentmouse->Cursor.Last.height = h = 16;
-  };
+  }
 
   srcbpl = currentdsp->Display.width;
   dstbpl = 16;

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2811,7 +2811,7 @@ static int make_directory(char *dir)
  */
 #ifdef DOS
 #define FindHighestVersion(varray, mentry, max_no)                                         \
-  {                                                                                        \
+  do {                                                                                        \
     FileName *centry;                                                             \
     for (centry = varray, max_no = -1; centry->version_no != LASTVERSIONARRAY; centry++) { \
       if (centry->version_no > max_no) {                                                   \
@@ -2819,10 +2819,10 @@ static int make_directory(char *dir)
         mentry = centry;                                                                   \
       }                                                                                    \
     }                                                                                      \
-  }
+    } while (0)
 #else
 #define FindHighestVersion(varray, mentry, max_no)                                        \
-  {                                                                                       \
+  do {                                                                                       \
     FileName *centry;                                                            \
     for (centry = (varray), (max_no) = 0; centry->version_no != LASTVERSIONARRAY; centry++) { \
       if (centry->version_no > (max_no)) {                                                  \
@@ -2830,7 +2830,7 @@ static int make_directory(char *dir)
         (mentry) = centry;                                                                  \
       }                                                                                   \
     }                                                                                     \
-  }
+    } while (0)
 #endif /* DOS */
 
 /*
@@ -2859,7 +2859,7 @@ static int make_directory(char *dir)
  */
 #ifdef DOS
 #define FindLowestVersion(varray, mentry, min_no)                                                  \
-  {                                                                                                \
+  do {                                                                                                \
     FileName *centry;                                                                     \
     for (centry = varray, min_no = MAXVERSION; centry->version_no != LASTVERSIONARRAY; centry++) { \
       if (centry->version_no < min_no) {                                                           \
@@ -2867,10 +2867,10 @@ static int make_directory(char *dir)
         mentry = centry;                                                                           \
       }                                                                                            \
     }                                                                                              \
-  }
+    } while (0)
 #else
 #define FindLowestVersion(varray, mentry, min_no)                                                  \
-  {                                                                                                \
+  do {                                                                                                \
     FileName *centry;                                                                     \
     for (centry = (varray), (min_no) = MAXVERSION; centry->version_no != LASTVERSIONARRAY; centry++) { \
       if (centry->version_no < (min_no) && centry->version_no != 0) {                                \
@@ -2878,7 +2878,7 @@ static int make_directory(char *dir)
         (mentry) = centry;                                                                           \
       }                                                                                            \
     }                                                                                              \
-  }
+  } while (0)
 #endif /* DOS */
 
 /*
@@ -2906,7 +2906,7 @@ static int make_directory(char *dir)
  */
 
 #define FindSpecifiedVersion(varray, sentry, ver_no)                        \
-  {                                                                         \
+  do {                                                                         \
     FileName *centry;                                              \
                                                                             \
     (sentry) = (FileName *)NULL;                                              \
@@ -2915,7 +2915,7 @@ static int make_directory(char *dir)
         (sentry) = centry;                                                    \
         break;                                                              \
       }                                                                     \
-  }
+  } while (0)
 
 /************************************************************************/
 /*									*/

--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -165,12 +165,12 @@ void flip_cursor() {
      except those who want to try building loadups.  */
 
   if (!for_makeinit) {
-    for (cnt = CURSORHEIGHT; (cnt--);) { GETWORD(word++) ^= 0xFFFF; };
-  };
+    for (cnt = CURSORHEIGHT; (cnt--);) { GETWORD(word++) ^= 0xFFFF; }
+  }
 
 #else
 
-  for (cnt = CURSORHEIGHT; (cnt--);) { GETWORD(word++) ^= 0xFFFF; };
+  for (cnt = CURSORHEIGHT; (cnt--);) { GETWORD(word++) ^= 0xFFFF; }
 
 #endif
 

--- a/src/ejlisp.c
+++ b/src/ejlisp.c
@@ -37,7 +37,7 @@
 #define CHAR_SIZE CHAR_MAXLEN *(sizeof(char) / sizeof(int))
 
 #define LStringToCString(Lisp, C, MaxLen, Len)                                                     \
-  {                                                                                                \
+  do {                                                                                                \
     OneDArray *arrayp;                                                                             \
     char *base;                                                                                    \
     short *sbase;                                                                                  \
@@ -64,10 +64,10 @@
                                                                                                    \
       default: error("LStringToCString can not handle\n");                                         \
     }                                                                                              \
-  }
+  } while (0)
 
 #define CStringToLString(C, Lisp, Len)                                                             \
-  {                                                                                                \
+  do {                                                                                                \
     OneDArray *arrayp;                                                                             \
     char *base;                                                                                    \
     short *sbase;                                                                                  \
@@ -93,18 +93,18 @@
                                                                                                    \
       default: error("CStringToLString can not handle\n");                                         \
     }                                                                                              \
-  }
+  } while (0)
 
 #define IntToFixp(C, Lisp)                                \
-  {                                                       \
+  do {                                                       \
     int *base;                                            \
                                                           \
     base = (int *)NativeAligned4FromLAddr((unsigned int)Lisp); \
     *base = C;                                            \
-  }
+  } while (0)
 
 #define ZeroFix(C)                                       \
-  {                                                      \
+  do {                                                      \
     int k, j;                                            \
                                                          \
     if (C[0] == 0 && C[1] != 0) {                        \
@@ -113,15 +113,15 @@
       }                                                  \
       C[j] = 0;                                          \
     }                                                    \
-  }
+  } while (0)
 
 #define EJLISP_SETJMP(x)       \
-  {                            \
+  do {                            \
     if (setjmp(jmpbuf) != 0) { \
       ejlisp_buf = NULL;       \
       return (x);              \
     }                          \
-  }
+  } while (0)
 
 typedef struct first_array {
   unsigned int orig : 1;

--- a/src/eqf.c
+++ b/src/eqf.c
@@ -64,12 +64,14 @@ BIGNUM  (integer that can't be represented bigger than 32 bits)
 */
 
 #define IF_IMMEDIATE(arg, doit, doitsmall)                                 \
-  switch (SEGMASK & (arg)) {                                               \
-    case ATOM_OFFSET: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
-    case S_CHARACTER: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
-    case S_POSITIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
-    case S_NEGATIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
-  }
+  do {                                                                     \
+    switch (SEGMASK & (arg)) {                                             \
+      case ATOM_OFFSET: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
+      case S_CHARACTER: doit;       /* NOLINT(bugprone-macro-parentheses) */ \
+      case S_POSITIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
+      case S_NEGATIVE: doitsmall;   /* NOLINT(bugprone-macro-parentheses) */ \
+    }                                                                      \
+  } while (0)
 
 /************************************************************************/
 /*									*/

--- a/src/ether.c
+++ b/src/ether.c
@@ -727,13 +727,13 @@ static int check_filter(u_char *buffer)
       case PacketTypeIP: return (0);
       case PacketTypeARP: return (0);
       default: return (1);
-    };
+    }
   /* my address */
   if (ether_addr_equal(buffer, ether_host)) switch (((short *)buffer)[6]) {
       case PacketTypeIP: return (0);
       case PacketTypeARP: return (0);
       default: return (1);
-    };
+    }
   return (0);
 }
 

--- a/src/foreign.c
+++ b/src/foreign.c
@@ -43,7 +43,7 @@
 /***********************************************************/
 
 #define LStringToCString(Lisp, C, MaxLen, Len)                                                     \
-  {                                                                                                \
+  do {                                                                                                \
     OneDArray *arrayp;                                                                             \
     char *base;                                                                                    \
     short *sbase;                                                                                  \
@@ -70,7 +70,7 @@
                                                                                                    \
       default: error("LStringToCString can not handle\n");                                         \
     }                                                                                              \
-  }
+  } while (0)
 
 /************************************************************************/
 /*									*/
@@ -134,7 +134,7 @@ LispPTR call_c_fn(LispPTR *args) {
   *errorflag = 0;
 
   /* Initialize the argvector */
-  for (i = 0; i < Max_Arg; i++) { intarg[i] = 0; };
+  for (i = 0; i < Max_Arg; i++) { intarg[i] = 0; }
 
   /* Test the function addr. If it is 0 we can not execute. */
   if (fnaddr == 0) {
@@ -329,7 +329,7 @@ LispPTR call_c_fn(LispPTR *args) {
                           intarg[24], intarg[25], intarg[26], intarg[27], intarg[28], intarg[29],
                           intarg[30], intarg[31]);
       return (CIntToLispInt(tmp));
-    }; break;
+    } break;
     case TYPE_CHARACTERP: {
       int tmp;
       tmp = ((PFC)fnaddr)(intarg[0], intarg[1], intarg[2], intarg[3], intarg[4], intarg[5],
@@ -339,7 +339,7 @@ LispPTR call_c_fn(LispPTR *args) {
                           intarg[24], intarg[25], intarg[26], intarg[27], intarg[28], intarg[29],
                           intarg[30], intarg[31]);
       return (S_CHARACTER | tmp);
-    }; break;
+    } break;
     case TYPE_FLOATP:
       fresult = ((PFF)fnaddr)(intarg[0], intarg[1], intarg[2], intarg[3], intarg[4], intarg[5],
                               intarg[6], intarg[7], intarg[8], intarg[9], intarg[10], intarg[11],
@@ -416,7 +416,7 @@ LispPTR smashing_c_fn(LispPTR *args) {
   valueplace = (int *)NativeAligned4FromLAddr(args[1]);
 
   /* Initialize the argvector */
-  for (i = 0; i < Max_Arg; i++) { intarg[i] = 0; };
+  for (i = 0; i < Max_Arg; i++) { intarg[i] = 0; }
 
   /* Test the function addr. If it is 0 we can not execute. */
   if (fnaddr == 0) {
@@ -597,7 +597,7 @@ LispPTR smashing_c_fn(LispPTR *args) {
                           intarg[30], intarg[31]);
       *valueplace = tmp;
       return (NIL);
-    }; break;
+    } break;
     case TYPE_CHARACTERP:
       return (S_CHARACTER |
               (((PFC)fnaddr)(intarg[0], intarg[1], intarg[2], intarg[3], intarg[4], intarg[5],
@@ -867,7 +867,7 @@ int put_c_basebyte(LispPTR *args) {
         GETBYTE((char *)(addr + (offset >> 3))) &= (~(1 << (0x7 & offset)));
       } else {
         GETBYTE((char *)(addr + (offset >> 3))) |= (1 << (0x7 & offset));
-      };
+      }
       break;
     case 1: /* byte */ GETBYTE((char *)(addr + offset)) = 0xFF & newval; break;
     case 2: /* word */
@@ -917,7 +917,7 @@ int get_c_basebyte(LispPTR *args) {
         return (ATOM_T);
       } else {
         return (NIL);
-      };
+      }
       break;
     case 1: /* byte */ return ((0xFF & (GETBYTE((char *)(addr + offset)))) | S_POSITIVE); break;
     case 2: /* word */

--- a/src/fvar.c
+++ b/src/fvar.c
@@ -492,7 +492,6 @@ LispPTR native_newframe(int slot)
             ppvar = (DLword *)newpfra2 - 1;
             /* ppvar points to IVAR field in Basic frame */
             return (*((LispPTR *)achain) = STK_HI_RET(GETWORD(ppvar) + fvaroffset));
-            ;
           default: error("Stack corrupted: bad value in name table");
         } /* end switch */
       }   /* end if */

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -128,7 +128,7 @@ LispPTR aref1(LispPTR array, int index) {
       break;
     case 38: retval = (*(((LispPTR *)NativeAligned4FromLAddr(base)) + index)); break;
     default: error("Not Implemented in gc's aref1 (other types)");
-  };
+  }
   return (retval);
 }
 

--- a/src/gccode.c
+++ b/src/gccode.c
@@ -151,8 +151,8 @@ LispPTR map_code_pointers(LispPTR codeblock, short int casep) {
         {
           REC_GCLOOKUP(reclaimed, casep);
         }
-      };
-    };
+      }
+    }
     if ((len = oplength[opnum]) >
         LONGEST_OPCODE) { /* len > biggest possible marks an unknown opcode */
       char errtext[200];
@@ -164,7 +164,7 @@ LispPTR map_code_pointers(LispPTR codeblock, short int casep) {
       oplength[opnum] = len = (((UFN *)UFNTable) + (opnum))->byte_num;
     }
     codeptr += len + 1;
-  };
+  }
 }
 
 /************************************************************************/
@@ -190,20 +190,20 @@ LispPTR remimplicitkeyhash(LispPTR item, LispPTR ik_hash_table) {
   value = Getikvalue(base, index);
   if (value != *Deleted_Implicit_Hash_Slot_word) {
     if (value != NIL) {
-      if (item == getikkey(value)) { goto found; };
+      if (item == getikkey(value)) { goto found; }
     } else
       return (NIL);
-  };
+  }
   reprobe = Reprobefn(bits, limits);
 lp:
   index = Fn16bits(index, reprobe) & limits;
   value = Getikvalue(base, index);
   if (value != *Deleted_Implicit_Hash_Slot_word) {
     if (value != NIL) {
-      if (item == getikkey(value)) { goto found; };
+      if (item == getikkey(value)) { goto found; }
     } else
       return (NIL);
-  };
+  }
   goto lp;
 found:
   /*
@@ -235,7 +235,7 @@ LispPTR reclaimcodeblock(LispPTR codebase) {
   if ((*Closure_Cache_Enabled_word != NIL) &&
       (remimplicitkeyhash(codebase, *Closure_Cache_word) != NIL)) {
     return (T);
-  };
+  }
   fnbase = (struct fnhead *)NativeAligned4FromLAddr(codebase);
   REC_GCLOOKUP((POINTERMASK & fnbase->framename), DELREF);
   if (fnbase->startpc != 0) map_code_pointers(codebase, DELREF);
@@ -260,7 +260,7 @@ int code_block_size(long unsigned int codeblock68k) {
   while (T) {
     switch (opnum = Get_BYTE(codeptr)) {
       case ENDOFX: /* -X- */ return (codeptr - initcodeptr);
-    };
+    }
     if ((len = oplength[opnum]) >
         LONGEST_OPCODE) { /* len > biggest possible marks an unknown opcode */
       char errtext[200];
@@ -272,5 +272,5 @@ int code_block_size(long unsigned int codeblock68k) {
       oplength[opnum] = len = (((UFN *)UFNTable) + (opnum))->byte_num;
     }
     codeptr += len + 1;
-  };
+  }
 }

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -123,7 +123,7 @@ int integerlength(unsigned int n) {
       n = (n >> 1);
     } while (n != 1);
     return (cnt);
-  };
+  }
 }
 
 /************* The above procedure is common !! **************************/
@@ -146,7 +146,7 @@ LispPTR findptrsbuffer(LispPTR ptr) {
       return (LAddrFromNative(bptr));
     else
       bptr = (struct buf *)NativeAligned4FromLAddr(bptr->sysnext);
-  };
+  }
   return (NIL);
 }
 
@@ -229,8 +229,8 @@ LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist) {
         rbase = (struct arrayblock *)NativeAligned4FromLAddr(*rover & POINTERMASK);
       } while (((*rover = rbase->fwd) & POINTERMASK) != (*tmprover & POINTERMASK));
       return (NIL);
-    };
-  };
+    }
+  }
   return (NIL);
 }
 
@@ -299,11 +299,11 @@ LispPTR linkblock(LispPTR base) {
         tmpbase = (struct arrayblock *)NativeAligned4FromLAddr(fbbase->bkwd);
         tmpbase->fwd = base;
         fbbase->bkwd = base;
-      };
+      }
       *freeblock = base;
       checkarrayblock(base, T, T);
-    };
-  };
+    }
+  }
   return (base);
 }
 
@@ -357,10 +357,10 @@ LispPTR arrayblockmerger(LispPTR base, LispPTR nbase) {
       narlens = minblocksize;
       arlens += shaveback;
       secondbite += shaveback;
-    };
+    }
     linkblock(makefreearrayblock(nbase + 2 * secondbite, narlens));
     narlens = 0;
-  };
+  }
   return (linkblock(makefreearrayblock(base, arlens + narlens)));
 }
 
@@ -457,7 +457,7 @@ LispPTR reclaimarrayblock(LispPTR ptr) {
       ((ARRAYBLOCKPASSWORD != base->password) || (base->inuse == NIL))) {
     error("Bad array block reclaimed--continue with 'q' but save state ASAP. \n");
     return (T);
-  };
+  }
 #endif /* ARRAYCHECK */
 
   switch (base->gctype) {
@@ -472,12 +472,12 @@ LispPTR reclaimarrayblock(LispPTR ptr) {
         tmpptr += 2;
       } while (tmpptr != btrailer);
       break;
-    };
+    }
     case CODEBLOCK_GCT:
       reclaim_p = ((reclaimcodeblock(ptr) == NIL) ? T : NIL);
 
       /* default:   No Action */
-  };
+  }
   if (reclaim_p == T)
     mergeforward(mergebackward(makefreearrayblock(ptr - ARRAYBLOCKHEADERWORDS, base->arlen)));
   return (T);

--- a/src/gchtfind.c
+++ b/src/gchtfind.c
@@ -32,21 +32,21 @@
 
 /* GetLink gets a new entry from the GC collision table */
 #define GetLink(var)                                               \
-  {                                                                \
+  do {                                                                \
     GCENTRY linkoff;                                      \
     linkoff = GETGC(HTcoll);                                       \
     if (linkoff == 0) {                                            \
       if ((linkoff = GETGC((GCENTRY *)HTcoll + 1)) >= HTCOLLMAX) { \
         disablegc1(NIL);                                           \
         return (NIL);                                              \
-      };                                                           \
+      }                                                           \
       GETGC((GCENTRY *)HTcoll + 1) = linkoff + 2;                  \
       (var) = (GCENTRY *)(HTcoll + linkoff);                       \
     } else {                                                       \
       GETGC(HTcoll) = GETGC((GCENTRY *)(HTcoll + linkoff + 1));    \
       (var) = (GCENTRY *)(HTcoll + linkoff);                       \
     }                                                              \
-  }
+  } while (0)
 
 #ifdef BIGVM
 #define HTCNTSHIFT 17           /* amount to shift to get hash table count */
@@ -81,7 +81,7 @@
  * Thus STKREF case is not needed.
  */
 #define NewEntry(entry, hiptr, casep, ptr)                              \
-  {                                                                     \
+  do {                                                                     \
     switch (casep) {                                                    \
       case ADDREF:                                                      \
         GETGC(entry) = (hiptr) | (2 << HTCNTSHIFT); /* set count = 2 */ \
@@ -94,14 +94,14 @@
       default: error("GC error: new entry touches stack bit");          \
         return NIL; /* NOT REACHED */                                   \
     }                                                                   \
-  }
+  } while (0)
 
 /*
  * RecNewEntry is called in the course of the reclamation.
  * Does not maintain the allocation count.
  */
 #define RecNewEntry(entry, hiptr, casep, ptr)                           \
-  {                                                                     \
+  do {                                                                     \
     switch (casep) {                                                    \
       case ADDREF:                                                      \
         GETGC(entry) = (hiptr) | (2 << HTCNTSHIFT); /* set count = 2 */ \
@@ -115,7 +115,7 @@
       default: error("GC error: new entry when turning off stack bit"); \
         return NIL; /* NOT REACHED */                                   \
     }                                                                   \
-  }
+  } while (0)
 
 /* ModEntry is a macro to modify an old gc hash table entry.
      entry is a pointer to the entry
@@ -131,7 +131,7 @@
  * Thus STKREF and UNSTKREF cases are not needed.
  */
 #define ModEntry(entry, contents, ptr, casep, remove)                                       \
-  {                                                                                         \
+  do {                                                                                         \
     if (((contents) & HTCNTMASK) == HTCNTMASK) { /* overflow; return non-zero */            \
       modify_big_reference_count(entry, casep, ptr);                                        \
       return NIL;                                                                           \
@@ -161,14 +161,14 @@
     }                                                                                       \
     GETGC(entry) = contents;                                                                \
     return NIL;                                                                             \
-  }
+  } while (0)
 
 /*
  * RecModEntry is called in the course of the reclamation.
  * Does not maintain the allocation count.
  */
 #define RecModEntry(entry, contents, ptr, casep, remove)                                    \
-  {                                                                                         \
+  do {                                                                                         \
     if (((contents) & HTCNTMASK) == HTCNTMASK) { /* overflow; return non-zero */            \
       modify_big_reference_count(entry, casep, ptr);                                        \
       return NIL;                                                                           \
@@ -200,7 +200,7 @@
     if (((contents) & HTCNTSTKMASK) == (1 << HTCNTSHIFT)) goto remove;                      \
     GETGC(entry) = contents;                                                                \
     return NIL;                                                                             \
-  }
+  } while (0)
 
 /************************************************************************/
 /*									*/
@@ -231,7 +231,7 @@ void enter_big_reference_count(LispPTR ptr) {
       return;
     } else
       ++oventry;
-  };
+  }
 
   if (tmp == NIL) {
     if (Evenp(LAddrFromNative(oventry + 1), DLWORDSPER_PAGE)) {

--- a/src/gcmain3.c
+++ b/src/gcmain3.c
@@ -219,7 +219,7 @@ LispPTR gcscanstack(void) {
 #endif /* BIGVM */
             Stkref(fn_head);
             fnheader = (struct fnhead *)NativeAligned4FromLAddr(fn_head);
-          };
+          }
           {
             int pcou;
             LispPTR *pvars;
@@ -230,8 +230,8 @@ LispPTR gcscanstack(void) {
               if
                 Boundp(BIND_BITS(value)) Stkref(value);
               ++pvars;
-            }; /* for */
-          };   /* int pcou */
+            } /* for */
+          }   /* int pcou */
 
           {
             UNSIGNED qtemp;
@@ -264,7 +264,7 @@ LispPTR gcscanstack(void) {
                                    (((struct fnhead *)qtemp)->ntsize) * 2);
               } else
                 Stkref(nametable);
-            }; /* frameex->validnametable */
+            } /* frameex->validnametable */
 
             obasicframe = basicframe;
             basicframe =
@@ -286,7 +286,7 @@ LispPTR gcscanstack(void) {
               if
                 Boundp(BIND_BITS(value)) Stkref(value);
               basicframe++;
-            }; /* while */
+            } /* while */
 
             if (ntend != 0) {
               obasicframe = basicframe;
@@ -303,7 +303,7 @@ LispPTR gcscanstack(void) {
               qtemp = next;
               ntend = 0;
               goto scantemps;
-            };
+            }
 
             obasicframe = basicframe;
             basicframe = (Bframe *)next;
@@ -317,10 +317,10 @@ LispPTR gcscanstack(void) {
               error(debugStr);
             }
 
-          }; /* LOCAL regs qtemp next */
-        };   /* local regs fnheader frameex */
+          } /* LOCAL regs qtemp next */
+        }   /* local regs fnheader frameex */
         break;
-      };
+      }
       case STK_GUARD: /* stack's tail ? */ {
         if ((UNSIGNED)basicframe >= (UNSIGNED)scanend68K)
           return (NIL);
@@ -336,9 +336,9 @@ LispPTR gcscanstack(void) {
                     (void *)basicframe, (void *)obasicframe);
             error(debugStr);
           }
-        };
+        }
         break;
-      };
+      }
       case STK_FSB: {
         obasicframe = basicframe;
         basicframe = (Bframe *)((DLword *)basicframe + basicframe->ivar);
@@ -353,25 +353,25 @@ LispPTR gcscanstack(void) {
         }
 
         break;
-      };
+      }
       default: /* must be basic frame !! */
       {
         LispPTR bf_word;
         while (STK_BF != BF_FLAGS(bf_word = *((LispPTR *)basicframe))) {
           Stkref(PTR_BITS(bf_word));
           basicframe++;
-        };
+        }
         basicframe++;
-      };
+      }
 
         /* **** NOTE THIS CODE DOES NOT COMPILE CORRECTLY ON THE SUN 4
            {LispPTR bf_word;
            while(STK_BF != BF_FLAGS(
            bf_word = *((LispPTR *)basicframe++)))
            { Stkref(PTR_BITS(bf_word));
-           };
-           };
+           }
+           }
            **** */
-    }; /* switch */
-  };   /* while(1) */
+    } /* switch */
+  }   /* while(1) */
 }

--- a/src/gcoflow.c
+++ b/src/gcoflow.c
@@ -37,14 +37,16 @@
 #include "lsptypes.h"     // for dtd, GetDTD, TYPE_LISTP
 
 #define Increment_Allocation_Count(n) \
-  if (*Reclaim_cnt_word != NIL) {     \
-    if (*Reclaim_cnt_word > (n))      \
-      (*Reclaim_cnt_word) -= (n);     \
-    else {                            \
-      *Reclaim_cnt_word = NIL;        \
-      doreclaim();                    \
-    }                                 \
-  }
+  do {                                \
+    if (*Reclaim_cnt_word != NIL) {     \
+      if (*Reclaim_cnt_word > (n))      \
+        (*Reclaim_cnt_word) -= (n);     \
+      else {                            \
+        *Reclaim_cnt_word = NIL;        \
+        doreclaim();                    \
+      }                                 \
+    }                                   \
+  } while (0)
 
 DLword gc_handleoverflow(DLword arg) {
   struct htoverflow *cell;
@@ -58,14 +60,14 @@ DLword gc_handleoverflow(DLword arg) {
     cell->ptr = 0;
     cell->pcase = 0;
     ++cell; /* (\ADDBASE CELL WORDSPERCELL) */
-  };
+  }
   ptr = (struct dtd *)GetDTD(TYPE_LISTP);
   /* same as "extern struct dtd *ListpDTD" */
   if ((cellcnt = ptr->dtd_cnt0) > 1024) {
     Increment_Allocation_Count(cellcnt);
     ptr->dtd_oldcnt += cellcnt;
     ptr->dtd_cnt0 = 0;
-  };
+  }
   return (arg);
 }
 
@@ -82,7 +84,7 @@ DLword gcmaptable(DLword arg) {
     cell->ptr = 0;
     cell->pcase = 0;
     ++cell; /* (\ADDBASE CELL WORDSPERCELL) */
-  };
+  }
   for (typnum = 1; typnum <= *MaxTypeNumber_word; ++typnum)
   /* applied alltype */
   {
@@ -91,7 +93,7 @@ DLword gcmaptable(DLword arg) {
       ptr->dtd_oldcnt += cellcnt;
       ptr->dtd_cnt0 = 0;
       Increment_Allocation_Count(cellcnt);
-    };
-  };
+    }
+  }
   return (arg);
 }

--- a/src/gcr.c
+++ b/src/gcr.c
@@ -149,6 +149,6 @@ void disablegc1(int noerror) {
   if ((noerror == NIL) && (*GcDisabled_word == NIL)) {
     gcinterruptstate->gcdisabled = T;
     *PENDINGINTERRUPT_word = ATOM_T;
-  };
+  }
   *GcDisabled_word = ATOM_T;
 }

--- a/src/hardrtn.c
+++ b/src/hardrtn.c
@@ -36,12 +36,12 @@
 #include "stack.h"        // for FX, frameex1, Bframe, CHECK_FX, StackWord
 
 #define MAKE_FXCOPY(fx68k)                                                                   \
-  {                                                                                          \
+  do {                                                                                          \
     BEFORE_CONTEXTSW;                                                                        \
     if (((fx68k) = (FX *)make_FXcopy(fx68k)) == 0) { return (1); /* Whole space exhausted */ } \
     AFTER_CONTEXTSW;                                                                         \
     CHECK_FX(fx68k);                                                                         \
-  }
+  } while (0)
 static FX *make_FXcopy(FX *fx68k) {
   int size;
   int nametbl_on_stk = NIL;

--- a/src/initsout.c
+++ b/src/initsout.c
@@ -457,7 +457,7 @@ void init_for_bltchar(void) {
   if (!for_makeinit) {
     BLTCHAR_index = get_package_atom("\\MAIKO.PUNTBLTCHAR", 18, IL, 9, NIL);
     TEDIT_BLTCHAR_index = get_package_atom("\\TEDIT.BLTCHAR", 14, IL, 9, NIL);
-  };
+  }
   TOPWDS68k = MakeAtom68k("\\TOPWDS");
 
 #ifdef COLOR

--- a/src/keyevent.c
+++ b/src/keyevent.c
@@ -78,28 +78,28 @@ extern IOPAGE *IOPage68K;
 
 /*  EmMouseX68K are already swapped, no need for GETWORD */
 #define MouseMove(x, y)           \
-  {                               \
+  do {                               \
     *((DLword *)EmMouseX68K) = x; \
     *((DLword *)EmMouseY68K) = y; \
-  }
+  } while (0)
 #ifdef NEVER
 #ifndef BYTESWAP
 #define PUTBASEBIT68K(base68k, offset, bitvalue)               \
-  {                                                            \
+  do {                                                            \
     if (bitvalue)                                              \
       *((DLword *)(base68k) + (((u_short)(offset)) >> 4)) |=   \
           1 << (15 - ((u_short)(offset)) % BITSPER_DLWORD);    \
     else                                                       \
       *((DLword *)(base68k) + (((u_short)(offset)) >> 4)) &=   \
           ~(1 << (15 - ((u_short)(offset)) % BITSPER_DLWORD)); \
-  }
+  } while (0)
 #else
 
 /* convert to real 68 k address, then do arithmetic, and convert
    back to i386 address pointer */
 
 #define PUTBASEBIT68K(base68k, offset, bitvalue)                       \
-  {                                                                    \
+  do {                                                                    \
     int real68kbase;                                                   \
     real68kbase = 2 ^ ((int)(base68k));                                \
     if (bitvalue)                                                      \
@@ -108,7 +108,7 @@ extern IOPAGE *IOPage68K;
     else                                                               \
       GETWORD((DLword *)(real68kbase) + (((u_short)(offset)) >> 4)) &= \
           ~(1 << (15 - ((u_short)(offset)) % BITSPER_DLWORD));         \
-  }
+  } while (0)
 #endif
 #endif /* NEVER */
 
@@ -336,22 +336,22 @@ typedef struct {
 } CURSOR;
 
 #define CursorClippingX(posx, width)                         \
-  {                                                          \
+  do {                                                       \
     if (displaywidth < ((posx) + HARD_CURSORWIDTH)) {        \
       LastCursorClippingX = (width) = displaywidth - (posx); \
     } else {                                                 \
       LastCursorClippingX = (width) = HARD_CURSORWIDTH;      \
     }                                                        \
-  }
+  } while (0)
 
 #define CursorClippingY(posy, height)                          \
-  {                                                            \
+  do {                                                         \
     if (displayheight < ((posy) + HARD_CURSORHEIGHT)) {        \
       LastCursorClippingY = (height) = displayheight - (posy); \
     } else {                                                   \
       LastCursorClippingY = (height) = HARD_CURSORHEIGHT;      \
     }                                                          \
-  }
+  } while (0)
 
 extern int displaywidth, displayheight;
 extern int DisplayInitialized;
@@ -448,7 +448,7 @@ void copy_cursor(int newx, int newy)
   dx = newx;
   w = LastCursorClippingX;
   h = LastCursorClippingY;
-  ;
+
   srcbpl = HARD_CURSORWIDTH;
   dstbpl = displaywidth;
   op = 2; /* OR-in */

--- a/src/ldeboot.c
+++ b/src/ldeboot.c
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
   } else {
     perror("lde: This Display Model does not supported\n");
     exit(-1);
-  }; /* endif( my_screen... */
+  } /* endif( my_screen... */
 
   close(FrameBufferFd);
 

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -302,7 +302,7 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
         perror("sysout_loader: can't seek sysout file");
         free(fptovp);
         exit(-1);
-      };
+      }
       lispworld_offset = GETFPTOVP(fptovp, i) * BYTESPER_PAGE;
       if (read(sysout, lispworld_scratch + lispworld_offset, BYTESPER_PAGE) == -1) {
         printf("sysout_loader: can't read sysout file at %d\n", i);
@@ -314,11 +314,11 @@ int sysout_loader(const char *sysout_file_name, int sys_size) {
         }
         free(fptovp);
         exit(-1);
-      };
+      }
 #ifdef BYTESWAP
       word_swap_page((DLword *)(lispworld_scratch + lispworld_offset), 128);
 #endif
-    };
+    }
   }
   free(fptovp);
   DBPRINT(("sysout file is read completely.\n"));

--- a/src/lineblt8.c
+++ b/src/lineblt8.c
@@ -56,7 +56,7 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
        therefore, width indicates the rest bits in source bitmap */
 
 #define LineBLT8(srcWptr, offset, width, dstLptr, op1, op2)                                \
-  {                                                                                        \
+  do {                                                                                     \
     DLword *srcw;                                                                 \
     u_int temp1;                                                                  \
     for (srcw = (srcWptr) + (offset) / BITSPERDLWORD; ((width)-BITSPERNIBBLE) >= 0;        \
@@ -116,7 +116,7 @@ unsigned int BMask_tbl[] = {0xf, 7, 3, 1};
         break;                                                                             \
       default:; /* error */                                                                \
     }           /* switch end */                                                           \
-  }             /* MACRO END */
+  } while (0)   /* MACRO END */
 
 /************************************************************************/
 /*									*/

--- a/src/llcolor.c
+++ b/src/llcolor.c
@@ -178,7 +178,7 @@ LispPTR cgfour_change_screen_mode(LispPTR which_screen)
       break;
     }
     default: { error("cgfour_change_screen_mode:Unknown mode:"); }
-  };
+  }
 
 #ifndef DISPLAYBUFFER
   pr_close(ColorFb);

--- a/src/llstk.c
+++ b/src/llstk.c
@@ -335,7 +335,7 @@ SCAN:
       while (STKWORD(scanptr68k)->flags != STK_BF) {
         S_WARN(STKWORD(scanptr68k)->flags == STK_NOTFLG, "NOTFLG not on", (void *)scanptr68k);
         scanptr68k = (StackWord *)(((DLword *)scanptr68k) + DLWORDSPER_CELL);
-      };
+      }
 
 #ifdef STACKCHECK
       if (((Bframe *)scanptr68k)->residual) {
@@ -605,7 +605,7 @@ void stack_check(StackWord *start68k) {
             WARN("StackCheck:!=STK_NOTFLG", printf("content:0x%x\n", GETWORD((DLword *)scanptr68k)));
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
-        } /* while end */;
+        } /* while end */
         CHECK_BF((Bframe *)scanptr68k);
         if (((Bframe *)scanptr68k)->residual) {
           if ((DLword *)scanptr68k != top_ivar)
@@ -774,7 +774,7 @@ void walk_stack(StackWord *start68k) {
                    GETWORD((DLword *)scanptr68k));
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
-        } /* while end */;
+        } /* while end */
         /* CHECK_BF(scanptr68k); */
         {
           Bframe *bf = (Bframe *)scanptr68k;
@@ -900,7 +900,7 @@ int quick_stack_check(void) {
             return(1);
           }
           scanptr68k = (StackWord *)((DLword *)scanptr68k + DLWORDSPER_CELL);
-        } /* while end */;
+        } /* while end */
         CHECK_BF((Bframe *)scanptr68k);
         if (((Bframe *)scanptr68k)->residual) {
           if ((DLword *)scanptr68k != top_ivar)

--- a/src/loopsops.c
+++ b/src/loopsops.c
@@ -65,21 +65,21 @@ static const char il_string[] = "INTERLISP";
 #define CLASSP(obj) (LC_TYPEP((obj), atom_class))
 
 #define INSTANCE_OR_PUNT(obj, fn, argnum)                     \
-  {                                                           \
+  do {                                                        \
     if (!LC_TYPEP((obj), atom_instance)) RETCALL(fn, argnum); \
-  }
+  } while (0)
 
 #define INSTANCE_CLASS_OR_PUNT(obj, fn, argnum)                         \
-  {                                                                     \
+  do {                                                                  \
     LispPTR tmp = DTD_FROM_LADDR(obj);                         \
     if (tmp != atom_instance && tmp != atom_class) RETCALL(fn, argnum); \
-  }
+  } while (0)
 
 #define LC_INIT \
   if (atom_instance == 0) LCinit()
 
 #define GET_IV_INDEX(objptr, iv, dest, otherwise)                 \
-  {                                                               \
+  do {                                                            \
     struct LCIVCacheEntry *ce;                           \
     LispPTR iNames = (objptr)->iNames;                   \
                                                                   \
@@ -105,7 +105,7 @@ static const char il_string[] = "INTERLISP";
         }                                                         \
       }                                                           \
     }                                                             \
-  }
+  } while (0)
 
 struct LCClass { /* class datatype */
   LispPTR metaClass, ivNames, ivDescrs, classUnitRec, localIVs, cvNames, cvDescrs, className,
@@ -206,7 +206,7 @@ LispPTR LCFetchMethodOrHelp(LispPTR object, LispPTR selector) {
           ce->selector = selector;
           return (ce->method_fn = ((LispPTR *)NativeAligned4FromLAddr(classptr->methods))[i - 1]);
         }
-      };
+      }
 
     next_class:
       if ((cur_class = car(supers)) == NIL_PTR) break;
@@ -255,7 +255,7 @@ LispPTR LCFetchMethod(LispPTR class, LispPTR selector) {
           ce->selector = selector;
           return (ce->method_fn = ((LispPTR *)NativeAligned4FromLAddr(classptr->methods))[i - 1]);
         }
-      };
+      }
 
     next_class:
       if ((cur_class = car(supers)) == NIL_PTR) break;

--- a/src/lowlev1.c
+++ b/src/lowlev1.c
@@ -50,7 +50,7 @@ LispPTR N_OP_putbitsnfd(LispPTR base, LispPTR data, int word_offset,
   if (beta > 0xFF) { error("bad beta argument to PUTBITS"); }
 #endif
 
-  if ((SEGMASK & data) != S_POSITIVE) { ERROR_EXIT(data); };
+  if ((SEGMASK & data) != S_POSITIVE) { ERROR_EXIT(data); }
 
   pword = NativeAligned2FromLAddr(base + word_offset);
   field_size = 0xF & beta;

--- a/src/lsthandl.c
+++ b/src/lsthandl.c
@@ -73,19 +73,19 @@ LispPTR fmemb(LispPTR item, LispPTR list) {
 /**********************************************************************/
 
 #define SAVE_ERROR_EXIT2(topcstk, tos) \
-  {                                    \
+  do {                                  \
     Scratch_CSTK = topcstk;            \
     ERROR_EXIT(tos);                   \
-  }
+  } while (0)
 
 #define S_N_CHECKANDCADR2(sour, dest, tos, tcstk) \
-  {                                               \
+  do {                                            \
     LispPTR parm = sour;                 \
     if (GetTypeNumber(parm) != TYPE_LISTP) {      \
       SAVE_ERROR_EXIT2(tcstk, tos);               \
     } else                                        \
       (dest) = cadr(parm);                        \
-  }
+  } while (0)
 
 LispPTR N_OP_listget(LispPTR plist, LispPTR tos) {
   struct cadr_cell cadrobj;

--- a/src/main.c
+++ b/src/main.c
@@ -304,7 +304,7 @@ int main(int argc, char *argv[])
     perror("Name of executable not found.");
   } else if (dld_init(dld_find_executable(argv[0])) != 0) {
     dld_perror("Can't init DLD.");
-  };
+  }
 #endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */
 
 #ifdef XWINDOW

--- a/src/misc7.c
+++ b/src/misc7.c
@@ -77,7 +77,7 @@ LispPTR N_OP_misc7(LispPTR arg1, LispPTR arg2, LispPTR arg3, LispPTR arg4, LispP
   case OP_ERASE: GETWORDBASEWORD(base, offset) = bmdata & ~bmmask; break;
   case OP_READ: break;
   default: GETWORDBASEWORD(base, offset) = bmdata | bmmask;
-  };
+  }
 
 
 #ifdef XWINDOW

--- a/src/mvs.c
+++ b/src/mvs.c
@@ -274,7 +274,6 @@ void simulate_unbind(FX2 *frame, int unbind_count, FX2 *returner) {
       ; /* find the binding mark */
     value = (int)*stackptr;
     lastpvar = (LispPTR *)((DLword *)frame + FRAMESIZE + 2 + GetLoWord(value));
-    ;
     bindnvalues = (~value) >> 16;
     for (value = bindnvalues; --value >= 0;) { *--lastpvar = 0xffffffff; }
     /* This line caused \NSMAIL.READ.HEADING to smash memory, */

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -143,7 +143,7 @@ gotpty:
 #ifdef DEBUG
     perror("fcntl F_SETOWN of log PTY");
 #endif
-  };
+  }
   FD_SET(LogFileFd, &LispReadFds);
   flush_pty();
 #endif

--- a/src/subr.c
+++ b/src/subr.c
@@ -498,7 +498,7 @@ void OP_subrcall(int subr_no, int argnum) {
         N_GETNUMBER(args[0], iarg, ret_nil);
         ARITH_SWITCH(LAddrFromNative(iarg), TopOfStack);
         break;
-      };
+      }
       */
       TopOfStack = NIL_PTR;
       break;

--- a/src/sxhash.c
+++ b/src/sxhash.c
@@ -220,7 +220,7 @@ static unsigned short stringequalhash(LispPTR obj) {
         return (EQHASHINGBITS(obj));
       break;
     default: return (EQHASHINGBITS(obj));
-  };
+  }
 
   if (fatp) {
     unsigned short *fat;
@@ -288,7 +288,7 @@ static unsigned short stringhash(LispPTR obj) {
         return (EQHASHINGBITS(obj));
       break;
     default: return (EQHASHINGBITS(obj));
-  }; /* switch */
+  } /* switch */
 
   if (fatp) {
     unsigned short *fat;

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -851,7 +851,7 @@ void dump_bf(Bframe *bf) {
   if (BFRAMEPTR(bf)->flags != 4) {
     printf("\nInvalid basic frame");
     return;
-  };
+  }
 
   if (BFRAMEPTR(bf)->residual) { goto printflags; }
 
@@ -885,7 +885,7 @@ void dump_fx(struct frameex1 *fx_addr68k) {
   if (fx_addr68k->flags != 6) {
     printf("\nInvalid frame,NOT FX");
     return;
-  };
+  }
 
   atomindex = get_framename((struct frameex1 *)fx_addr68k);
   printf("\n*** Frame Extension for ");
@@ -971,7 +971,7 @@ loop:
   if (fx_addr68k->alink == 0) {
     printf("\n BTV end");
     return;
-  };
+  }
 
   fx_addr68k = get_nextFX(fx_addr68k);
   goto loop;
@@ -1065,14 +1065,16 @@ jmp_buf SD_jumpbuf;
 
 #define SDMAXLINE 30
 #define SD_morep                                     \
-  if (++sdlines > SDMAXLINE) {                       \
-    int temp;                                        \
-    printf("\nPress Return:(to quit Esc and Ret):"); \
-    temp = getchar();                                \
-    fflush(stdin);                                   \
-    sdlines = 0;                                     \
-    if (temp == 27) longjmp(SD_jumpbuf, 1);          \
-  }
+  do {                                               \
+    if (++sdlines > SDMAXLINE) {                       \
+      int temp;                                        \
+      printf("\nPress Return:(to quit Esc and Ret):"); \
+      temp = getchar();                                \
+      fflush(stdin);                                   \
+      sdlines = 0;                                     \
+      if (temp == 27) longjmp(SD_jumpbuf, 1);          \
+    }                                                  \
+  } while (0)
 
 #ifndef BYTESWAP
 typedef struct stack_header {
@@ -1119,19 +1121,19 @@ void all_stack_dump(DLword start, DLword end, DLword silent)
     switch (STKHPTR(stkptr)->flags1) {
       case STK_GUARD:
       case STK_FSB:
-        if ((STKHPTR(stkptr)->flags2 != 0) || (STKHPTR(stkptr)->usecount != 0)) { goto badblock; };
+        if ((STKHPTR(stkptr)->flags2 != 0) || (STKHPTR(stkptr)->usecount != 0)) { goto badblock; }
         size = GETWORD(((DLword *)stkptr) + 1);
         if (STKHPTR(stkptr)->flags1 == STK_GUARD)
           printf("\n0x%x GUARD, size : 0x%x", LAddrFromNative(stkptr), size);
         else
           printf("\n0x%x FSB,   size : 0x%x", LAddrFromNative(stkptr), size);
 
-        if (size <= 0 || size > ((DLword *)end68k - (DLword *)stkptr)) { goto badblock; };
+        if (size <= 0 || size > ((DLword *)end68k - (DLword *)stkptr)) { goto badblock; }
 
         SD_morep;
         size = GETWORD(((DLword *)stkptr) + 1);
       checksize:
-        if (size <= 0 || size > ((DLword *)end68k - (DLword *)stkptr)) { goto badblock; };
+        if (size <= 0 || size > ((DLword *)end68k - (DLword *)stkptr)) { goto badblock; }
         stkptr = (STKH *)(((DLword *)stkptr) + size);
         break;
 
@@ -1159,15 +1161,15 @@ void all_stack_dump(DLword start, DLword end, DLword silent)
           size = EndSTKP - (DLword *)stkptr;
         } else {
           size = NativeAligned2FromLAddr(STK_OFFSET | ((FX *)stkptr)->nextblock) - (DLword *)stkptr;
-        };
+        }
         goto checksize;
       default:
         orig68k = (DLword *)stkptr;
 
         while (STKHPTR(stkptr)->flags1 != STK_BF) {
-          if (STKHPTR(stkptr)->flags1 != STK_NOTFLG) { goto badblock; };
+          if (STKHPTR(stkptr)->flags1 != STK_NOTFLG) { goto badblock; }
           stkptr = (STKH *)(((DLword *)stkptr) + DLWORDSPER_CELL);
-        };
+        }
 
         if ((BFRAMEPTR(stkptr))->residual) {
           if ((DLword *)stkptr != orig68k) {

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -506,7 +506,7 @@ int unixpathname(char *src, char *dst, int versionp, int genp)
  * in the course of the following conversion.
  */
 #ifdef DOS
-  if (versionp) LispVersionToUnixVersion(lfname, version) else version = -1;
+  if (versionp) LispVersionToUnixVersion(lfname, version); else version = -1;
 #else
   if (versionp) LispVersionToUnixVersion(lfname);
 #endif /* DOS */

--- a/src/unwind.c
+++ b/src/unwind.c
@@ -80,8 +80,8 @@ LispPTR *N_OP_unwind(LispPTR *cstkptr, LispPTR tos, int n, int keep) {
       lastpvar = (LispPTR *)(2 + PVar + (unsigned short)num);
       num = ~(num >> 16) + 1;
       for (; --num > 0;) { *--lastpvar = 0xffffffff; /* Mark as UNBOUND */ }
-    };
-  };
+    }
+  }
 
   /* endptr = cstkptr */
 
@@ -127,11 +127,11 @@ LispPTR find_the_blip(LispPTR blip, LispPTR throwp, FX *unwinder)
         }
         goto cons_result;
       } else if (var_name_in_frame == CATCH_RETURN_FROM_ATOM) {
-        if (throwp) { target = GETCLINK(target_addr); };
+        if (throwp) { target = GETCLINK(target_addr); }
         goto cons_result;
       }
     } /* if blip */
-  };  /* for */
+  }  /* for */
 
 no_result:
   return (NIL_PTR);
@@ -151,8 +151,8 @@ LispPTR variable_name_in_frame(FX *fx_addr, LispPTR code)
   name_table_base = name_ptr + ((FNHEAD *)name_table_base)->ntsize;
 
   while (value = GETWORD(name_ptr++)) do {
-      if (code == GETWORD(name_bind_ptr++)) { return (value) };
-    }; /* while */
+      if (code == GETWORD(name_bind_ptr++)) { return (value) }
+    } /* while */
   return (NIL_PTR);
 }; /* variable_name_in_frame */
 
@@ -184,11 +184,11 @@ LispPTR pvar_value_in_frame(FX *frame_addr, LispPTR atom_index)
           LispPTR slot_value = *((LispPTR *)(FRAMESIZE + (DLword *)frame_addr) +
                                           (bind_info - (FVPVAR << 8))) if (slot_value > 0) {
             return (slot_value & POINTERMASK);
-          };
-        };
-      };
+          }
+        }
+      }
       name_bind_ptr++;
-    }; /* while */
+    } /* while */
   return (NIL_PTR);
 
 }; /* pvar_value_in_frame */

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -228,11 +228,13 @@ v filename\t\tSaves the virtual memory on the filename (Not Bootable)\n\
 ?\t\t\tDisplays this summary";
 #endif /* DOS */
 
-#define ADD_RANGEP(address)                           \
-  if (((address) < 0) || (POINTERMASK < (address))) { \
-    printf("Address out of range.\n");                \
-    return (T);                                       \
-  }
+#define ADD_RANGEP(address)                             \
+  do {                                                  \
+    if (((address) < 0) || (POINTERMASK < (address))) { \
+      printf("Address out of range.\n");                \
+      return (T);                                       \
+    }                                                   \
+  } while (0)
 
 /*** URaid G vals ***/
 int URaid_scanlink = URSCAN_ALINK;

--- a/src/usrsubr.c
+++ b/src/usrsubr.c
@@ -17,9 +17,6 @@
 /** User defined subrs here.  Do NOT attempt to use this unless you FULLY
     understand the dependencies of the LDE architecture.                 **/
 
-#define DO_UFN \
-  { return (-1); }
-
 int UserSubr(int user_subr_index, int num_args, unsigned *args) {
   int result = 0;
 
@@ -29,14 +26,15 @@ int UserSubr(int user_subr_index, int num_args, unsigned *args) {
   {
     int i;
     for (i = 0; i < num_args; i++) printf("debug: arg[%d]: 0x%x\n", i, args[i]);
-  };
+  }
 
   switch (user_subr_index) {
     case 0:
       printf("sample UFN\n");
       result = args[0];
       break;
-    default: DO_UFN;
+  default:
+      return (-1); /* DO UFN */
   }
 
   return (result);

--- a/src/xc.c
+++ b/src/xc.c
@@ -199,7 +199,7 @@ void dispatch(void) {
     &&case350, &&case351, &&case352, &&case353, &&case354, &&case355, &&case356, &&case357,
     &&case360, &&case361, &&case362, &&case363, &&case364, &&case365, &&case366, &&case367,
     &&case370, &&case371, &&case372, &&case373, &&case374, &&case375, &&case376, &&case377,
-  };
+  }
 #endif
 
 #if (DOS && OPDISP)
@@ -647,7 +647,7 @@ nextopcode:
       OP_subrcall(Get_BYTE_PCMAC1, Get_BYTE_PCMAC2);
       RET;
       nextop0;
-    };
+    }
     case 0176:
     case176 : { CONTEXTSWITCH; }
     case 0177:

--- a/src/xwinman.c
+++ b/src/xwinman.c
@@ -73,7 +73,7 @@ void Set_BitGravity(XButtonEvent *event, DspInterface dsp, Window window, int gr
     case NorthEastGravity: OldWindow = dsp->NEGrav; break;
     case SouthWestGravity: OldWindow = dsp->SWGrav; break;
     case SouthEastGravity: OldWindow = dsp->SEGrav; break;
-  };
+  }
 
   dsp->BitGravity = grav;
 


### PR DESCRIPTION
Converts some problematic `#define x` macros which expanded to a `{ ... }` statement to have a `do { ... } while (0)` style so that when you use `x;` you don't get a complaint about the extra semicolon following the closing brace.
The code also had a few instances where extra semicolons were scattered in unnecessary places.

This should not change any functionality.