### PR TITLE
Cleanup in the "version array" handling in the {DSK} device

### DIFF
--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -499,7 +499,8 @@ do  {				\
 #define	MAXVERSION		999999999
 
 #define	LASTVERSIONARRAY	((unsigned) -1)
-#define	VERSIONARRAYLENGTH	200
+#define	VERSIONARRAYCHUNKLENGTH	200
+#define	VERSIONARRAYMAXLENGTH   2000
 
 #define NoFileP(varray)						\
         (((varray)->version_no == LASTVERSIONARRAY)? 1 : 0)

--- a/inc/version.h
+++ b/inc/version.h
@@ -237,6 +237,14 @@ typedef unsigned short USHORT;
 	/* 	    --Start of system-specific flags		 	*/
 	/*								*/
 	/****************************************************************/
+#ifdef MAIKO_OS_MACOS
+/* macOS does not follow the POSIX standard for the names of the stat
+   fields that allow access to the nanosecond resolution times
+*/
+#define st_atim st_atimespec
+#define st_mtim st_mtimespec
+#define st_ctim st_ctimespec
+#endif
 
 	/****************************************************************/
 	/* 	    End of system-specific flag settings		*/

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -38,7 +38,7 @@
 #include <pwd.h>            // for getpwuid, passwd
 #include <sys/param.h>      // for MAXPATHLEN
 #include <sys/statvfs.h>    // for statvfs
-#include <sys/time.h>       // for timeval, futimes
+#include <sys/time.h>       // for timeval, utimes, futimens
 #else
 #include <direct.h>
 #include <dos.h>
@@ -680,7 +680,7 @@ LispPTR COM_closefile(LispPTR *args)
   char lfname[MAXPATHLEN + 5], host[MAXNAMLEN];
   char file[MAXPATHLEN];
   struct stat sbuf;
-  struct timeval time[2];
+  struct timespec timesp[2];
 
   ERRSETJMP(NIL);
   Lisp_errno = (int *)NativeAligned4FromLAddr(args[3]);
@@ -745,17 +745,17 @@ LispPTR COM_closefile(LispPTR *args)
     }
   }
 
-  /* introduction of futimes() allows us to set the times on an open
+  /* introduction of futimens() allows us to set the times on an open
    * file descriptor so a lot of directory manipulation to find the
    * appropriate name associated with the inode is no longer required
    */
 
-  time[0].tv_sec = (long)sbuf.st_atime;
-  time[0].tv_usec = 0L;
-  time[1].tv_sec = (long)ToUnixTime(cdate);
-  time[1].tv_usec = 0L;
+  timesp[0].tv_sec = (long)sbuf.st_atime;
+  timesp[0].tv_nsec = 0L;
+  timesp[1].tv_sec = (long)ToUnixTime(cdate);
+  timesp[1].tv_nsec = 0L;
 
-  TIMEOUT(rval = futimes(fd, time));
+  TIMEOUT(rval = futimens(fd, timesp));
   if (rval != 0) {
     *Lisp_errno = errno;
     return (NIL);

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2994,7 +2994,7 @@ static int get_version_array(char *dir, char *file, FileName varray[])
    * without version in the last marker entry.
    */
   if (!NoFileP(varray)) {
-    strcpy(name, varray->name);
+    strcpy(name, varray[0].name);
     separate_version(name, ver, 1);
     strcpy(varray[varray_index].name, name);
   }
@@ -3080,7 +3080,7 @@ static int get_version_array(char *dir, char *file, FileName varray[])
    * without version in the last marker entry.
    */
   if (!NoFileP(varray)) {
-    strcpy(name, varray->name);
+    strcpy(name, varray[0].name);
     separate_version(name, ver, 1);
     strcpy(varray[varray_index].name, name);
   }

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -2766,34 +2766,26 @@ static int make_directory(char *dir)
  *		and highest version number respectively.
  *
  * Description:
+ * Finds the highest versioned entry in varray.
  *
- * Find the highest versioned entry in varray.  Varray has to include at least
- * one versioned file, that is varray has to satisfy (!NoFileP(varray) &&
- * !OnlyVersionlessP(varray)).
- *
+ * Preconditions:
+ *     Varray must include at least one versioned file, satisfying the condition:
+ *       (!NoFileP(varray) && !OnlyVersionlessP(varray))
+ *     Varray must be sorted from highest to lowest version
  */
+
 #ifdef DOS
 #define FindHighestVersion(varray, mentry, max_no)                                         \
-  do {                                                                                        \
-    FileName *centry;                                                             \
-    for (centry = varray, max_no = -1; centry->version_no != LASTVERSIONARRAY; centry++) { \
-      if (centry->version_no > max_no) {                                                   \
-        max_no = centry->version_no;                                                       \
-        mentry = centry;                                                                   \
-      }                                                                                    \
-    }                                                                                      \
-    } while (0)
+  do {                                    \
+    (max_no) = varray[0].version_no;      \
+    (mentry) = &varray[0];                \
+  } while (0)
 #else
 #define FindHighestVersion(varray, mentry, max_no)                                        \
-  do {                                                                                       \
-    FileName *centry;                                                            \
-    for (centry = (varray), (max_no) = 0; centry->version_no != LASTVERSIONARRAY; centry++) { \
-      if (centry->version_no > (max_no)) {                                                  \
-        (max_no) = centry->version_no;                                                      \
-        (mentry) = centry;                                                                  \
-      }                                                                                   \
-    }                                                                                     \
-    } while (0)
+  do {                                    \
+    (max_no) = varray[0].version_no;      \
+    (mentry) = &varray[0];                \
+  } while (0)
 #endif /* DOS */
 
 /*


### PR DESCRIPTION
Removed the unused caching of version array entries but then reimplemented it using nanosecond resolution directory modification timestamps which will avoid the issue of an outdated cache failing to be detected.

Simplified setting of file modification times on close through use of the `futimens()` call which operates on the open file descriptor directly rather than having to find the file name after closing.

Switch to chunked allocation (200 entries) for the version array, maintaining an upper limit on the number of versions of a file (2000 entries).  There's no particular basis for these limits other than things will get pretty slow if you're working with 2000 versions of a file.  The numbers can be adjusted by changing `VERSIONARRAYCHUNKLENGTH` and `VERSIONARRAYMAXLENGTH`.

Sort (quicksort) the version array, in decending version order, when it is created.  `FindHighestVersion` is a frequent operation and it can make use of the ordering.

