### PR TITLE
Add ctrl-shift-esc as a synonym for ctrl-shift-delete (user interrupt)

### DIFF
--- a/src/xlspwin.c
+++ b/src/xlspwin.c
@@ -352,7 +352,7 @@ do_ring:
     ((RING *)CTopKeyevent)->read = 0; /* reset queue */
     ((RING *)CTopKeyevent)->write = MINKEYEVENT;
     /*return(0);*/
-  } else if (((*EmKbdAd268K) & 2114) == 0) { /* Ctrl-Shift-DEL */
+  } else if (((*EmKbdAd268K) & 2114) == 0 || ((*EmKbdAd268K) & 18496) == 0) { /* Ctrl-Shift-DEL */
     *EmKbdAd268K = KB_ALLUP;                 /*reset*/
     URaid_req = T;
     ((RING *)CTopKeyevent)->read = 0; /* reset queue */


### PR DESCRIPTION
On a Mac laptop (without a full keyboard) it isn't easy to generate the delete in the ctrl-shift-delete user interrupt.  The esc key is in the same word and can easily be generated, so add ctrl-shift-esc as an alternative.