### PR TITLE
XFree(mapping) was called *before* mapping was referenced …

### DIFF
--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -375,8 +375,6 @@ static u_char *make_X_keymap(void) {
     table[xcode - 7] = code;
   }
 
-  XFree(mapping); /* No locking required? */
-
 #ifdef DEBUG
   printf("\n\n\tXGetKeyboardMapping table\n\n");
   for (i = 0; i < codecount * symspercode; i += symspercode) {
@@ -393,6 +391,8 @@ static u_char *make_X_keymap(void) {
            table[i + 5], table[i + 6], table[i + 7]);
   }
 #endif /* DEBUG */
+
+  XFree(mapping); /* No locking required? */
 
   return (table);
 }


### PR DESCRIPTION
…in DEBUG conditional code.

This is only a potential issue in DEBUG build. A problem hasn't occurred, that I know of, but it seemed best just to be safe. Moved the DEBUG code to precede the XFree(mapping) call. (Equivalent to moving the XFree down.)