### PR TITLE
exit with non-zero status if unable to open sysout or...

### DIFF
--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -133,7 +133,7 @@ void print_Xusage(const char *prog)
  -nh-loglevel level        Loglevel for Dodo networking (0..2, optional, default: 0)\n\n");
 #endif
   fprintf(stderr, "Please refer to the manual for further information.\n\n");
-  exit(0);
+  exit(EXIT_FAILURE);
 } /* end print_Xusage() */
 
 /************************************************************************/


### PR DESCRIPTION
If for any reason (missing sysout, can't determine name of sysout, syntax error in options, ...) the program exits by calling `print_Xusage()` then it should exit with a non-zero (failure) status.