### PR TITLE
Add a workflow to build a Docker image with all tools to build Maiko for Linux

### DIFF
--- a/.github/workflows/buildBuilderImage.yml
+++ b/.github/workflows/buildBuilderImage.yml
@@ -1,0 +1,93 @@
+#*******************************************************************************
+# buildBuilderImage.yml
+#
+# Workflow to build a multiarch Docker image that includes all of the tools for
+# building maiko for linux.  Intended to be used (exclusively?) by the github
+# actions that build maiko releases - e.g., buildRelease.yml.
+#
+# The purpose is to make the maiko github actions quicker and less resource
+# consuming by not hving to intll the tools every time and instead just reuse
+# this Docker image.
+#
+#
+# Copyright 2023 by Interlisp.org
+#
+# Frank Haasz 2023-02-21
+#
+# ******************************************************************************
+
+name: 'Build/Push Builder Image'
+
+# Run this workflow on ...
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+
+  buildBuilder:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout just the relevant Dockerfile
+      - name: Checkout files
+        uses: Bhacaz/checkout-files@v2
+        with:
+          files: .github/workflows/Dockerfile_builder
+
+      # Checkout the branch of maiko code  
+      #- name: Checkout
+      #  uses: actions/checkout@v3
+
+      # Setup docker environment variables
+      - name: Setup Docker Environment Variables
+        id: docker_env
+        run: |
+          DOCKER_REGISTRY="ghcr.io"
+          DOCKER_NAMESPACE=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          DOCKER_REPO=${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/maiko-builder
+          DOCKER_TAGS="${DOCKER_REPO}:latest
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> ${GITHUB_ENV}
+          echo "DOCKER_TAGS=${DOCKER_TAGS}" >> ${GITHUB_ENV}
+
+      # Setup the Docker Machine Emulation environment.  
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@master
+        with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+
+      # Setup the Docker Buildx funtion
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@master
+
+      # Login to ghcr.io
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Do the Docker Build using the Dockerfile_builder in the repository we
+      # checked out.  Push the result to ghcr.io.
+      #
+      - name: Build Docker Images for Push to GHCR
+        if: ${{ true }}
+        uses: docker/build-push-action@v4
+        with:
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: |
+            BUILD_DATE=${{ env.BUILD_DATE }}
+          context: ./.github/workflows
+          file: ./.github/workflows/Dockerfile_builder
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          # Push the result to DockerHub
+          push: true
+          tags: ${{ env.DOCKER_TAGS }}
+
+          
+######################################################################################


### PR DESCRIPTION
Adding a new workflow (github action) to build a multi-platform Docker image with all the tools to build Linux Maiko.  This is part of making Maiko Release build workflow much more efficient.

This just adds first-pass at said workflow.  But need to integrate this into Master now, since without the workflow in master, it will not show up in github actions for testing on the development branch.

WIll have no effect on anything unless you execute this workflow and then - if successful -- it will only create a docker image and store it in ghcr.io.