### PR TITLE
Improves behavior of display subrs DSPBOUT and SHOWDISPLAY

### DIFF
--- a/src/dspsubrs.c
+++ b/src/dspsubrs.c
@@ -40,7 +40,12 @@ extern int Mouse_Included;
  ****************************************************/
 
 void DSP_dspbout(LispPTR *args) /* args[0] :	charcode	*/
-{ putc((args[0] & 0xFFFF) & 0x7f, BCPLDISPLAY); }
+{
+  int charcode = (args[0] & 0x7F);
+  /* Interlisp-D uses CR as EOL which isn't useful here */
+  putc((charcode == '\r') ? '\n' : charcode, BCPLDISPLAY);
+  fflush(BCPLDISPLAY);
+}
 
 /****************************************************
  *
@@ -52,7 +57,16 @@ void DSP_dspbout(LispPTR *args) /* args[0] :	charcode	*/
 extern int DisplayInitialized;
 
 void DSP_showdisplay(LispPTR *args)
-{ DisplayInitialized = 1; }
+{
+  LispPTR base = args[0];   /* pointer to the display bitmap */
+  LispPTR rasterwidth = args[1];  /* should be a smallp */
+
+  if (base == NIL) {
+    DisplayInitialized = 0;
+  } else {
+    DisplayInitialized = 1;
+  }
+}
 
 /****************************************************
  *


### PR DESCRIPTION
DSPBOUT is called to output a single character to the "BCPL display", which is the system text output rather than the bitmapped display. Under maiko, this is mapped to "stdout". Interlisp-D uses CR as the EOL character, but that is not appropriate for output to standard output so CR is translated to LF here.  Standard output is buffered, but there is no indication of when the output should be flushed, so flush on every character, since this is a low frequency operation.

SHOWDISPLAY is called to switch between the "BCPL display" and the bitmapped display.  The current display subsystems are not hooked up to this subr, but this is a potential place to hook display size changes in the future, so the code is updated to indicate the parameters passed in and to set/reset the display initialization state variable.

Closes interlisp/medley#1920