### PR TITLE
Improve implementation of word_swap_page() and remove unused code

### DIFF
--- a/inc/byteswapdefs.h
+++ b/inc/byteswapdefs.h
@@ -10,16 +10,6 @@ static inline unsigned int swapx(unsigned int word) {
   return (((word >> 16) & 0xffff) | ((word & 0xffff) << 16));
 }
 
-/****************************************************************/
-/*                                                              */
-/*                 Byte-swap a single 2-byte word               */
-/*                                                              */
-/****************************************************************/
-static inline unsigned short byte_swap_word(unsigned short word) {
-  return ((word >> 8) | (unsigned short)((word & 0xff) << 8));
-}
-
-void byte_swap_page(unsigned short *page, int wordcount);
 void word_swap_page(unsigned short *page, int longwordcount);
 void bit_reverse_region(unsigned short *top, int width, int height, int rasterwidth);
 #ifdef RESWAPPEDCODESTREAM

--- a/src/byteswap.c
+++ b/src/byteswap.c
@@ -19,19 +19,9 @@
 /*                                                                         */
 /***************************************************************************/
 
+#include <arpa/inet.h>
 #include "byteswapdefs.h"
 #include "lsptypes.h"
-
-/****************************************************************/
-/*                                                              */
-/*            Byte-swap a region wordcount words long           */
-/*            This does NOT swap words in a long-word!          */
-/*                                                              */
-/****************************************************************/
-void byte_swap_page(unsigned short *page, int wordcount) {
-  int i;
-  for (i = 0; i < wordcount; i++) { *(page + i) = byte_swap_word(*(page + i)); }
-}
 
 /****************************************************************/
 /*                                                              */
@@ -39,13 +29,8 @@ void byte_swap_page(unsigned short *page, int wordcount) {
 /*                                                              */
 /****************************************************************/
 void word_swap_page(unsigned short *page, int longwordcount) {
-  int i;
-  unsigned int *longpage;
-  longpage = (unsigned int *)page;
-  for (i = 0; i < (longwordcount + longwordcount); i++) {
-    *(page + i) = byte_swap_word(*(page + i));
-  }
-  for (i = 0; i < longwordcount; i++) { *(longpage + i) = swapx(*(longpage + i)); }
+  unsigned int *longpage = (unsigned int *)page;
+  for (int i = 0; i < longwordcount; i++) { *(longpage + i) = ntohl(*(longpage + i)); }
 }
 
 /****************************************************************/


### PR DESCRIPTION
  word_swap_page() should only touch each 32-bit word once to change
  the byte order from ABCD to DCBA rather than twice doing a transform
  of the entire region from ABCD to BADC and then again to DCBA

  The compiler provided ntohl() usually gets favorable optimizations
  applied, so use it for the byte reordering.

  With word_swap_page() rewritten, byte_swap_word() is superfluous.