### PR TITLE
Replaces shadowed "-t <interval>" with "-timer <interval>"

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -407,20 +407,20 @@ int main(int argc, char *argv[])
       }
     }
 
-    /* -t and -m are undocumented and somewhat dangerous... */
+    /* -timer and -m are undocumented and somewhat dangerous... */
 
-    else if (!strcmp(argv[i], "-t")) { /**** timer interval	****/
+    else if (!strcmp(argv[i], "-timer")) { /**** timer interval	****/
       if (argc > ++i) {
         errno = 0;
         tmpint = strtol(argv[i], (char **)NULL, 10);
         if (errno == 0 && tmpint > 0) {
           TIMER_INTERVAL = tmpint;
         } else {
-          (void)fprintf(stderr, "Bad value for -t (integer > 0)\n");
+          (void)fprintf(stderr, "Bad value for -timer (integer > 0)\n");
           exit(1);
         }
       } else {
-        (void)fprintf(stderr, "Missing argument after -t\n");
+        (void)fprintf(stderr, "Missing argument after -timer\n");
         exit(1);
       }
     }

--- a/src/xrdopt.c
+++ b/src/xrdopt.c
@@ -36,6 +36,7 @@ extern int LispDisplayRequestedX, LispDisplayRequestedY;
 extern unsigned LispDisplayRequestedWidth, LispDisplayRequestedHeight;
 
 extern int xsync;
+extern int TIMER_INTERVAL;
 
 static XrmOptionDescRec opTable[] = {
     {"-help", "*help", XrmoptionIsArg, (XPointer)NULL},
@@ -295,6 +296,14 @@ void read_Xoption(int *argc, char *argv[])
 
   if (XrmGetResource(rDB, "ldex.noscroll", "Ldex.noscroll", str_type, &value) == True) {
     noscroll = 1;
+  }
+
+  if (XrmGetResource(rDB, "ldex.timer", "Ldex.timer", str_type, &value) == True) {
+    (void)strncpy(tmp, value.addr, value.size);
+    errno = 0;
+    i = (int)strtol(tmp, (char **)NULL, 10);
+    if (errno == 0 && i > 0)
+      TIMER_INTERVAL = i;
   }
 
   /*    if (XrmGetResource(rDB,


### PR DESCRIPTION
At some point option "-t" was introduced as an abbreviation for "-title" but "-t" was already in use, though undocumented, for overriding the timer interval.  This commit changes the command line timer option to "-timer" and adds "timer" to the options that are processed from the X11 resources.