### PR TITLE
Specify Ubuntu22.04 instead of Ubuntu-latest in various github action scripts to solve libc version issue crashing online

### DIFF
--- a/.github/workflows/Dockerfile_builder
+++ b/.github/workflows/Dockerfile_builder
@@ -8,7 +8,7 @@
 #
 # ******************************************************************************
 
-FROM ubuntu:latest
+FROM ubuntu:22.04
 SHELL ["/bin/bash", "-c"]
 USER root:root
 # Install build tools

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -152,7 +152,7 @@ jobs:
          || needs.inputs.outputs.force == 'true'
       )
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       # Checkout the actions for this repo owner

--- a/.github/workflows/buildRelease.yml
+++ b/.github/workflows/buildRelease.yml
@@ -503,6 +503,7 @@ jobs:
       - name: Install SDL2
         run: |
           export DEBIAN_FRONTEND=noninteractive
+          sudo -E apt-get update
           sudo -E apt-get install -y libsdl2-dev libsdl2-2.0-0
 
       # Install Emscripten SDK


### PR DESCRIPTION
We haven't built an official release of maiko since May 24.  When I did an official release, the online system failed with a libc and libm version mismatch in lde and ldex.  To solve this (without having to upgrade the online server to ubuntu 24.04), I updated the maiko build actions for linux to use Ubuntu22.04 instead of ubuntu-latest (which is now 24.04 or 24.10, depending).  Builds now run fine on 22.04 and 24.04.