### PR TITLE
Introduce buildCygwinBuilderImage.yml into master so I can test on dev branch

### DIFF
--- a/.github/workflows/buildCygwinBuilderImage.yml
+++ b/.github/workflows/buildCygwinBuilderImage.yml
@@ -1,0 +1,92 @@
+#*******************************************************************************
+# buildCygwinBuilderImage.yml
+#
+# Workflow to build a hWindows Docker image that includes cygwin and SDL compiled for cygwin
+# and all of the tools for building maiko for linuxcygwin and sdl.  Intended to be used 
+# (exclusively?) by the github actions that build maiko releases - e.g., buildRelease.yml.
+#
+#
+# Copyright 2023 by Interlisp.org
+#
+# Frank Haasz 2023-06-2104
+#
+# ******************************************************************************
+
+name: 'Build/Push Cygwin Builder'
+
+# Run this workflow on ...
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: powershell
+
+jobs:
+
+  buildBuilder:
+
+    runs-on: windows-2022
+
+    steps:
+
+      # Checkout the branch
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      # Fetch cygwin and sdl from net
+      - name: Fetch cygwin
+        id: cygwin
+        run: |
+          wget https://cygwin.com/setup-x86_64.exe -OutFile .\.github\workflows\setup-x86_64.exe
+
+      - name: Fetch SDL2
+        id: SDL2
+        env: 
+          GH_TOKEN: ${{ github_token }}
+        run: |
+          gh release download release-2.26.5 --repo libsdl-org/SDL --pattern SDL2-2.26.5.tar.gz --output sdl2.tar.gz
+
+      # Setup docker environment variables
+      - name: Setup Docker Environment Variables
+        id: docker_env
+        run: |
+          $crt="${{ needs.loadup.outputs.combined_release_tag }}"
+          echo "COMBINED_RELEASE_TAG=$crt" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+          $DOCKER_REGISTRY="ghcr.io"
+          $DOCKER_NAMESPACE="${{ github.repository_owner }}"
+          $DOCKER_REPO="${DOCKER_REGISTRY}/${DOCKER_NAMESPACE}/maiko-cygwin-builder"
+          $DOCKER_TAG="${DOCKER_REPO}:latest"
+          $bd=Get-Date -UFormat "%Y-%m-%d_%H:%M_%Z"
+          echo "BUILD_DATE=$bd" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+          echo "DOCKER_TAG=${DOCKER_TAG}" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
+
+
+      # Do the Docker Build using the Dockerfile_cygwin_builder in the repository we
+      # checked out.
+      #
+      - name: Build Docker Image
+        id: build
+        run: |
+          docker build \ 
+                 -f ./.github/workflows/Dockerfile_cygwin_builder \
+                 -t ${{ env.DOCKER_TAG }} \
+                 --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
+                 ./.github/workflows
+                       
+      # Login to ghcr.io
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Push the result to ghcr.io.
+      - name: Push image to ghcr
+        id: push
+        run: |
+          docker push ${{ env.DOCKER_TAG }}  
+
+          
+######################################################################################


### PR DESCRIPTION
End-run around limitation in github actions that allows one to run a workflow only when it is in master branch - even though testing only on a dev branch.
