### PR TITLE
Remove `USHORT` typedef.

### DIFF
--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -18,7 +18,7 @@
 */
 /**********************************************************************/
 #include "lispemul.h" /* for LispPTR, DLword */
-#include "version.h" /* for USHORT */
+#include "version.h" /* for BIGVM */
 #include "gchtfinddefs.h"
 
 #define ADDREF  0       /* for gclookup routine. */
@@ -163,10 +163,10 @@ struct  htoverflow
 #else
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT count        :6;
-    USHORT stackref     :1;
-    USHORT segnum       :8;
-    USHORT collision    :1;
+    unsigned count      :6;
+    unsigned stackref   :1;
+    unsigned segnum     :8;
+    unsigned collision  :1;
   };
 
 struct  htlinkptr
@@ -201,10 +201,10 @@ struct  htoverflow
 #ifdef BIGVM
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT collision    :1;
-    USHORT segnum       :15;
-    USHORT stackref     :1;
-    USHORT count        :15;
+    unsigned collision  :1;
+    unsigned segnum     :15;
+    unsigned stackref   :1;
+    unsigned count      :15;
   };
 
 struct  htlinkptr
@@ -232,10 +232,10 @@ struct  htoverflow
 #else
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT collision    :1;
-    USHORT segnum       :8;
-    USHORT stackref     :1;
-    USHORT count        :6;
+    unsigned collision  :1;
+    unsigned segnum     :8;
+    unsigned stackref   :1;
+    unsigned count      :6;
   };
 
 struct  htlinkptr

--- a/inc/lispemul.h
+++ b/inc/lispemul.h
@@ -273,22 +273,22 @@ struct state {
 
 /* For bit test */
 typedef struct wbits {
-  USHORT LSB : 1;
-  USHORT B14 : 1;
-  USHORT B13 : 1;
-  USHORT B12 : 1;
-  USHORT B11 : 1;
-  USHORT B10 : 1;
-  USHORT B9 : 1;
-  USHORT B8 : 1;
-  USHORT B7 : 1;
-  USHORT B6 : 1;
-  USHORT B5 : 1;
-  USHORT B4 : 1;
-  USHORT B3 : 1;
-  USHORT B2 : 1;
-  USHORT B1 : 1;
-  USHORT xMSB : 1;
+  unsigned LSB : 1;
+  unsigned B14 : 1;
+  unsigned B13 : 1;
+  unsigned B12 : 1;
+  unsigned B11 : 1;
+  unsigned B10 : 1;
+  unsigned B9 : 1;
+  unsigned B8 : 1;
+  unsigned B7 : 1;
+  unsigned B6 : 1;
+  unsigned B5 : 1;
+  unsigned B4 : 1;
+  unsigned B3 : 1;
+  unsigned B2 : 1;
+  unsigned B1 : 1;
+  unsigned xMSB : 1;
 } WBITS;
 
 typedef struct lbits {

--- a/inc/stack.h
+++ b/inc/stack.h
@@ -270,9 +270,9 @@ typedef struct basic_frame {
 } Bframe;
 
 typedef struct stkword {
-  USHORT usecount : 8;
-  USHORT nil : 5;
-  USHORT flags : 3;
+  unsigned usecount : 8;
+  unsigned nil : 5;
+  unsigned flags : 3;
 } StackWord;
 
 typedef struct stack_block {

--- a/inc/version.h
+++ b/inc/version.h
@@ -227,9 +227,6 @@ typedef unsigned char u_char;
 typedef unsigned long u_int;
 typedef unsigned short u_short;
 #undef UNALIGNED_FETCH_OK
-typedef unsigned USHORT;
-#else
-typedef unsigned short USHORT;
 #endif /* DOS */
 
 	/****************************************************************/


### PR DESCRIPTION
This was defined as `unsigned` for DOS and `unsigned short` for everyone else, but it was only used in bitfield definitions where just having `unsigned` is fine.

Other bitfield definitions (in some cases, immediately adjacent to the ones modified here), were already just using a bare `unsigned`, so this improves the consistency of the definitions.