### PR TITLE
Avoid setting Lisp variables whose locations are unknown when in INIT mode

### DIFF
--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -531,5 +531,5 @@ void lisp_finish(void) {
 #ifdef DOS
   exit_host_filesystem();
 #endif /* DOS */
-  exit(1);
+  exit(0);
 }

--- a/src/xwinman.c
+++ b/src/xwinman.c
@@ -189,11 +189,13 @@ void process_Xevents(DspInterface dsp)
     if (report.xany.window == dsp->DisplayWindow) /* Try the most important window first. */
       switch (report.type) {
         case MotionNotify:
+#ifndef INIT
           *CLastUserActionCell68k = MiscStats->secondstmp;
           *EmCursorX68K = (*((DLword *)EmMouseX68K)) =
               (short)((report.xmotion.x + dsp->Visible.x) & 0xFFFF) - Current_Hot_X;
           *EmCursorY68K = (*((DLword *)EmMouseY68K)) =
               (short)((report.xmotion.y + dsp->Visible.y) & 0xFFFF) - Current_Hot_Y;
+#endif
           break;
         case KeyPress:
           kb_trans(SUNLispKeyMap[(report.xkey.keycode) - KEYCODE_OFFSET], FALSE);


### PR DESCRIPTION
The X11 event handling will attempt to update the last user action time and the mouse/cursor position Lisp variables, but when the code is running in INIT mode the native addresses for those variables are not initialized and so we end up with a segmentation fault. Just don't attempt those updates when compiled with -DINIT