### PR TITLE
Remove USHORT and direct "unsigned short" uses in struct bitfields

### DIFF
--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -18,7 +18,7 @@
 */
 /**********************************************************************/
 #include "lispemul.h" /* for LispPTR, DLword */
-#include "version.h" /* for USHORT */
+#include "version.h" /* for BIGVM */
 
 #define ADDREF  0       /* for gclookup routine. */
 #define DELREF  1       /* for gclookup routine. */
@@ -162,10 +162,10 @@ struct  htoverflow
 #else
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT count        :6;
-    USHORT stackref     :1;
-    USHORT segnum       :8;
-    USHORT collision    :1;
+    DLword count        :6;
+    DLword stackref     :1;
+    DLword segnum       :8;
+    DLword collision    :1;
   };
 
 struct  htlinkptr
@@ -200,10 +200,10 @@ struct  htoverflow
 #ifdef BIGVM
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT collision    :1;
-    USHORT segnum       :15;
-    USHORT stackref     :1;
-    USHORT count        :15;
+    DLword collision    :1;
+    DLword segnum       :15;
+    DLword stackref     :1;
+    DLword count        :15;
   };
 
 struct  htlinkptr
@@ -231,10 +231,10 @@ struct  htoverflow
 #else
 struct   hashentry
   { /* GC hashtable entry */
-    USHORT collision    :1;
-    USHORT segnum       :8;
-    USHORT stackref     :1;
-    USHORT count        :6;
+    DLword collision    :1;
+    DLword segnum       :8;
+    DLword stackref     :1;
+    DLword count        :6;
   };
 
 struct  htlinkptr

--- a/inc/gcdata.h
+++ b/inc/gcdata.h
@@ -131,10 +131,10 @@
 #ifdef BIGVM  
 struct   hashentry
   { /* GC hashtable entry */
-    unsigned short count        :15;
-    unsigned short stackref     :1;
-    unsigned short segnum       :15;
-    unsigned short collision    :1;
+    DLword count        :15;
+    DLword stackref     :1;
+    DLword segnum       :15;
+    DLword collision    :1;
   };
 
 struct  htlinkptr

--- a/inc/lispemul.h
+++ b/inc/lispemul.h
@@ -267,22 +267,22 @@ struct state {
 
 /* For bit test */
 typedef struct wbits {
-  USHORT LSB : 1;
-  USHORT B14 : 1;
-  USHORT B13 : 1;
-  USHORT B12 : 1;
-  USHORT B11 : 1;
-  USHORT B10 : 1;
-  USHORT B9 : 1;
-  USHORT B8 : 1;
-  USHORT B7 : 1;
-  USHORT B6 : 1;
-  USHORT B5 : 1;
-  USHORT B4 : 1;
-  USHORT B3 : 1;
-  USHORT B2 : 1;
-  USHORT B1 : 1;
-  USHORT xMSB : 1;
+  DLword LSB : 1;
+  DLword B14 : 1;
+  DLword B13 : 1;
+  DLword B12 : 1;
+  DLword B11 : 1;
+  DLword B10 : 1;
+  DLword B9 : 1;
+  DLword B8 : 1;
+  DLword B7 : 1;
+  DLword B6 : 1;
+  DLword B5 : 1;
+  DLword B4 : 1;
+  DLword B3 : 1;
+  DLword B2 : 1;
+  DLword B1 : 1;
+  DLword xMSB : 1;
 } WBITS;
 
 #define PUTBASEBIT68K(base68k, offset, bitvalue)                                             \

--- a/inc/stack.h
+++ b/inc/stack.h
@@ -79,22 +79,22 @@ typedef struct fnhead {
 } FNHEAD;
 
 typedef struct frameex1 {
-  unsigned short flags : 3;
-  unsigned short fast : 1;
-  unsigned short nil2 : 1; /* not used, prev: This frame treats N-func */
-  unsigned short incall : 1;
-  unsigned short validnametable : 1;
+  DLword flags : 3;
+  DLword fast : 1;
+  DLword nil2 : 1; /* not used, prev: This frame treats N-func */
+  DLword incall : 1;
+  DLword validnametable : 1;
   /* 0: look for FunctionHeader
      1: look for NameTable on this FrameEx */
-  unsigned short nopush : 1;
-  unsigned short usecount : 8;
+  DLword nopush : 1;
+  DLword usecount : 8;
   DLword alink; /* alink pointer (Low addr) */
 #ifdef BIGVM
   LispPTR fnheader; /* pointer to FunctionHeader (Hi2 addr) */
 #else
   DLword lofnheader;        /* pointer to FunctionHeader (Low addr) */
-  unsigned short hi1fnheader : 8; /* pointer to FunctionHeader (Hi1 addr) */
-  unsigned short hi2fnheader : 8; /* pointer to FunctionHeader (Hi2 addr) */
+  DLword hi1fnheader : 8; /* pointer to FunctionHeader (Hi1 addr) */
+  DLword hi2fnheader : 8; /* pointer to FunctionHeader (Hi2 addr) */
 #endif /* BIGVM */
   DLword nextblock; /* pointer to FreeStackBlock */
   DLword pc;        /* Program counter */
@@ -102,23 +102,23 @@ typedef struct frameex1 {
   LispPTR nametable; /* ptr to NameTable of this FrameEx (Hi2 addr) */
 #else
   DLword lonametable;        /* ptr to NameTable of this FrameEx (Low addr) */
-  unsigned short hi1nametable : 8; /* ptr to NameTable of this FrameEx (Hi1 addr) */
-  unsigned short hi2nametable : 8; /* ptr to NameTable of this FrameEx (Hi2 addr) */
+  DLword hi1nametable : 8; /* ptr to NameTable of this FrameEx (Hi1 addr) */
+  DLword hi2nametable : 8; /* ptr to NameTable of this FrameEx (Hi2 addr) */
 #endif /* BIGVM */
   DLword blink; /* blink pointer (Low addr) */
   DLword clink; /* clink pointer (Low addr) */
 } FX;
 
 typedef struct frameex2 {
-  unsigned short flags : 3;
-  unsigned short fast : 1;
-  unsigned short nil2 : 1; /* not used, prev: This frame treats N-func */
-  unsigned short incall : 1;
-  unsigned short validnametable : 1;
+  DLword flags : 3;
+  DLword fast : 1;
+  DLword nil2 : 1; /* not used, prev: This frame treats N-func */
+  DLword incall : 1;
+  DLword validnametable : 1;
   /* 0: look for FunctionHeader
      1: look for NameTable on this FrameEx */
-  unsigned short nopush : 1;
-  unsigned short usecount : 8;
+  DLword nopush : 1;
+  DLword usecount : 8;
   DLword alink;      /* alink pointer (Low addr) */
   LispPTR fnheader;  /* pointer to FunctionHeader */
   DLword nextblock;  /* pointer to FreeStackBlock */
@@ -135,19 +135,19 @@ typedef struct fxblock {
 } FXBLOCK;
 
 typedef struct basic_frame {
-  unsigned short flags : 3;
-  unsigned short nil : 3;
-  unsigned short residual : 1;
-  unsigned short padding : 1;
-  unsigned short usecnt : 8;
+  DLword flags : 3;
+  DLword nil : 3;
+  DLword residual : 1;
+  DLword padding : 1;
+  DLword usecnt : 8;
   DLword ivar; /* stk offset of IVARs for this frame ?? */
 
 } Bframe;
 
 typedef struct stkword {
-  unsigned short flags : 3;
-  unsigned short nil : 5;
-  unsigned short usecount : 8;
+  DLword flags : 3;
+  DLword nil : 5;
+  DLword usecount : 8;
 } StackWord;
 
 typedef struct stack_block {
@@ -185,33 +185,33 @@ typedef struct fnhead {
   unsigned nil3 : 2;       /* not used */
   unsigned nil2 : 2;       /* not used */
 #endif /* BIGVM */
-  unsigned short argtype : 2;     /* ?? */
-  unsigned short byteswapped : 1; /* code was reswapped.	*/
-  unsigned short nil4 : 1;        /* not used, prev: native translated? */
-  unsigned short fvaroffset : 8;
+  DLword argtype : 2;     /* ?? */
+  DLword byteswapped : 1; /* code was reswapped.	*/
+  DLword nil4 : 1;        /* not used, prev: native translated? */
+  DLword fvaroffset : 8;
   /* DLword offset from head of NameTable */
-  unsigned short nlocals : 8; /* ?? */
+  DLword nlocals : 8; /* ?? */
   DLword ntsize;        /* size of NameTable */
                         /* NameTable of variable length is following with this structure. */
 } FNHEAD;
 
 typedef struct frameex1 {
   DLword alink; /* alink pointer (Low addr) */
-  unsigned short usecount : 8;
-  unsigned short nopush : 1;
-  unsigned short validnametable : 1;
+  DLword usecount : 8;
+  DLword nopush : 1;
+  DLword validnametable : 1;
   /* 0: look for FunctionHeader
      1: look for NameTable on this FrameEx */
-  unsigned short incall : 1;
-  unsigned short nil2 : 1; /* not used, prev: This frame treats N-func */
-  unsigned short fast : 1;
-  unsigned short flags : 3; /* hi word */
+  DLword incall : 1;
+  DLword nil2 : 1; /* not used, prev: This frame treats N-func */
+  DLword fast : 1;
+  DLword flags : 3; /* hi word */
 
 #ifdef BIGVM
   LispPTR fnheader; /* pointer to FunctionHeader (Hi2 addr) */
 #else
-  unsigned short hi2fnheader : 8; /* pointer to FunctionHeader (Hi2 addr) */
-  unsigned short hi1fnheader : 8; /* pointer to FunctionHeader (Hi1 addr) */
+  DLword hi2fnheader : 8; /* pointer to FunctionHeader (Hi2 addr) */
+  DLword hi1fnheader : 8; /* pointer to FunctionHeader (Hi1 addr) */
   DLword lofnheader;        /* pointer to FunctionHeader (Low addr) */
 #endif /* BIGVM */
 
@@ -221,8 +221,8 @@ typedef struct frameex1 {
 #ifdef BIGVM
   LispPTR nametable; /* pointer to NameTable of this FX (Hi2 addr) */
 #else
-  unsigned short hi2nametable : 8; /* pointer to NameTable of this FX (Hi2 addr) */
-  unsigned short hi1nametable : 8; /* pointer to NameTable of this FX (Hi1 addr) */
+  DLword hi2nametable : 8; /* pointer to NameTable of this FX (Hi2 addr) */
+  DLword hi1nametable : 8; /* pointer to NameTable of this FX (Hi1 addr) */
   DLword lonametable;        /* pointer to NameTable of this FX (Low addr) */
 #endif /* BIGVM */
 
@@ -232,15 +232,15 @@ typedef struct frameex1 {
 
 typedef struct frameex2 {
   DLword alink; /* alink pointer (Low addr) */
-  unsigned short usecount : 8;
-  unsigned short nopush : 1;
-  unsigned short validnametable : 1;
+  DLword usecount : 8;
+  DLword nopush : 1;
+  DLword validnametable : 1;
   /* 0: look for FunctionHeader
      1: look for NameTable on this FrameEx */
-  unsigned short incall : 1;
-  unsigned short nil2 : 1; /* not used, prev: This frame treats N-func */
-  unsigned short fast : 1;
-  unsigned short flags : 3;
+  DLword incall : 1;
+  DLword nil2 : 1; /* not used, prev: This frame treats N-func */
+  DLword fast : 1;
+  DLword flags : 3;
 
   LispPTR fnheader; /* pointer to FunctionHeader (swapped) */
 
@@ -261,11 +261,11 @@ typedef struct fxblock {
 
 typedef struct basic_frame {
   DLword ivar;
-  unsigned short usecnt : 8;
-  unsigned short padding : 1;
-  unsigned short residual : 1;
-  unsigned short nil : 3;
-  unsigned short flags : 3;
+  DLword usecnt : 8;
+  DLword padding : 1;
+  DLword residual : 1;
+  DLword nil : 3;
+  DLword flags : 3;
 
 } Bframe;
 

--- a/inc/stack.h
+++ b/inc/stack.h
@@ -270,9 +270,9 @@ typedef struct basic_frame {
 } Bframe;
 
 typedef struct stkword {
-  USHORT usecount : 8;
-  USHORT nil : 5;
-  USHORT flags : 3;
+  DLword usecount : 8;
+  DLword nil : 5;
+  DLword flags : 3;
 } StackWord;
 
 typedef struct stack_block {

--- a/inc/version.h
+++ b/inc/version.h
@@ -227,9 +227,6 @@ typedef unsigned char u_char;
 typedef unsigned long u_int;
 typedef unsigned short u_short;
 #undef UNALIGNED_FETCH_OK
-typedef unsigned USHORT;
-#else
-typedef unsigned short USHORT;
 #endif /* DOS */
 
 	/****************************************************************/


### PR DESCRIPTION
Replace all USHORT and "unsigned short" usage for bit-field declarations by DLword which better represents
the intent of the definitions.
