### PR TITLE
Clean up display related variable names differing only in case

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -327,10 +327,10 @@ extern char backgroundColorName[64];
 #endif
 char windowTitle[255] = "Medley";
 extern char windowTitle[255];
-int lispDisplayRequestedWidth = 1024;
-extern int lispDisplayRequestedWidth;
-int lispDisplayRequestedHeight = 768;
-extern int lispDisplayRequestedHeight;
+unsigned LispDisplayRequestedWidth = 1024, LispDisplayRequestedHeight = 768;
+extern unsigned LispDisplayRequestedWidth, LispDisplayRequestedHeight;
+int LispDisplayRequestedX = 0, LispDisplayRequestedY = 0;
+extern int LispDisplayRequestedX, LispDisplayRequestedY;
 int pixelScale = 1;
 extern int pixelScale;
 
@@ -474,7 +474,7 @@ int main(int argc, char *argv[])
 #ifdef SDL
     else if ((strcmp(argv[i], "-sc") == 0) || (strcmp(argv[i], "-SC") == 0)) {
       if (argc > ++i) {
-        int read = sscanf(argv[i], "%dx%d", &lispDisplayRequestedWidth, &lispDisplayRequestedHeight);
+        int read = sscanf(argv[i], "%dx%d", &LispDisplayRequestedWidth, &LispDisplayRequestedHeight);
         if(read != 2) {
           (void)fprintf(stderr, "Could not parse -sc argument %s\n", argv[i]);
           exit(1);
@@ -717,7 +717,7 @@ int main(int argc, char *argv[])
   make_dsp_instance(currentdsp, 0, 0, 0, 1); /* All defaults the first time */
 #endif                                       /* DOS || XWINDOW */
 #if defined(SDL)
-  init_SDL(windowTitle, lispDisplayRequestedWidth, lispDisplayRequestedHeight, pixelScale);
+  init_SDL(windowTitle, LispDisplayRequestedWidth, LispDisplayRequestedHeight, pixelScale);
 #endif /* SDL */
   /* Load sysout to VM space and returns real sysout_size(not 0) */
   sysout_size = sysout_loader(sysout_name, sysout_size);

--- a/src/xinit.c
+++ b/src/xinit.c
@@ -50,8 +50,6 @@ unsigned LispWindowRequestedHeight = DEF_WIN_HEIGHT;
 
 extern int LispDisplayRequestedX, LispDisplayRequestedY;
 extern unsigned LispDisplayRequestedWidth, LispDisplayRequestedHeight;
-int LispDisplayRequestedX, LispDisplayRequestedY;
-unsigned LispDisplayRequestedWidth, LispDisplayRequestedHeight;
 
 extern Colormap Colors;
 Colormap Colors;


### PR DESCRIPTION
Unify the LispDisplayRequested... and lispDisplayRequested... variables from the SDL and X11 display modules under the initial uppercase letter version.

Move the storage definitions for LispDisplayRequested... to main.c leaving external references in the modules that utilize them.