### PR TITLE
Add "clean" as synonym for "cleanup" in ./makeright <display> cleanup

### DIFF
--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -1055,7 +1055,7 @@ $(OBJECTDIR)lpy.tab.o: $(SRCDIR)lpy.tab.c $(REQUIRED-INCS) $(INCDIR)lpdefs.h $(I
 #	.c.s. should always have -O
 ################################################################################
 
-cleanup:
+clean cleanup:
 	$(RM) -r $(OBJECTDIR) $(OSARCHDIR)
 
 .c.o:


### PR DESCRIPTION
There is no reason for the constructed makefile not to recognize "clean" as well as the original "cleanup" as target to remove the object files and executables.
