### PR TITLE
Fix Issue#1541: IL:LOGOUT does not work running Medley on emscripten maiko

### DIFF
--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -354,7 +354,7 @@ LispPTR vmem_save(char *sysout_file_name)
   TIMEOUT(sysout = open(sysout_file_name, O_WRONLY, 0666));
   if (sysout == -1) {
     /* No file error skip return. */
-    if (errno != 2) return (FILECANNOTOPEN); /* No such file error.*/
+    if (errno != ENOENT) return (FILECANNOTOPEN); /* No such file error.*/
   } else
     TIMEOUT(rval = close(sysout));
 
@@ -481,7 +481,7 @@ LispPTR vmem_save(char *sysout_file_name)
   TIMEOUT(rval = unlink(sysout_file_name));
   if (rval == -1) {
     /* No file error skip return. */
-    if (errno != 2) /* No such file error.*/
+    if (errno != ENOENT) /* No such file error.*/
       return (FILECANNOTOPEN);
   }
 


### PR DESCRIPTION
The function vmem_save uses the construction `if ( errno != 2) ...` (in 2 places).

On most systems, errno 2 is ENOENT.  But for some reason on emscripten, ENOENT is errno 44.

Changed construction to `if ( errno != ENOENT) ...` for all platforms (i.e., not conditionalized on MAIKO_OS_EMSCRIPTEN).  Shouldn't really have hard-wired errnos in cross-platform code.

