### PR TITLE
Workflow updates for Darwin: add SDL to release builds; enable cross-compile in makefiles; add cross-compile & universal executables to release builds ...

### DIFF
--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -309,7 +309,7 @@ jobs:
         run: |
           gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.dmg
           hdiutil attach SDL2-2.26.5.dmg
-          cp -r /Volumes/SDL2/SDL2.framework /Library/Frameworks
+          ditto /Volumes/SDL2/SDL2.framework /Library/Frameworks/SDL2.framework
           hdiutil detach /Volumes/SDL2/
 
       # Build maiko   

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -139,9 +139,9 @@ jobs:
   linux:
   
     needs: [inputs, sentry]
-    if: |
-      needs.sentry.outputs.release_not_built == 'true'
-      || needs.inputs.outputs.force == 'true'
+    if: ${{ false }}
+#      needs.sentry.outputs.release_not_built == 'true'
+#      || needs.inputs.outputs.force == 'true'
     
     runs-on: ubuntu-latest
 
@@ -297,10 +297,11 @@ jobs:
         id: tag
         uses: ./../actions/release-tag-action
 
-      # Install X11 dependencies
+      # Install X11 and SDL dependencies
       - name: Install X11 dependencies on MacOS
-        if: ${{ runner.os == 'macOS'}}
-        run: brew install --cask xquartz
+        run: |
+          brew install --cask xquartz
+          brew install SDL2
 
       # Build maiko   
       - name: Build
@@ -308,12 +309,14 @@ jobs:
         run: |
           export LDEARCH=x86_64-apple-darwin
           ./makeright x
+          ./makeright sdl
           ./makeright init
           export LDEARCH=aarch64-apple-darwin
-          ./makeright x   
+          ./makeright x
+          ./makeright sdl 
           ./makeright init
           mkdir -p ../darwin.universal
-          for exe in ldeinit lde ldex 
+          for exe in ldeinit lde ldex ldesdl 
           do
             lipo -create \
                  -arch arm64 ../darwin.aarch64/${exe}  \

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -321,8 +321,11 @@ jobs:
           brew uninstall --ignore-dependencies libx11
 
       - name: Install X11 dependencies on MacOS
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          brew install --cask xquartz
+          gh release download XQuartz-2.8.5 --repo XQuartz/XQuartz --pattern XQuartz-2.8.5.pkg
+          installer -pkg ./XQuartz-2.8.5.pkg -target /
 
       - name: List2
         run: |

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -331,11 +331,13 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 \
-                   -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
-                   -DMAIKO_DISPLAY_SDL=ON \
-                   -DMAIKO_DISPLAY_X11=ON
-          make
+# -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+          cmake .. \
+            -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+            -DMAIKO_DISPLAY_SDL=ON \
+            -DMAIKO_DISPLAY_X11=ON \ 
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --config Release
           for arch in x86_64 aarch64 universal
           do
             for exe in lde ldex ldesdl

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -315,6 +315,7 @@ jobs:
 
       - name: Install X11 dependencies on MacOS
         run: |
+          brew uninstall libx11
           brew install --cask xquartz
 
       - name: List2

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -297,15 +297,7 @@ jobs:
         id: tag
         uses: ./../actions/release-tag-action
 
-      - name: List
-        run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/include
-          ls -l /usr/local/include/X11
-          echo "---------------------------------------------------------------------"
-        continue-on-error: true
-
-      # Install X11 dependencies
+      # Uninstall exisitng X11 stuff preconfigured on runner then install correct X11 dependencies
       - name: Unistall X components already on the runner
         run: |
           brew uninstall --ignore-dependencies libxft
@@ -315,21 +307,6 @@ jobs:
           brew uninstall --ignore-dependencies xorgproto
           brew uninstall --ignore-dependencies libxdmcp
           brew uninstall --ignore-dependencies libxau
-
-      - name: List2
-        run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/include
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/include/X11
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/include/X11/dri
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/include/X11/extensions
-          echo "--------------------------------------------------------------------"
-          ls -l /usr/local/include/X11/fonts
-          echo "---------------------------------------------------------------------"
-        continue-on-error: true
 
       - name: Install X11 dependencies on MacOS
         env:
@@ -374,17 +351,11 @@ jobs:
             -DMAIKO_DISPLAY_X11=ON \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
-          for arch in x86_64 aarch64 universal
+          for exe in lde ldex ldesdl
           do
-            for exe in lde ldex ldesdl
-            do
-              if [ "${arch}" != "universal" ]
-              then 
-                lipo ${exe} -output ../darwin.${arch}/${exe} -extract ${arch}
-              else
-                cp -p ${exe} ../darwin.${arch}/${exe}
-              fi
-            done
+            lipo ${exe} -output ../darwin.x86_64/${exe} -extract x86_64
+            lipo ${exe} -output ../darwin.aarch64/${exe} -extract arm64
+            cp -p ${exe} ../darwin.universal/${exe}
           done  
 
       # Create release tar for github.

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -302,12 +302,16 @@ jobs:
         run: |
           echo "---------------------------------------------------------------------"
           ls -l /usr/local/lib/libX11*
+        continue-on-error: true
+      - run: |
+          echo "---------------------------------------------------------------------"
+          ls -l /private/var/select/X11
+        continue-on-error: true
+      - run: |
           echo "---------------------------------------------------------------------"
           ls -l /opt/X11
           echo "---------------------------------------------------------------------"
-          ls -l /private/var/select/X11
-          echo "---------------------------------------------------------------------"
-
+        continue-on-error: true
 
       - name: Install X11 dependencies on MacOS
         run: |
@@ -315,13 +319,19 @@ jobs:
 
       - name: List2
         run: |
+        run: |
           echo "---------------------------------------------------------------------"
           ls -l /usr/local/lib/libX11*
+        continue-on-error: true
+      - run: |
+          echo "---------------------------------------------------------------------"
+          ls -l /private/var/select/X11
+        continue-on-error: true
+      - run: |
           echo "---------------------------------------------------------------------"
           ls -l /opt/X11
           echo "---------------------------------------------------------------------"
-          ls -l /private/var/select/X11
-          echo "---------------------------------------------------------------------"
+        continue-on-error: true
 
       # Install SDL dependencies
       - name: Install SDL2 dependencies on MacOS

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -309,7 +309,7 @@ jobs:
         run: |
           gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.dmg
           hdiutil attach SDL2-2.26.5.dmg
-          ditto /Volumes/SDL2/SDL2.framework /Library/Frameworks/SDL2.framework
+          sudo ditto /Volumes/SDL2/SDL2.framework /Library/Frameworks/SDL2.framework
           hdiutil detach /Volumes/SDL2/
 
       # Build maiko   

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -306,17 +306,17 @@ jobs:
       - name: Build
         working-directory: ./bin
         run: |
-          export LDEARCH=x86_64
+          export LDEARCH=x86_64-apple-darwin
           ./makeright x
           ./makeright init
-          export LDEARCH=aarch64
+          export LDEARCH=aarch64-apple-darwin
           ./makeright x   
           ./makeright init
           mkdir -p ../darwin.universal
           for exe in ldeinit lde ldex 
           do
             lipo -create \
-                 -arch arm64 ../darwin.aarch64/$exe}  \
+                 -arch arm64 ../darwin.aarch64/${exe}  \
                  -arch x86_64 ../darwin.x86_64/${exe} \
                  -output ../darwin.universal/${exe}
           done

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -27,6 +27,12 @@ env:
 on: 
     workflow_dispatch:
       inputs:
+        draft:
+          description: "Mark this as a draft release"
+          type: choice
+          options:
+          - 'false'
+          - 'true'
         force:
           description: "Force build even if build already successfully completed for this commit"
           type: choice
@@ -45,6 +51,11 @@ on:
           description: "'True' if maiko build completed successully"
           value: ${{ jobs.complete.outputs.build_successful }}
       inputs:
+        draft:
+          description: "Mark this as a draft release"
+          required: false
+          type: string
+          default: 'false'
         force:
           description: "Force build even if build already successfully completed for this commit"
           required: false
@@ -60,7 +71,8 @@ defaults:
 #  1.  Linux: Build/push a multiplatform Linux Docker image and use results to
 #      build/push Linux release assets.
 #
-#  2.  MacOs_x86_64:  Build maiko for MacOS on X86_64 then create and push release assets.
+#  2.  MacOs:  Build maiko for MacOS (x86_64, aarch64, and universal)  then create
+#      and push release assets.
 #
 
 jobs:
@@ -73,13 +85,20 @@ jobs:
   inputs:
     runs-on: ubuntu-latest
     outputs:
-      force: ${{ steps.force.outputs.force }}
+      draft: ${{ steps.one.outputs.draft }}
+      force: ${{ steps.one.outputs.force }}
     steps:
-      - id: force
+      - id: one
         run: >
           if [ '${{ toJSON(inputs) }}' = 'null'  ];
-          then echo ::set-output name=force::'${{ github.event.inputs.force }}'; echo "workflow_dispatch";
-          else echo ::set-output name=force::'${{ inputs.force }}'; echo "workflow_call";
+          then
+              echo "workflow_dispatch";
+              echo "draft=${{ github.event.inputs.draft }}" >> $GITHUB_OUTPUT;
+              echo "force=${{ github.event.inputs.force }}" >> $GITHUB_OUTPUT;
+          else
+              echo "workflow_call";
+              echo "draft=${{ inputs.draft }}" >> $GITHUB_OUTPUT;
+              echo "force=${{ inputs.force }}" >> $GITHUB_OUTPUT;
           fi
         
 
@@ -234,7 +253,7 @@ jobs:
 
       # Push Release to github
       - name: Push the release
-        uses: ncipollo/release-action@v1.8.10
+        uses: ncipollo/release-action@v1
         with: 
           allowUpdates: true
           artifacts:
@@ -242,22 +261,22 @@ jobs:
             /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-linux.aarch64.tgz,
             /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-linux.armv7l.tgz
           tag: ${{ steps.tag.outputs.release_tag }}
-          draft: true
+          draft: ${{ needs.inputs.outputs.draft }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
 
 ######################################################################################
 
-  # MacOS: build for MacOS (X86_64) and use results to
+  # MacOS: build for MacOS (x86_64, aarch64, universal) and use results to
   # create and push release assets to github
-  macos_x86_64:
+  macos:
 
     needs: [inputs, sentry]
     if: |
       needs.sentry.outputs.release_not_built == 'true'
       || needs.inputs.outputs.force == 'true'
 
-    runs-on: macos-10.15
+    runs-on: macos-latest
 
     steps:
 
@@ -287,8 +306,20 @@ jobs:
       - name: Build
         working-directory: ./bin
         run: |
+          export LDEARCH=x86_64
           ./makeright x
           ./makeright init
+          export LDEARCH=aarch64
+          ./makeright x   
+          ./makeright init
+          mkdir -p ../darwin.universal
+          for exe in ldeinit lde ldex 
+          do
+            lipo -create \
+                 -arch arm64 ../darwin.aarch64/$exe}  \
+                 -arch x86_64 ../darwin.x86_64/${exe} \
+                 -output ../darwin.universal/${exe}
+          done
 
       # Create release tar for github.
       - name: Make release tar(s)
@@ -296,25 +327,29 @@ jobs:
           RELEASE_TAG: ${{ steps.tag.outputs.release_tag }}
         run: |
           mkdir -p /tmp/release_tars
-          pushd ${GITHUB_WORKSPACE}/../ >/dev/null
-          tar -c -z                                                       \
-            -f /tmp/release_tars/${RELEASE_TAG}-darwin.x86_64.tgz                  \
-            maiko/bin/osversion                                                    \
-            maiko/bin/machinetype                                                  \
-            maiko/bin/config.guess                                                 \
-            maiko/bin/config.sub                                                   \
-            maiko/darwin.x86_64/lde*
-          popd >/dev/null
+          cd ${GITHUB_WORKSPACE}/../
+          for arch in x86_64 aarch64 universal
+          do
+            tar -c -z                                                                \
+              -f /tmp/release_tars/${RELEASE_TAG}-darwin.${arch}.tgz                 \
+              maiko/bin/osversion                                                    \
+              maiko/bin/machinetype                                                  \
+              maiko/bin/config.guess                                                 \
+              maiko/bin/config.sub                                                   \
+              maiko/darwin.${arch}/lde*
+          done
 
       # Push Release
       - name: Push the release
-        uses: ncipollo/release-action@v1.8.10
+        uses: ncipollo/release-action@v1
         with: 
           allowUpdates: true
           artifacts:
-            /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-darwin.x86_64.tgz
+            /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-darwin.x86_64.tgz,
+            /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-darwin.aarch64.tgz,
+            /tmp/release_tars/${{ steps.tag.outputs.release_tag }}-darwin.universal.tgz
           tag: ${{ steps.tag.outputs.release_tag }}
-          draft: true
+          draft: ${{ needs.inputs.outputs.draft }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
 
@@ -331,7 +366,7 @@ jobs:
     outputs:
       build_successful: ${{ steps.output.outputs.build_successful }}
 
-    needs: [inputs, sentry, linux, macos_x86_64]
+    needs: [inputs, sentry, linux, macos]
 
     steps: 
       # Checkout the actions for this repo owner

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -326,12 +326,12 @@ jobs:
                -arch arm64 ../darwin.aarch64/${exe}  \
                -arch x86_64 ../darwin.x86_64/${exe} \
                -output ../darwin.universal/${exe}
-      
+
       - name: Build lde, ldex, & ldesdl
         run: |
           mkdir build
           cd build
-# -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
+          # -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12
           cmake .. \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DMAIKO_DISPLAY_SDL=ON \

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -309,8 +309,7 @@ jobs:
         run: |
           gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.dmg
           hdiutil attach SDL2-2.26.5.dmg
-          cd /Volumes/SDL2/
-          cp SDL2.framework /Library/Frameworks
+          cp -r /Volumes/SDL2/SDL2.framework /Library/Frameworks
           hdiutil detach /Volumes/SDL2/
 
       # Build maiko   

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -313,9 +313,15 @@ jobs:
           echo "---------------------------------------------------------------------"
         continue-on-error: true
 
+      - name: Unistall X components already on the runner
+        run: |
+          brew uninstall --ignore-dependencies libxft
+          brew uninstall --ignore-dependencies libxrender
+          brew uninstall --ignore-dependencies libxext
+          brew uninstall --ignore-dependencies libx11
+
       - name: Install X11 dependencies on MacOS
         run: |
-          brew uninstall libx11
           brew install --cask xquartz
 
       - name: List2

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -171,8 +171,8 @@ jobs:
           echo "DOCKER_NAMESPACE=${DOCKER_NAMESPACE}" >> ${GITHUB_ENV}
           DOCKER_IMAGE=${DOCKER_NAMESPACE}/${{ steps.tag.outputs.repo_name }}
           DOCKER_TAGS="${DOCKER_IMAGE}:latest,${DOCKER_IMAGE}:${RELEASE_TAG#*-}"
-          echo ::set-output name=build_time::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-          echo ::set-output name=docker_tags::${DOCKER_TAGS}
+          echo "build_time=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
+          echo "docker_tags=${DOCKER_TAGS}"  >> $GITHUB_OUTPUT
 
       # Setup the Docker Machine Emulation environment.  
       - name: Set up QEMU
@@ -187,7 +187,7 @@ jobs:
 
       # Login into DockerHub - required to store the created image
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -201,7 +201,7 @@ jobs:
       #
       - name: Build Docker Image for Push to Docker Hub
         if: ${{ true }}
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
@@ -217,7 +217,7 @@ jobs:
       # Redo the Docker Build (hopefully mostly using the cache from the previous build).
       # But save the results in a directory under /tmp to be used for creating release tars.
       - name: Rebuild Docker Image For Saving Locally
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           builder: ${{ steps.buildx.outputs.name }}
           build-args: |
@@ -387,6 +387,7 @@ jobs:
       - name: Output
         id: output
         run: |
-          echo ::set-output name=build_successful::'true'
+          echo "build_successful=true"  >> $GITHUB_OUTPUT
+
           
 ######################################################################################

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -312,12 +312,22 @@ jobs:
           brew uninstall --ignore-dependencies libxrender
           brew uninstall --ignore-dependencies libxext
           brew uninstall --ignore-dependencies libx11
+          brew uninstall --ignore-dependencies xorgproto
+          brew uninstall --ignore-dependencies libxdmcp
+          brew uninstall --ignore-dependencies libxau
 
       - name: List2
         run: |
           echo "---------------------------------------------------------------------"
           ls -l /usr/local/include
+          echo "---------------------------------------------------------------------"
           ls -l /usr/local/include/X11
+          echo "---------------------------------------------------------------------"
+          ls -l /usr/local/include/X11/dri
+          echo "---------------------------------------------------------------------"
+          ls -l /usr/local/include/X11/extensions
+          echo "--------------------------------------------------------------------"
+          ls -l /usr/local/include/X11/fonts
           echo "---------------------------------------------------------------------"
         continue-on-error: true
 

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -304,6 +304,8 @@ jobs:
 
       # Install SDL dependencies
       - name: Install SDL2 dependencies on MacOS
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.dmg
           hdiutil attach SDL2-2.26.5.dmg

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -325,7 +325,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release download XQuartz-2.8.5 --repo XQuartz/XQuartz --pattern XQuartz-2.8.5.pkg
-          installer -pkg ./XQuartz-2.8.5.pkg -target /
+          sudo installer -pkg ./XQuartz-2.8.5.pkg -target /
 
       - name: List2
         run: |

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -313,25 +313,41 @@ jobs:
           hdiutil detach /Volumes/SDL2/
 
       # Build maiko   
-      - name: Build
+      - name: Build ldeinit
         working-directory: ./bin
         run: |
           export LDEARCH=x86_64-apple-darwin
-          ./makeright x
-          ./makeright sdl
           ./makeright init
           export LDEARCH=aarch64-apple-darwin
-          ./makeright x
-          ./makeright sdl 
           ./makeright init
           mkdir -p ../darwin.universal
-          for exe in ldeinit lde ldex ldesdl 
+          exe=ldeinit 
+          lipo -create \
+               -arch arm64 ../darwin.aarch64/${exe}  \
+               -arch x86_64 ../darwin.x86_64/${exe} \
+               -output ../darwin.universal/${exe}
+      
+      - name: Build lde, ldex, & ldesdl
+        run: |
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_OSX_DEPLOYMENT_TARGET=10.12 \
+                   -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
+                   -DMAIKO_DISPLAY_SDL=ON \
+                   -DMAIKO_DISPLAY_X11=ON
+          make
+          for arch in x86_64 aarch64 universal
           do
-            lipo -create \
-                 -arch arm64 ../darwin.aarch64/${exe}  \
-                 -arch x86_64 ../darwin.x86_64/${exe} \
-                 -output ../darwin.universal/${exe}
-          done
+            for exe in lde ldex ldesdl
+            do
+              if [ "${arch}" != "universal" ]
+              then 
+                lipo ${exe} -output ../darwin.${arch}/${exe} -extract ${arch}
+              else
+                cp -p ${exe} ../darwin.${arch}/${exe}
+              fi
+            done
+          done  
 
       # Create release tar for github.
       - name: Make release tar(s)

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -335,7 +335,7 @@ jobs:
           cmake .. \
             -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" \
             -DMAIKO_DISPLAY_SDL=ON \
-            -DMAIKO_DISPLAY_X11=ON \ 
+            -DMAIKO_DISPLAY_X11=ON \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build . --config Release
           for arch in x86_64 aarch64 universal

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -319,7 +319,6 @@ jobs:
 
       - name: List2
         run: |
-        run: |
           echo "---------------------------------------------------------------------"
           ls -l /usr/local/lib/libX11*
         continue-on-error: true

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -297,11 +297,19 @@ jobs:
         id: tag
         uses: ./../actions/release-tag-action
 
-      # Install X11 and SDL dependencies
+      # Install X11 dependencies
       - name: Install X11 dependencies on MacOS
         run: |
           brew install --cask xquartz
-          brew install SDL2
+
+      # Install SDL dependencies
+      - name: Install SDL2 dependencies on MacOS
+        run: |
+          gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.dmg
+          hdiutil attach SDL2-2.26.5.dmg
+          cd /Volumes/SDL2/
+          cp SDL2.framework /Library/Frameworks
+          hdiutil detach /Volumes/SDL2/
 
       # Build maiko   
       - name: Build

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -297,22 +297,15 @@ jobs:
         id: tag
         uses: ./../actions/release-tag-action
 
-      # Install X11 dependencies
       - name: List
         run: |
           echo "---------------------------------------------------------------------"
-          ls -l /usr/local/lib/libX11*
-        continue-on-error: true
-      - run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /private/var/select/X11
-        continue-on-error: true
-      - run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /opt/X11
+          ls -l /usr/local/include
+          ls -l /usr/local/include/X11
           echo "---------------------------------------------------------------------"
         continue-on-error: true
 
+      # Install X11 dependencies
       - name: Unistall X components already on the runner
         run: |
           brew uninstall --ignore-dependencies libxft
@@ -320,27 +313,20 @@ jobs:
           brew uninstall --ignore-dependencies libxext
           brew uninstall --ignore-dependencies libx11
 
+      - name: List2
+        run: |
+          echo "---------------------------------------------------------------------"
+          ls -l /usr/local/include
+          ls -l /usr/local/include/X11
+          echo "---------------------------------------------------------------------"
+        continue-on-error: true
+
       - name: Install X11 dependencies on MacOS
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release download XQuartz-2.8.5 --repo XQuartz/XQuartz --pattern XQuartz-2.8.5.pkg
           sudo installer -pkg ./XQuartz-2.8.5.pkg -target /
-
-      - name: List2
-        run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /usr/local/lib/libX11*
-        continue-on-error: true
-      - run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /private/var/select/X11
-        continue-on-error: true
-      - run: |
-          echo "---------------------------------------------------------------------"
-          ls -l /opt/X11
-          echo "---------------------------------------------------------------------"
-        continue-on-error: true
 
       # Install SDL dependencies
       - name: Install SDL2 dependencies on MacOS

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -139,9 +139,9 @@ jobs:
   linux:
   
     needs: [inputs, sentry]
-    if: ${{ false }}
-#      needs.sentry.outputs.release_not_built == 'true'
-#      || needs.inputs.outputs.force == 'true'
+    if: |
+      needs.sentry.outputs.release_not_built == 'true'
+      || needs.inputs.outputs.force == 'true'
     
     runs-on: ubuntu-latest
 

--- a/.github/workflows/buildReleaseInclDocker.yml
+++ b/.github/workflows/buildReleaseInclDocker.yml
@@ -298,9 +298,30 @@ jobs:
         uses: ./../actions/release-tag-action
 
       # Install X11 dependencies
+      - name: List
+        run: |
+          echo "---------------------------------------------------------------------"
+          ls -l /usr/local/lib/libX11*
+          echo "---------------------------------------------------------------------"
+          ls -l /opt/X11
+          echo "---------------------------------------------------------------------"
+          ls -l /private/var/select/X11
+          echo "---------------------------------------------------------------------"
+
+
       - name: Install X11 dependencies on MacOS
         run: |
           brew install --cask xquartz
+
+      - name: List2
+        run: |
+          echo "---------------------------------------------------------------------"
+          ls -l /usr/local/lib/libX11*
+          echo "---------------------------------------------------------------------"
+          ls -l /opt/X11
+          echo "---------------------------------------------------------------------"
+          ls -l /private/var/select/X11
+          echo "---------------------------------------------------------------------"
 
       # Install SDL dependencies
       - name: Install SDL2 dependencies on MacOS

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ cmake-build-*/**
 *.aarch64-x/**
 *.aarch64/**
 init.386/**
+*.universal/**
 # core files
 core
 *.core

--- a/bin/makefile-darwin.aarch64-sdl
+++ b/bin/makefile-darwin.aarch64-sdl
@@ -1,6 +1,6 @@
-# Options for MacOS, x86 processor, SDL
+# Options for MacOS, arm64 (aka aarch64) processor, SDL
 
-CC = clang $(CLANG_CFLAGS)
+CC = clang -target aarch64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)sdl.o
 

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -1,6 +1,6 @@
-# Options for MacOS, arm64 (aka aarch64)  processor, X windows
+# Options for MacOS, arm64 (aka aarch64) processor, X windows
 
-CC = clang  -target aarch64-apple-darwin $(CLANG_CFLAGS)
+CC = clang -target aarch64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -1,6 +1,6 @@
-# Options for MacOS, x86 processor, X windows
+# Options for MacOS, arm64 (aka aarch64)  processor, X windows
 
-CC = clang $(CLANG_CFLAGS)
+CC = clang  -target arm64-apple-darwin13 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.aarch64-x
+++ b/bin/makefile-darwin.aarch64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, arm64 (aka aarch64)  processor, X windows
 
-CC = clang  -target arm64-apple-darwin13 $(CLANG_CFLAGS)
+CC = clang  -target aarch64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.x86_64-sdl
+++ b/bin/makefile-darwin.x86_64-sdl
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, SDL
 
-CC = clang -m64 $(CLANG_CFLAGS)
+CC = clang -m64 -target x86_64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)sdl.o
 

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -target x86_64-apple-darwin13 $(CLANG_CFLAGS)
+CC = clang -target x86_64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-darwin.x86_64-x
+++ b/bin/makefile-darwin.x86_64-x
@@ -1,6 +1,6 @@
 # Options for MacOS, x86 processor, X windows
 
-CC = clang -m64 $(CLANG_CFLAGS)
+CC = clang -target x86_64-apple-darwin13 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \
@@ -26,3 +26,4 @@ LDELDFLAGS =  -L/opt/X11/lib -lX11 -lm
 OBJECTDIR = ../$(RELEASENAME)/
 
 default	: ../$(OSARCHNAME)/lde ../$(OSARCHNAME)/ldex
+

--- a/bin/makefile-init-darwin.aarch64
+++ b/bin/makefile-init-darwin.aarch64
@@ -1,6 +1,6 @@
 # Options for MacOS, aarch64 processor, X windows, for INIT processing
 
-CC = clang -target arm64-apple-darwin13 $(CLANG_CFLAGS)
+CC = clang -target aarch64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
         $(OBJECTDIR)xbbt.o \

--- a/bin/makefile-init-darwin.aarch64
+++ b/bin/makefile-init-darwin.aarch64
@@ -1,6 +1,6 @@
 # Options for MacOS, aarch64 processor, X windows, for INIT processing
 
-CC = clang $(CLANG_CFLAGS)
+CC = clang -target arm64-apple-darwin13 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
         $(OBJECTDIR)xbbt.o \

--- a/bin/makefile-init-darwin.x86_64
+++ b/bin/makefile-init-darwin.x86_64
@@ -1,6 +1,6 @@
 # Options for MacOS, x86_64 processor, X windows, for INIT processing
 
-CC = clang -m64 $(CLANG_CFLAGS)
+CC = clang -m64 -target x86_64-apple-darwin13 $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makefile-init-darwin.x86_64
+++ b/bin/makefile-init-darwin.x86_64
@@ -1,6 +1,6 @@
 # Options for MacOS, x86_64 processor, X windows, for INIT processing
 
-CC = clang -m64 -target x86_64-apple-darwin13 $(CLANG_CFLAGS)
+CC = clang -m64 -target x86_64-apple-darwin $(CLANG_CFLAGS)
 
 XFILES = $(OBJECTDIR)xmkicon.o \
 	$(OBJECTDIR)xbbt.o \

--- a/bin/makeright
+++ b/bin/makeright
@@ -54,9 +54,30 @@ if test $# -gt 0
 	shift
 fi
 
+target_arch="$1"
+
+if test $# -gt 0
+    then
+	shift
+fi
+
 architecture=`machinetype`
 osversion=`osversion`
+
+if test "$osversion" != "darwin"
+   then
+       echo "WARNING: target architecture applies only to the Darwin (MacOS) platform":
+       echo "Ignoring target architecture argument: $target"
+elif test "$target_arch" = "x86_64"
+   then
+       architecure=$target_arch
+elif test "$target_arch" = "aarch64"
+   then
+       architecure=$target_arch
+fi
+
 echo "making so far for ${osversion} on ${architecture}."
+
 case "$display" in
 	init)	display=single
 		releasename=init-${osversion}.${architecture}

--- a/bin/makeright
+++ b/bin/makeright
@@ -54,36 +54,9 @@ if test $# -gt 0
 	shift
 fi
 
-target_arch="$1"
-
-if test $# -gt 0
-    then
-	shift
-fi
-
 architecture=`machinetype`
 osversion=`osversion`
-
-if test "$target_arch" != ""
-   then
-       if test "$osversion" != "darwin"
-          then
-              echo "!!!!!!!!!! WARNING: target architecture applies only to the Darwin (MacOS) platform"
-              echo "!!!!!!!!!! Ignoring target architecture argument: $target_arch"
-       elif test "$target_arch" = "x86_64"
-          then
-               architecture=$target_arch
-       elif test "$target_arch" = "aarch64"
-          then
-               architecture=$target_arch
-       else
-          echo "!!!!!!!!! WARNING: Unknown target architecture: $target_arch"
-          echo "!!!!!!!!! Ignoring second argument."
-       fi
-fi
-
 echo "making so far for ${osversion} on ${architecture}."
-
 case "$display" in
 	init)	display=single
 		releasename=init-${osversion}.${architecture}

--- a/bin/makeright
+++ b/bin/makeright
@@ -64,16 +64,22 @@ fi
 architecture=`machinetype`
 osversion=`osversion`
 
-if test "$osversion" != "darwin"
+if test "$target_arch" != ""
    then
-       echo "WARNING: target architecture applies only to the Darwin (MacOS) platform":
-       echo "Ignoring target architecture argument: $target"
-elif test "$target_arch" = "x86_64"
-   then
-       architecure=$target_arch
-elif test "$target_arch" = "aarch64"
-   then
-       architecure=$target_arch
+       if test "$osversion" != "darwin"
+          then
+              echo "!!!!!!!!!! WARNING: target architecture applies only to the Darwin (MacOS) platform"
+              echo "!!!!!!!!!! Ignoring target architecture argument: $target_arch"
+       elif test "$target_arch" = "x86_64"
+          then
+               architecture=$target_arch
+       elif test "$target_arch" = "aarch64"
+          then
+               architecture=$target_arch
+       else
+          echo "!!!!!!!!! WARNING: Unknown target architecture: $target_arch"
+          echo "!!!!!!!!! Ignoring second argument."
+       fi
 fi
 
 echo "making so far for ${osversion} on ${architecture}."


### PR DESCRIPTION
Also update workflows to latest action versions and update handling of GITHIUB_ENV to get rid of deprecated set-output.

This is a resubmit of closed PR#469.  Changes from that PR include rebased branch onto latest master; added support for SDL in release builds for Darwin.