### PR TITLE
Fix Issue#2164 - mouse does not work on WSL1.  Root cause is that WSL1 does not support setitimer(ITIMER_VIRTUAL ...).

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -315,7 +315,7 @@ const char *nethubHelpstring =
 const char *nethubHelpstring = "";
 #endif
 
-#if defined(MAIKO_EMULATE_TIMER_INTERRUPTS) || defined(MAIKO_EMULATE_ASYNC_INTERRUPTS)
+#if MAIKO_OS_LINUX || defined(MAIKO_EMULATE_TIMER_INTERRUPTS) || defined(MAIKO_EMULATE_ASYNC_INTERRUPTS)
 extern int insnsCountdownForTimerAsyncEmulation;
 #endif
 
@@ -601,7 +601,7 @@ int main(int argc, char *argv[])
     }
 #endif /* MAIKO_ENABLE_NETHUB */
 
-#if defined(MAIKO_EMULATE_TIMER_INTERRUPTS) || defined(MAIKO_EMULATE_ASYNC_INTERRUPTS)
+#if MAIKO_OS_LINUX || defined(MAIKO_EMULATE_TIMER_INTERRUPTS) || defined(MAIKO_EMULATE_ASYNC_INTERRUPTS)
     else if (!strcmp(argv[i], "-intr-emu-insns")) {
       if (argc > ++i) {
         errno = 0;

--- a/src/timer.c
+++ b/src/timer.c
@@ -454,6 +454,11 @@ static void int_timer_service(int sig)
 /*									*/
 /************************************************************************/
 
+#if MAIKO_OS_LINUX
+  // for WSL1, which doesn't support setitimer(ITIMER_VIRTUAL ...)
+  int linux_emulate_timer = 0;
+#endif /* MAIKO_OS_LINUX */
+
 static void int_timer_init(void)
 
 {
@@ -489,6 +494,11 @@ static void int_timer_init(void)
   /* then attach a timer to it and turn it loose */
   timert.it_interval.tv_sec = timert.it_value.tv_sec = 0;
   timert.it_interval.tv_usec = timert.it_value.tv_usec = TIMER_INTERVAL;
+
+#if MAIKO_OS_LINUX
+  // (For WSL1) Capture error output from setittimer to indicate need to emulate timer
+  linux_emulate_timer =
+#endif /* MAIKO_OS_LINUX */
   setitimer(ITIMER_VIRTUAL, &timert, NULL);
 
   DBPRINT(("Timer interval set to %ld usec\n", (long)timert.it_value.tv_usec));
@@ -499,7 +509,7 @@ static void int_timer_init(void)
 /*									*/
 /*									*/
 /*									*/
-/*									*/
+/*
 /*									*/
 /*									*/
 /*									*/


### PR DESCRIPTION
Fix Issue#2164 - mouse does not work on WSL1.  Root cause is that, like cygwin, WSL1 does not support setitimer(ITIMER_VIRTRUAL ...)…  

WSL1 compiles using gcc and clang as straight linux and WSL1 cannot be detected using any preprocessor macros.  Also don't want to create yet another platform (WSL1) to run through the whole github actions release process. 

So in the case of MAIKO_OS_LINUX (including WSL1), we now detect setitimer failure and use emulated timer when such failure occurs. So unlike CYGWIN and Emscripten, the decision to use emulated timers for WSL1 is made at runtime not compile time.  This will add a very small overhead to all non-WSL1 Linux runs but should not effect any other platforms.