### PR TITLE
Update github runners os matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-22.04, ubuntu-18.04]
+        os: [macos-11, macos-12, ubuntu-22.04, ubuntu-20.04]
     steps:
       - uses: actions/checkout@v2
       - name: Install X11 dependencies on MacOS
@@ -37,7 +37,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-11, ubuntu-22.04, ubuntu-20.04, ubuntu-18.04]
+        os: [macos-11, macos-12, ubuntu-22.04, ubuntu-20.04]
     env:
       BUILD_TYPE: Release
     steps:


### PR DESCRIPTION
 Update github runners os matrix to add macos-12 and replace now deprecated ubuntu-18.04 with ubuntu-20.04
