### PR TITLE
Add -rpath /Library/Frameworks to accommodate newer macOS releases

### DIFF
--- a/bin/makefile-darwin.aarch64-sdl
+++ b/bin/makefile-darwin.aarch64-sdl
@@ -11,7 +11,7 @@ OPTFLAGS =  -O2 -g
 DEBUGFLAGS = # -DDEBUG -DOPTRACE
 DFLAGS = $(DEBUGFLAGS) $(SDLFLAGS) -DRELEASE=351
 
-LDFLAGS = -F /Library/Frameworks -framework SDL2
+LDFLAGS = -rpath /Library/Frameworks -F /Library/Frameworks -framework SDL2
 LDELDFLAGS =
 
 OBJECTDIR = ../$(RELEASENAME)/

--- a/bin/makefile-darwin.x86_64-sdl
+++ b/bin/makefile-darwin.x86_64-sdl
@@ -11,7 +11,7 @@ OPTFLAGS =  -O2 -g
 DEBUGFLAGS = # -DDEBUG -DOPTRACE
 DFLAGS = $(DEBUGFLAGS) $(SDLFLAGS) -DRELEASE=351
 
-LDFLAGS = -F /Library/Frameworks -framework SDL2
+LDFLAGS = -rpath /Library/Frameworks -F /Library/Frameworks -framework SDL2
 LDELDFLAGS =
 
 OBJECTDIR = ../$(RELEASENAME)/


### PR DESCRIPTION
On or before macOS Ventura's release, defaulting the @rpath to include /Library/Frameworks stopped.  Since we expect the SDL2 framework to be installed there we must add a -rpath option. This should be backwards compatible with older macOS releases. (verified on Catalina but nothing older)