### PR TITLE
Enable runtime controlled debug output.

### DIFF
--- a/src/initkbd.c
+++ b/src/initkbd.c
@@ -71,6 +71,8 @@ extern DspInterface currentdsp;
 extern int LispKbdFd;
 int LispKbdFd = -1;
 
+extern int runtime_debug_level;
+
 extern fd_set LispReadFds;
 
 extern DLword *EmMouseX68K;
@@ -375,6 +377,20 @@ static u_char *make_X_keymap(void) {
     table[xcode - 7] = code;
   }
 
+  if (runtime_debug_level > 0) {
+    printf("*********************************************************************\n");
+    printf("(DEFINE-FILE-INFO \036PACKAGE \"INTERLISP\" \036READTABLE \"XCL\" \036 BASE 10)\n");
+    printf("(SETQ XGetKeyboardMappingTable '(\n");
+    for (i = 0; i < codecount * symspercode; i += symspercode) {
+      printf("(%d (", minkey + (i / symspercode));
+      for (int j = 0; j < symspercode; j++) {
+        printf("    #X%lx", (unsigned long)mapping[i+j]);
+      }
+      printf(" ))\n");
+    }
+    printf("\n))\nSTOP\n");
+    printf("*********************************************************************\n");
+  }
 #ifdef DEBUG
   printf("\n\n\tXGetKeyboardMapping table\n\n");
   for (i = 0; i < codecount * symspercode; i += symspercode) {

--- a/src/main.c
+++ b/src/main.c
@@ -226,6 +226,8 @@ int save_argc;
 char **save_argv;
 int display_max = 65536 * 16 * 2;
 
+long runtime_debug_level = 0;
+
 /* diagnostic flag for sysout dumping */
 extern unsigned maxpages;
 
@@ -345,6 +347,7 @@ int main(int argc, char *argv[])
 {
   int i;
   char *envname;
+  char *rtdebug;
   extern int TIMER_INTERVAL;
   extern fd_set LispReadFds;
   long tmpint;
@@ -677,6 +680,14 @@ int main(int argc, char *argv[])
   //
   //
 
+  if ((rtdebug = getenv("LDERUNTIMEDEBUG")) != NULL) {
+      errno = 0;
+      runtime_debug_level = strtol(rtdebug, (char **)NULL, 10);
+      if (errno != 0) {
+        runtime_debug_level = 0; // default to OFF if erroneous value
+    }
+  }
+  
 
 /* Sanity checks. */
 #ifdef DOS


### PR DESCRIPTION
Currently only in `make_X_keymap`.
Output is to `STDOUT` (since the conditional compilation `DEBUG` did)

Medley branch: **mth38--command-line-arg-to-support-maiko-runtime-debug** adds command line argument support for this.

This is draft as it probably isn't generally applicable. OTOH, it's also relatively harmless (as of now).