### PR TITLE
Correct {DSK} versioned file cache failures

### DIFF
--- a/src/dsk.c
+++ b/src/dsk.c
@@ -66,6 +66,7 @@ typedef struct filename_entry {
  */
 static struct {
   char name[MAXPATHLEN];     /* lowercase unversioned file name */
+  ino_t dir_ino;             /* inode of the directory */
   struct timespec lastMTime; /* modification time of the directory */
   int allocated;             /* number of entries in the files array */
   int lastUsed;              /* index of the last entry in use in files array */
@@ -3055,11 +3056,13 @@ static int get_version_array(char *dir, char *file)
     *Lisp_errno = errno;
     return(0);
   }
-  if (0 == strcmp(lcased_file, VA.name) &&
+  if (sbuf.st_ino == VA.dir_ino &&
+      0 == strcmp(lcased_file, VA.name) &&
       sbuf.st_mtim.tv_sec == VA.lastMTime.tv_sec &&
       sbuf.st_mtim.tv_nsec == VA.lastMTime.tv_nsec) {
     return (1);
   } else {
+    VA.dir_ino = sbuf.st_ino;
     VA.lastMTime = sbuf.st_mtim;
     strcpy(VA.name, lcased_file);
   }


### PR DESCRIPTION
A missing check for the applicability of a versioned file cache caused loadups to fail in the case where the modification timestamp of a directory and its parent were identical, and the file being looked up had the same name (when lowercased) as the directory it was contained within. E.g., looking up TEDIT in library/tedit/ where the modification times of library and library/tedit were identical.

The inode number of the directory containing the file must be the same as the inode number of the directory the cache was built from.