### PR TITLE
Add support for setting cursor color to ldex (X11 display)

### DIFF
--- a/src/xcursor.c
+++ b/src/xcursor.c
@@ -26,6 +26,7 @@
 
 static XColor cursor_fore_xcsd, cursor_back_xcsd, xced;
 extern Colormap Colors;
+extern char cursorColor[255];
 
 extern DspInterface currentdsp;
 /* a simple linked list to remember X cursors */
@@ -143,7 +144,7 @@ void init_Xcursor(DspInterface dsp)
 
   XLOCK; /* Take no X signals during this activity (ISC 386) */
 
-  XAllocNamedColor(dsp->display_id, Colors, "black", &cursor_fore_xcsd, &xced);
+  XAllocNamedColor(dsp->display_id, Colors, cursorColor, &cursor_fore_xcsd, &xced);
   XAllocNamedColor(dsp->display_id, Colors, "white", &cursor_back_xcsd, &xced);
 
   XUNLOCK(dsp); /* OK to take signals again */

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -53,6 +53,7 @@ static XrmOptionDescRec opTable[] = {
     {"-fg", "*foreground", XrmoptionSepArg, (XPointer)NULL},
     {"-background", "*background", XrmoptionSepArg, (XPointer)NULL},
     {"-bg", "*background", XrmoptionSepArg, (XPointer)NULL},
+    {"-cursorColor", "*cursorColor", XrmoptionSepArg, (XPointer)NULL},
     {"-title", "*title", XrmoptionSepArg, (XPointer)NULL},
     {"-t", "*title", XrmoptionSepArg, (XPointer)NULL},
     {"-icontitle", "*icontitle", XrmoptionSepArg, (XPointer)NULL},
@@ -84,6 +85,8 @@ extern char Window_Title[255];
 char Window_Title[255];
 extern char Icon_Title[255];
 char Icon_Title[255];
+extern char cursorColor[255];
+char cursorColor[255] = {0};
 
 extern char sysout_name_cl[];
 extern char sysout_name_xrm[];
@@ -115,6 +118,7 @@ void print_Xusage(const char *prog)
   (void)fprintf(stderr, " [-sysout] [<sysout>]                 -path to the Medley image\n");
   (void)fprintf(stderr, " -h[elp]                              -prints this text\n");
   (void)fprintf(stderr, " -info                                -prints configuration info\n");
+  (void)fprintf(stderr, " -cursorColor X11-color-spec	       -sets foreground cursor color\n");
   (void)fprintf(stderr, " -d[isplay] <host>:<display>.<screen>\n");
   (void)fprintf(stderr,
           " -g[eometry] <geom>                   -size & placement for the medley window on your X "
@@ -268,6 +272,10 @@ void read_Xoption(int *argc, char *argv[])
   }
 
   (void)strcpy(tmp, ""); /* Clear the string */
+
+  if (XrmGetResource(rDB, "ldex.cursorColor", "Ldex.cursorColor", str_type, &value) == True) {
+    (void)strncpy(cursorColor, value.addr, sizeof(cursorColor) - 1);
+  }
 
   if (XrmGetResource(rDB, "ldex.NoFork", "Ldex.NoFork", str_type, &value) == True) {
     please_fork = 0;


### PR DESCRIPTION
The cursor (foreground) color can be set with the
    -cursorColor x11-color-spec
option to ldex or any front-end that passes the options through to ldex. For example:
     lde ... -cursorColor red
     lde ... -cursorColor '#A020F0'
     ./run-medley -cursorColor RED -g 1200x700 -sc 1200x700 -noscroll

Alternatively, the color may be specified with the ldex*cursorColor resource (in ~/.Xresources, or other such X11 resource databases that are loaded by the X11 server)

The command line option will override the X11 resource option.