### PR TITLE
Increases number of stack frames that can be displayed by URaid 'l' command

### DIFF
--- a/inc/uraidextdefs.h
+++ b/inc/uraidextdefs.h
@@ -4,7 +4,7 @@
 #include "stack.h" /* for FX */
 #include "lispemul.h" /* for LispPTR */
 
-#define URMAXFXNUM 2000
+#define URMAXFXNUM 4096
 #define URMAXCOMM 512
 #define URSCAN_ALINK 0
 #define URSCAN_CLINK 1


### PR DESCRIPTION
Updates the URMAXFXNUM define to increase from 2000 to 4096 the number of stack frames that the URaid "l" command can process.  This makes it considerably more likely that in the case of a stack overflow you can see the entire stack.