### PR TITLE
Include for missing definition for MAXNAMLEN on Solaris

### DIFF
--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -10,6 +10,7 @@
 /************************************************************************/
 #include <errno.h>
 #include <limits.h>   /* for NAME_MAX */
+#include <dirent.h>   /* for MAXNAMLEN */
 #include "lispemul.h" /* for DLword */
 
 #define	FDEV_PAGE_SIZE		512	/* 1 page == 512 byte */


### PR DESCRIPTION
The fix to allow compiling for Alpine Linux caused breakage on Solaris because MAXNAMLEN is defined in <dirent.h> which was now NOT included. Pending a conversion to POSIX NAME_MAX, include <dirent.h> in "locfile.h".