### PR TITLE
Modifies LISPFINISH subr to use 2nd argument, if present, for exit status

### DIFF
--- a/src/subr.c
+++ b/src/subr.c
@@ -416,11 +416,11 @@ void OP_subrcall(int subr_no, int argnum) {
     case sb_LISP_FINISH: {
       int status;
       POP_SUBR_ARGS;
-      if (argnum == 0 || args[0] == NIL || args[0] == ATOM_T)
-        lisp_finish(EXIT_SUCCESS);
-      N_GETNUMBER(args[0], status, exit_fail);
+      if (argnum == 0 || argnum == 1 || (argnum == 2 && args[1] == NIL)) lisp_finish(EXIT_SUCCESS);
+      if (argnum > 2) lisp_finish(EXIT_FAILURE);
+      N_GETNUMBER(args[1], status, exit_fail);
       lisp_finish(status);
-      exit_fail:
+    exit_fail:
       lisp_finish(EXIT_FAILURE);
       break;
     }


### PR DESCRIPTION
Redesign of exit status handling, instead of overloading the FAST flag of (LOGOUT fast), add an optional 2nd argument, EXITSTATUS.

Retains compatability, with behavior unchanged, between new emulator and older sysouts which do not pass the second argument to LISPFINISH.

Newer sysouts, which pass the 2nd argument, will continue to work with older emulators though will not get the exit status set.

Full functionality requires updating `LOGOUT` and `\LOGOUT0` in medley/sources/ADIR to accept the second argument for exit status.