### PR TITLE
Maiko code changes needed to compile on Alpine Linux with clang. 

### DIFF
--- a/inc/dirdefs.h
+++ b/inc/dirdefs.h
@@ -1,17 +1,9 @@
 #ifndef DIRDEFS_H
 #define DIRDEFS_H 1
 
-#include <dirent.h>         // for MAXNAMLEN
-
-/* Needed for Alpine Linux */
-#ifndef MAXNAMLEN
-#include <limits.h>
-#define MAXNAMLEN NAME_MAX
-#endif
-/* End Needed for Alpine Linux */
-
 #include <sys/types.h>      // for u_short, ino_t
 #include "lispemul.h"       // for LispPTR
+#include "locfile.h"        // for MAXNAMLEN
 /*
  * FINFO and FPROP are used to store the information of the enumerated files
  * and directories.  They are arranged in a form of linked list.  Each list is

--- a/inc/dirdefs.h
+++ b/inc/dirdefs.h
@@ -1,6 +1,15 @@
 #ifndef DIRDEFS_H
 #define DIRDEFS_H 1
+
 #include <dirent.h>         // for MAXNAMLEN
+
+/* Needed for Alpine Linux */
+#ifndef MAXNAMLEN
+#include <limits.h>
+#define MAXNAMLEN NAME_MAX
+#endif
+/* End Needed for Alpine Linux */
+
 #include <sys/types.h>      // for u_short, ino_t
 #include "lispemul.h"       // for LispPTR
 /*

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -9,6 +9,7 @@
 /*									*/
 /************************************************************************/
 #include <errno.h>
+#include <limits.h>   /* for NAME_MAX */
 #include "lispemul.h" /* for DLword */
 
 #define	FDEV_PAGE_SIZE		512	/* 1 page == 512 byte */

--- a/src/ether_nethub.c
+++ b/src/ether_nethub.c
@@ -38,6 +38,12 @@
 #include "timerdefs.h"
 #include "lisp2cdefs.h"
 
+/* Needed for Alpine Linux */
+#include <sys/select.h>
+#include <sys/types.h>
+/* End Needed for Alpine Linux */
+
+
 /*
 **  --- ether implementation common data -------------------------------------------
 */

--- a/src/ether_nethub.c
+++ b/src/ether_nethub.c
@@ -14,8 +14,10 @@
 #include <string.h>
 #include <unistd.h>
 #include <sys/socket.h>
+#include <sys/select.h>
+#include <sys/types.h>
 #include <arpa/inet.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <signal.h>
 #include <fcntl.h>
 #include <errno.h>
@@ -37,12 +39,6 @@
 #include "dbprint.h"
 #include "timerdefs.h"
 #include "lisp2cdefs.h"
-
-/* Needed for Alpine Linux */
-#include <sys/select.h>
-#include <sys/types.h>
-/* End Needed for Alpine Linux */
-
 
 /*
 **  --- ether implementation common data -------------------------------------------


### PR DESCRIPTION
Switching to using Alpine Linux to compile maiko for Linux in the release build workflows.  Much more efficient than the bloated Ubuntu.

Needed to make small changes to two files to get to compile in Alpine:
1.  In inc/dirdefs.h:  MAXNAMLEN is BSD not Posix.  Posix is NAME_MAX.  So need to set MAXNAMLEN to NAME_MAX if MAXNAMLEN not defined.

2.  In src/ether_nethub.c:  need to add includes for <sys/select.h> and <sys/types.h> to get u_char, fd_set, and FD_SET defined.