### PR TITLE
Remove tabs embedded in strings used for formatting output

### DIFF
--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -552,15 +552,15 @@ void printarrayblock(LispPTR base) {
   printf("          Length: %d cells.\n\n", bbase->arlen);
 
   addr = ((LispPTR *)bbase) - 20;
-  for (; addr < (LispPTR *)bbase; addr++) printf("%p	%8x\n", (void *)addr, *addr);
-  printf("%p	%8x <- array header\n", (void *)addr, *addr);
+  for (; addr < (LispPTR *)bbase; addr++) printf("%16p %8x\n", (void *)addr, *addr);
+  printf("%16p %8x <- array header\n", (void *)addr, *addr);
   addr++;
-  for (; addr < (LispPTR *)bbase + 20; addr++) printf("%p	%8x\n", (void *)addr, *addr);
+  for (; addr < (LispPTR *)bbase + 20; addr++) printf("%16p %8x\n", (void *)addr, *addr);
   printf(". . .\n");
 
   addr = ((LispPTR *)btrailer) - 20;
-  for (; addr < (LispPTR *)btrailer; addr++) printf("%p	%8x\n", (void *)addr, *addr);
-  printf("%p	%8x <- array trailer\n", (void *)addr, *addr);
+  for (; addr < (LispPTR *)btrailer; addr++) printf("%16p %8x\n", (void *)addr, *addr);
+  printf("%16p %8x <- array trailer\n", (void *)addr, *addr);
   addr++;
-  for (; addr < (LispPTR *)btrailer + 20; addr++) printf("%p	%8x\n", (void *)addr, *addr);
+  for (; addr < (LispPTR *)btrailer + 20; addr++) printf("%16p %8x\n", (void *)addr, *addr);
 }

--- a/src/testtool.c
+++ b/src/testtool.c
@@ -683,9 +683,10 @@ int print_opcode(int pc, DLbyte *addr, struct fnhead *fnobj) {
   extern unsigned int oplength[256];
   int len = oplength[op] + 1;
 
-  printf(" 0%o (0x%x)	", pc, pc);
-  for (i = 0; i < len; i++) printf("%o ", 0xFF & GETBYTE(addr + i));
-  printf("	%s", opcode_table[op]);
+  printf(" 0%04o (0x%04x)    ", pc, pc);
+  for (i = 0; i < len; i++) printf("%4o", 0xFF & GETBYTE(addr + i));
+  for (; i < 9; i++) printf("    ");
+  printf("%s", opcode_table[op]);
 
   switch (op) {
     case 0:


### PR DESCRIPTION
Files gcfinal.c and testool.c both contain literal TAB characters embedded in printf() format strings in an attempt to align output. The output formatting depends on the user's simulated tab settings and therefore may not produce the expected results.

The output formatting is rewritten to make tab characters unnecessary.
