### PR TITLE
Update machinetype and osversion scripts to invoke config.guess from same directory

### DIFF
--- a/bin/machinetype
+++ b/bin/machinetype
@@ -9,7 +9,8 @@
 #									#
 #########################################################################
 
-os=${LDEARCH:-`./config.guess`}
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+os=${LDEARCH:-`$SCRIPTPATH/config.guess`}
 # o/s switch block
 case "$os" in
         m68k-*)		      echo m68k ;;

--- a/bin/osversion
+++ b/bin/osversion
@@ -1,5 +1,6 @@
 #!/bin/sh
-os=${LDEARCH:-`./config.guess`}
+SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+os=${LDEARCH:-`$SCRIPTPATH/config.guess`}
 case "$os" in
         m68k-*-amigaos)		echo amigaos ;;
         sparc-sun-sunos*)	echo sunos4 ;;


### PR DESCRIPTION
If machinetype or osversion are executed from other than the current working directory they will fail to execute the config.guess script because it was invoked with "./config.guess". This update attempts to determine the directory where machinetype or osversion were found and uses the same path to invoke config.guess.