### PR TITLE
Update github workflows from actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         os: [macos-11, macos-12, ubuntu-22.04, ubuntu-20.04]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install X11 dependencies on MacOS
         if: ${{ runner.os == 'macOS'}}
         run: brew install --cask xquartz
@@ -28,7 +28,7 @@ jobs:
 #    runs-on: [self-hosted, linux, ARM]
 #    if: ${{ github.repository == 'Interlisp/maiko' }}
 #    steps:
-#      - uses: actions/checkout@v2
+#      - uses: actions/checkout@v3
 #      - name: Build
 #        working-directory: bin
 #        run: ./makeright x
@@ -41,7 +41,7 @@ jobs:
     env:
       BUILD_TYPE: Release
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install X11 dependencies on MacOS
       if: ${{ runner.os == 'macOS'}}
       run: brew install --cask xquartz

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -98,7 +98,7 @@ jobs:
     steps: 
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -129,7 +129,7 @@ jobs:
     steps:
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -137,7 +137,7 @@ jobs:
 
       # Checkout the branch  
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Setup release tag
       - name: Setup Release Tag
@@ -263,11 +263,11 @@ jobs:
 
       # Checkout the branch  
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}
@@ -336,7 +336,7 @@ jobs:
     steps: 
       # Checkout the actions for this repo owner
       - name: Checkout Actions
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.repository_owner }}/.github
           path: ./Actions_${{ github.sha }}


### PR DESCRIPTION
Deals with deprecated node.js 12 warnings.  checkout@v3 uses node.js 16.