### PR TITLE
Adds the non-keypad arrow keys to be detected.

### DIFF
--- a/inc/XKeymap.h
+++ b/inc/XKeymap.h
@@ -221,17 +221,17 @@ static const int generic_X_keymap[] = {
     /* keypad digit assignments above, try assigning */
     /* the new arrow-key key#s assigned for RS/6000  */
     /* Failing that, try assigning the keypad #s.    */
+    1, 84, XK_Left,
     0, 129, XK_Left,
-    0, 84, XK_Left,
 
+    1, 82, XK_Up,
     0, 130, XK_Up,
-    0, 82, XK_Up,
 
+    1, 69, XK_Down,
     0, 131, XK_Down,
-    0, 69, XK_Down,
 
+    1, 87, XK_Right,
     0, 132, XK_Right,
-    0, 87, XK_Right,
 
     0, 93, XK_Multi_key,   /* Expand, Sun type-4 */
     0, 93, XK_Alt_R,       /* Expand, RH Alt key  */


### PR DESCRIPTION
(X11 in WSL Ubuntu 22.04 on Windows 11.)
With additional Medley calls to `KEYACTION` _(below)_, they should work in `TTYIN` (i.e., XCL and Interlisp EXECs). 
I didn't try `TEDIT`.
They are unrecognized in `SEDIT`. (In any case, their use there probably is pretty restricted by the nature of SEDIT.)

These `KEYACTION `calls also seems to make these work for the Keypad arrow keys.
```common-lisp
(KEYACTION 'KEYPAD8 '(("Meta,^" 56 NOLOCKSHIFT) . IGNORE))
(KEYACTION 'KEYPAD6 '(("Meta,>" 54 NOLOCKSHIFT) . IGNORE)) 
(KEYACTION 'KEYPAD4 '(("Meta,<" 52 NOLOCKSHIFT) . IGNORE)) 
(KEYACTION 'KEYPAD2 '(("Meta,^J" 50 NOLOCKSHIFT) . IGNORE))
``` 
