### PR TITLE
Modifies Lisp exit subr to permit passing an exit status code

### DIFF
--- a/inc/uutilsdefs.h
+++ b/inc/uutilsdefs.h
@@ -6,5 +6,5 @@ LispPTR unix_username(LispPTR *args);
 LispPTR unix_getparm(LispPTR *args);
 LispPTR unix_getenv(LispPTR *args);
 LispPTR unix_fullname(LispPTR *args);
-LispPTR suspend_lisp(LispPTR *args);
+LispPTR suspend_lisp(void);
 #endif

--- a/inc/vmemsavedefs.h
+++ b/inc/vmemsavedefs.h
@@ -4,5 +4,5 @@
 int lispstringP(LispPTR Lisp);
 LispPTR vmem_save(char *sysout_file_name);
 LispPTR vmem_save0(LispPTR *args);
-void lisp_finish(void);
+void lisp_finish(int exit_status);
 #endif

--- a/src/uutils.c
+++ b/src/uutils.c
@@ -292,7 +292,7 @@ LispPTR unix_fullname(LispPTR *args) {
 extern DLword *EmMouseX68K, *EmMouseY68K, *EmKbdAd068K, *EmRealUtilin68K, *EmUtilin68K;
 extern DLword *EmKbdAd168K, *EmKbdAd268K, *EmKbdAd368K, *EmKbdAd468K, *EmKbdAd568K;
 
-LispPTR suspend_lisp(LispPTR *args) {
+LispPTR suspend_lisp(void) {
 #ifndef DOS
   extern DLword *CTopKeyevent;
   extern LispPTR *KEYBUFFERING68k;

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -518,7 +518,7 @@ LispPTR vmem_save(char *sysout_file_name)
 
 /* Make sure that we kill off any Unix subprocesses before we go away */
 
-void lisp_finish(void) {
+void lisp_finish(int exit_status) {
   char d[4];
 
   DBPRINT(("finish lisp_finish\n"));
@@ -536,5 +536,5 @@ void lisp_finish(void) {
 #ifdef DOS
   exit_host_filesystem();
 #endif /* DOS */
-  exit(0);
+  exit(exit_status);
 }


### PR DESCRIPTION
These changes add `(LOGOUT <number>) `to the traditional (LOGOUT) and (LOGOUT T) calls.  If an integer `<number>` is provided it will be used as the exit status code, while NIL and T result in an EXIT_SUCCESS.

If the argument passed is none of NIL, T, or a number, the exit status code will be a generic EXIT_FAILURE (typically 1).

(LOGOUT) and (LOGOUT T) virtual memory behavior is unaffected. When a `<number>` is passed Lisp will exit without saving the virtual memory state, as is the case for (LOGOUT T), although this behavior is determined by Lisp rather than the Maiko emulator.