### PR TITLE
Fix typo in bin/mkvdate that was preventing it from executing correctly

### DIFF
--- a/bin/mkvdate
+++ b/bin/mkvdate
@@ -1,7 +1,7 @@
 #!/bin/sh
 if command -v "git" >/dev/null 2>&1; then
     MAIKO_REV="$(git status --porcelain)"
-    if [ $? == 0 ]; then
+    if [ $? -eq 0 ]; then
 	if [ ! -z "$(git status --porcelain)" ]; then
             MAIKO_REV="$(git rev-parse --short HEAD)-dirty"
 	else


### PR DESCRIPTION
mkvdate was failing in maiko builds due to "[ $? == 0 ]".  Fixed to "[ $? -eq 0 ]"