### PR TITLE
Update UNIX-GETPARM to return values for OSNAME and ARCH

### DIFF
--- a/src/uutils.c
+++ b/src/uutils.c
@@ -204,18 +204,10 @@ LispPTR unix_getparm(LispPTR *args) {
 #else
     envvalue = "mc68020";
 #endif
-
+  } else if (strcmp(envname, "OSNAME") == 0) {
+    envvalue = MAIKO_OS_NAME;
   } else if (strcmp(envname, "ARCH") == 0) {
-#if defined(sparc)
-    envvalue = "sun4";
-#elif defined(DOS)
-    envvalue = "dos";
-#elif defined(MAIKO_OS_MACOS)
-    envvalue = "i386";
-#else
-    envvalue = "sun3";
-#endif
-
+    envvalue = MAIKO_ARCH_NAME;
   } else if (strcmp(envname, "DISPLAY") == 0) {
 #if defined(XWINDOW)
     envvalue = "X";


### PR DESCRIPTION
Calls to UNIX-GETPARM with argument "OSNAME" or "ARCH" now return values derived from the compile-time settings in inc/maiko/platform.h. Relates to Interlisp/medley#1596

The current return values are
OSNAME:

- "macOS"
- "Cygwin"
- "DragonFly BSD"
- "FreeBSD"
- "Linux"
- "NetBSD"
- "OpenBSD"
- "AmigaOS 3"
- "Solaris"
- "Windows"
- "Emscripten"

ARCH:

- "WebAssembly"
- "x86_64"
- "arm"
- "arm64"
- "x86"
- "PowerPC"
- "RISC-V"
- "SPARC"
- "Motorola68K"