### PR TITLE
Fix #1826 - emulator crash  when too many versions of a file in a directory

### DIFF
--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2941,7 +2941,7 @@ static int make_directory(char *dir)
 static int get_version_array(char *dir, char *file, FileName varray[], CurrentVArray *cache)
 {
 #ifdef DOS
-
+  /* DOS version-array builder */
   char lcased_file[MAXPATHLEN];
   char old_file[MAXPATHLEN];
   char name[MAXNAMLEN];


### PR DESCRIPTION
This is a preliminary fix to avoid a system crash (bus error/seg fault) when operating on a file with too many versions present in the directory.

Reports an error (EIO, SIMPLE-DEVICE-ERROR) when doing an operation that would result in an out-of-bounds access in the emulator.

A better fix would be to dynamically allocate the necessary version storage, but that will
take longer to work out.

Test environment is a directory that contains over 200 versions of a file and you attempt to do a create (new version) or delete operation on the file.