### PR TITLE
Rationalize the processing of command line args for the sysout.  Fixes Issue#1703

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -342,6 +342,24 @@ int main(int argc, char *argv[])
   }
 #endif /* MAIKO_ENABLE_FOREIGN_FUNCTION_INTERFACE */
 
+#ifdef PROFILE
+  moncontrol(0); /* initially stop sampling */
+#endif           /* PROFILE */
+
+  //
+  //
+  //  Process Command Line Arguments
+  //
+  //
+
+  // First check if the first argument is a sysout name
+  // and save it away if it is in case the X windows
+  // arg processing changes argc/argv
+  if (argc > 1 && argv[1][0] != '-') {
+    strncpy(sysout_name_first_arg, argv[1], MAXPATHLEN);
+    i++;
+  }
+
 
 #ifdef XWINDOW
   read_Xoption(&argc, argv);
@@ -349,10 +367,6 @@ int main(int argc, char *argv[])
 
   save_argc = argc;
   save_argv = argv;
-
-#ifdef PROFILE
-  moncontrol(0); /* initially stop sampling */
-#endif           /* PROFILE */
 
   i = 1;
 
@@ -366,13 +380,12 @@ int main(int argc, char *argv[])
     exit(0);
   }
 
-  if (argc > 1 && argv[1][0] != '-') {
-    strncpy(sysout_name_first_arg, argv[1], MAXPATHLEN);
-    i++;
-  }
-
 
   for (; i < argc; i += 1) { /* step by 1 in case of typo */
+
+   // NOTE:  in the case of X Windows, some of the args being checked for in this loop
+   // have already been processed (and removed from argv) by the call to read_Xoption()
+   // above.  (See readXoption() in xrdopt.c)
 
    /* Check for -sysout arg */
     if (!strcmp(argv[i], "-sysout")) {
@@ -629,6 +642,13 @@ int main(int argc, char *argv[])
     exit(1);
   }
   /* OK, sysout name is now in sysout_name */
+
+
+  //
+  //
+  // End of command line arg processing
+  //
+  //
 
 
 /* Sanity checks. */

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -85,7 +85,8 @@ char Window_Title[255];
 extern char Icon_Title[255];
 char Icon_Title[255];
 
-extern char sysout_name[];
+extern char sysout_name_cl[];
+extern char sysout_name_xrm[];
 extern unsigned sysout_size;
 extern int for_makeinit, please_fork, noscroll;
 /* diagnostic flag for sysout dumping */
@@ -181,20 +182,9 @@ void read_Xoption(int *argc, char *argv[])
     print_Xusage(argv[0]);
   }
 
-  sysout_name[0] = '\0';
-  if (*argc == 2) { /* There was probably a sysoutarg */
-    (void)strncpy(sysout_name, argv[1], PATH_MAX - 1);
-  } else if ((envname = getenv("LDESRCESYSOUT")) != NULL) {
-    strncpy(sysout_name, envname, PATH_MAX - 1);
-  } else if ((envname = getenv("LDESOURCESYSOUT")) != NULL)
-    strncpy(sysout_name, envname, PATH_MAX - 1);
-  else {
-    envname = getenv("HOME");
-    (void)strcat(sysout_name, envname);
-    (void)strcat(sysout_name, "/lisp.virtualmem");
-  }
-  if (access(sysout_name, R_OK) != 0) {
-    sysout_name[0] = '\0';
+  if (XrmGetResource(commandlineDB, "ldex.sysout", "Ldex.Sysout", str_type, &value) == True) {
+    /* Get Sysout from command line only */
+    (void)strncpy(sysout_name_cl, value.addr, value.size);
   }
 
   /* In order to access other DB's we have to open the main display now */
@@ -244,12 +234,8 @@ void read_Xoption(int *argc, char *argv[])
   (void)XrmMergeDatabases(commandlineDB, &rDB);
 
   if (XrmGetResource(rDB, "ldex.sysout", "Ldex.Sysout", str_type, &value) == True) {
-    /* Get Sysout */
-    (void)strncpy(sysout_name, value.addr, value.size);
-  }
-  if (sysout_name[0] == '\0') {
-    (void)fprintf(stderr, "Couldn't find a sysout to run;\n");
-    print_Xusage(argv[0]);
+    /* Get Sysout from x resource manager */
+    (void)strncpy(sysout_name_xrm, value.addr, value.size);
   }
 
   if (XrmGetResource(rDB, "ldex.title", "Ldex.Title", str_type, &value) == True) {


### PR DESCRIPTION
Fixes Issue#1703 and more.

Rationalize the processing of command line args for the sysout.  Remove most of the redundancy between what is done for sysout arg processing in xrdopt.c versus main.c.  Move all of the decision making about what sysout_name to use until all args have been processed (both in xrdpopt and main).  This is done in main, where the prioritization and checking is done in one place rather than spread in several places in xrdopt and main.

 Order of priority is specifying sysout to lde::
1. Value of -sysout command line arg
2. Value of the first command line arg
3. Value of LDESRCESYSOUT env variable
 4. Value of LDESOURCESYSOUT env variable
 5. Value as determined by X resource manager, if any
6.  Value of $HOME/lisp.virtualmem (or lisp.vm for DOS)