### PR TITLE
Minor cleanup of code style in gcfinal.c and additional array free list debugging from URaid

### DIFF
--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -5,7 +5,6 @@ void printarrayblock(LispPTR base);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);
 LispPTR makefreearrayblock(LispPTR block, DLword length);
-LispPTR arrayblockmerger(LispPTR base, LispPTR nbase);
 LispPTR mergebackward(LispPTR base);
 LispPTR mergeforward(LispPTR base);
 LispPTR reclaimarrayblock(LispPTR ptr);

--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -4,7 +4,6 @@
 void printarrayblock(LispPTR base);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);
-LispPTR linkblock(LispPTR base);
 LispPTR makefreearrayblock(LispPTR block, DLword length);
 LispPTR arrayblockmerger(LispPTR base, LispPTR nbase);
 LispPTR mergebackward(LispPTR base);

--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -4,7 +4,6 @@
 void printarrayblock(LispPTR base);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);
-LispPTR deleteblock(LispPTR base);
 LispPTR linkblock(LispPTR base);
 LispPTR makefreearrayblock(LispPTR block, DLword length);
 LispPTR arrayblockmerger(LispPTR base, LispPTR nbase);

--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -2,7 +2,6 @@
 #define GCFINALDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
 void printarrayblock(LispPTR base);
-int integerlength(unsigned int n);
 LispPTR findptrsbuffer(LispPTR ptr);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);

--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -2,6 +2,7 @@
 #define GCFINALDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
 void printarrayblock(LispPTR base);
+void printfreeblockchainn(int arlen);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);
 LispPTR makefreearrayblock(LispPTR block, DLword length);

--- a/inc/gcfinaldefs.h
+++ b/inc/gcfinaldefs.h
@@ -2,7 +2,6 @@
 #define GCFINALDEFS_H 1
 #include "lispemul.h" /* for LispPTR, DLword */
 void printarrayblock(LispPTR base);
-LispPTR findptrsbuffer(LispPTR ptr);
 LispPTR releasingvmempage(LispPTR ptr);
 LispPTR checkarrayblock(LispPTR base, LispPTR free, LispPTR onfreelist);
 LispPTR deleteblock(LispPTR base);

--- a/src/gcarray.c
+++ b/src/gcarray.c
@@ -99,35 +99,35 @@ struct hashtable {
 LispPTR aref1(LispPTR array, int index) {
   LispPTR retval = 0;
   LispPTR base;
-  short typenumber;
-  struct arrayheader *actarray;
+  struct arrayheader *array_np;
 
-  actarray = (struct arrayheader *)NativeAligned4FromLAddr(array);
-  if (index >= actarray->totalsize) {
+  array_np = (struct arrayheader *)NativeAligned4FromLAddr(array);
+  if (index >= array_np->totalsize) {
     printf("Invalid index in GC's AREF1:  0x%x\n", index);
-    printf(" Array size limit:  0x%x\n", actarray->totalsize);
+    printf(" Array size limit:  0x%x\n", array_np->totalsize);
     printf(" Array ptr: 0x%x\n", array);
-    printf(" Array 68K ptr: %p\n", (void *)actarray);
-    printf("base:     0x%x\n", actarray->base);
-    printf("offset:   0x%x\n", actarray->offset);
-    printf("type #:   0x%x\n", actarray->typenumber);
-    printf("fill ptr: 0x%x\n", actarray->fillpointer);
+    printf(" Array native ptr: %p\n", (void *)array_np);
+    printf("base:     0x%x\n", array_np->base);
+    printf("offset:   0x%x\n", array_np->offset);
+    printf("type #:   0x%x\n", array_np->typenumber);
+    printf("fill ptr: 0x%x\n", array_np->fillpointer);
     error("index out of range in GC's AREF1.");
   }
-  index += actarray->offset;
-  typenumber = actarray->typenumber;
-  base = actarray->base;
-  switch (typenumber) {
-    case 3: /* unsigned 8bits */
-      retval = (GETBYTE(((char *)NativeAligned2FromLAddr(base)) + index)) & 0x0ff;
-      retval |= S_POSITIVE;
-      break;
-    case 4: /* unsigned 16bits */
-      retval = (GETWORD(((DLword *)NativeAligned2FromLAddr(base)) + index)) & 0x0ffff;
-      retval |= S_POSITIVE;
-      break;
-    case 38: retval = (*(((LispPTR *)NativeAligned4FromLAddr(base)) + index)); break;
-    default: error("Not Implemented in gc's aref1 (other types)");
+  index += array_np->offset;
+  base = array_np->base;
+  switch (array_np->typenumber) {
+  case 3: /* unsigned 8 bits */
+    retval = (GETBYTE(((char *)NativeAligned2FromLAddr(base)) + index)) & 0x0ff;
+    retval |= S_POSITIVE;
+    break;
+  case 4: /* unsigned 16 bits */
+    retval = (GETWORD(((DLword *)NativeAligned2FromLAddr(base)) + index)) & 0x0ffff;
+    retval |= S_POSITIVE;
+    break;
+  case 38: /* pointer 32 bits */
+    retval = (*(((LispPTR *)NativeAligned4FromLAddr(base)) + index));
+    break;
+  default: error("Not Implemented in gc's aref1 (other types)");
   }
   return (retval);
 }

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -138,14 +138,16 @@ static int integerlength(unsigned int n) {
 /*									*/
 /************************************************************************/
 
-LispPTR findptrsbuffer(LispPTR ptr) {
-  struct buf *bptr;
-  bptr = (struct buf *)NativeAligned4FromLAddr(*System_Buffer_List_word);
-  while (LAddrFromNative(bptr) != NIL) {
-    if (ptr == bptr->vmempage)
-      return (LAddrFromNative(bptr));
-    else
-      bptr = (struct buf *)NativeAligned4FromLAddr(bptr->sysnext);
+static LispPTR findptrsbuffer(LispPTR ptr) {
+  LispPTR buf;
+  struct buf *buf_np;
+  buf = *System_Buffer_List_word;
+  while (buf != NIL) {
+    buf_np = (struct buf *)NativeAligned4FromLAddr(buf);
+    if (ptr == buf_np->vmempage) {
+      return (buf);
+    }
+    buf = buf_np->sysnext;
   }
   return (NIL);
 }

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -51,7 +51,7 @@
 #include "gccodedefs.h"   // for reclaimcodeblock
 #include "gcdata.h"       // for DELREF, REC_GCLOOKUP
 #include "gchtfinddefs.h" // for htfind, rec_htfind
-#include "gcfinaldefs.h"  // for arrayblockmerger, checkarrayblock
+#include "gcfinaldefs.h"  // for checkarrayblock
 #include "lispemul.h"     // for LispPTR, NIL, T, POINTERMASK, DLword, ATOM_T
 #include "llstkdefs.h"    // for decusecount68k
 #include "lspglob.h"      // for FreeBlockBuckets_word, ArrayMerging_word
@@ -374,13 +374,13 @@ LispPTR makefreearrayblock(LispPTR block, DLword length) {
 /*									*/
 /*									*/
 /************************************************************************/
-LispPTR arrayblockmerger(LispPTR base, LispPTR nbase) {
+static LispPTR arrayblockmerger(LispPTR base, LispPTR nbase) {
   DLword arlens, narlens, secondbite, minblocksize, shaveback;
-  struct arrayblock *bbase, *bnbase;
-  bbase = (struct arrayblock *)NativeAligned4FromLAddr(base);
-  bnbase = (struct arrayblock *)NativeAligned4FromLAddr(nbase);
-  arlens = bbase->arlen;
-  narlens = bnbase->arlen;
+  struct arrayblock *base_np, *nbase_np;
+  base_np = (struct arrayblock *)NativeAligned4FromLAddr(base);
+  nbase_np = (struct arrayblock *)NativeAligned4FromLAddr(nbase);
+  arlens = base_np->arlen;
+  narlens = nbase_np->arlen;
   secondbite = MAXARRAYBLOCKSIZE - arlens;
   /* There are three cases for merging the blocks
    * (1) the total size of the two blocks is less than max:

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -43,6 +43,7 @@
 /*************************************************************************/
 
 #include <stdio.h>        // for printf
+#include <strings.h>      // for fls
 #include "address.h"      // for HILOC
 #include "adr68k.h"       // for NativeAligned4FromLAddr, LAddrFromNative
 #include "array.h"        // for arrayblock, ARRAYBLOCKTRAILERCELLS, MAXBUCK...
@@ -123,23 +124,9 @@ struct buf {
 #endif /* BIGVM */
 #endif /* BYTESWAP */
 
-/************* The following procedure is common !! **************************/
-
-int integerlength(unsigned int n) {
-  int cnt;
-  if (n <= 2)
-    return (n);
-  else {
-    cnt = 1;
-    do {
-      cnt++;
-      n = (n >> 1);
-    } while (n != 1);
-    return (cnt);
-  }
+static int integerlength(unsigned int n) {
+  return (fls(n));
 }
-
-/************* The above procedure is common !! **************************/
 
 /************************************************************************/
 /*									*/

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -164,13 +164,13 @@ static LispPTR findptrsbuffer(LispPTR ptr) {
 /************************************************************************/
 
 LispPTR releasingvmempage(LispPTR ptr) {
-  struct buf *bptr;
-  LispPTR bufferptr = findptrsbuffer(ptr);
+  LispPTR buffer = findptrsbuffer(ptr);
+  struct buf *buffer_np;
 
-  if (bufferptr == NIL) return (NIL); /* Not in use, OK to reclaim it */
+  if (buffer == NIL) return (NIL); /* Not in use, OK to reclaim it */
 
-  bptr = (struct buf *)NativeAligned4FromLAddr(bufferptr);
-  bptr->noreference = T; /* Mark the buffer free to use ?? */
+  buffer_np = (struct buf *)NativeAligned4FromLAddr(buffer);
+  buffer_np->noreference = T; /* Mark the buffer free to use ?? */
   return (ATOM_T);
 }
 

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -74,9 +74,12 @@
 #define BucketIndex(n) min(integerlength(n), MAXBUCKETINDEX)
 #define FreeBlockChainN(n) ((POINTERMASK & *FreeBlockBuckets_word) + 2 * BucketIndex(n))
 
+/*
+ * Declaration of buffer must be identical layout to Lisp BUFFER datatype in PMAP.
+ */
 #ifndef BYTESWAP
 #ifdef BIGVM
-struct buf {
+struct buffer {
   LispPTR filepage;
   LispPTR vmempage;
   LispPTR buffernext;
@@ -87,7 +90,7 @@ struct buf {
   unsigned sysnext : 28;
 };
 #else
-struct buf {
+struct buffer {
   LispPTR filepage;
   LispPTR vmempage;
   LispPTR buffernext;
@@ -100,7 +103,7 @@ struct buf {
 #endif /* BIGVM */
 #else
 #ifdef BIGVM
-struct buf {
+struct buffer {
   LispPTR filepage;
   LispPTR vmempage;
   LispPTR buffernext;
@@ -111,7 +114,7 @@ struct buf {
   unsigned noreference : 1;
 };
 #else
-struct buf {
+struct buffer {
   LispPTR filepage;
   LispPTR vmempage;
   LispPTR buffernext;
@@ -140,10 +143,10 @@ static int integerlength(unsigned int n) {
 
 static LispPTR findptrsbuffer(LispPTR ptr) {
   LispPTR buf;
-  struct buf *buf_np;
+  struct buffer *buf_np;
   buf = *System_Buffer_List_word;
   while (buf != NIL) {
-    buf_np = (struct buf *)NativeAligned4FromLAddr(buf);
+    buf_np = (struct buffer *)NativeAligned4FromLAddr(buf);
     if (ptr == buf_np->vmempage) {
       return (buf);
     }
@@ -165,11 +168,11 @@ static LispPTR findptrsbuffer(LispPTR ptr) {
 
 LispPTR releasingvmempage(LispPTR ptr) {
   LispPTR buffer = findptrsbuffer(ptr);
-  struct buf *buffer_np;
+  struct buffer *buffer_np;
 
   if (buffer == NIL) return (NIL); /* Not in use, OK to reclaim it */
 
-  buffer_np = (struct buf *)NativeAligned4FromLAddr(buffer);
+  buffer_np = (struct buffer *)NativeAligned4FromLAddr(buffer);
   buffer_np->noreference = T; /* Mark the buffer free to use ?? */
   return (ATOM_T);
 }

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -460,17 +460,17 @@ LispPTR mergebackward(LispPTR base) {
 
 LispPTR mergeforward(LispPTR base) {
   LispPTR nbase, nbinuse;
-  struct arrayblock *bbase, *bnbase;
+  struct arrayblock *base_np, *nbase_np;
   if (*ArrayMerging_word == NIL) return NIL;
   if (base == NIL) return NIL;
   if (checkarrayblock(base, T, T)) return NIL;
 
-  bbase = (struct arrayblock *)NativeAligned4FromLAddr(base);
-  nbase = base + DLWORDSPER_CELL * (bbase->arlen);
+  base_np = (struct arrayblock *)NativeAligned4FromLAddr(base);
+  nbase = base + DLWORDSPER_CELL * (base_np->arlen);
   if (nbase == *ArrayFrLst_word || nbase == *ArrayFrLst2_word) return NIL;
 
-  bnbase = (struct arrayblock *)NativeAligned4FromLAddr(nbase);
-  nbinuse = bnbase->inuse;
+  nbase_np = (struct arrayblock *)NativeAligned4FromLAddr(nbase);
+  nbinuse = nbase_np->inuse;
   if (checkarrayblock(nbase, !nbinuse, NIL)) return NIL;
   if (nbinuse) return (NIL);
   deleteblock(nbase);

--- a/src/gcfinal.c
+++ b/src/gcfinal.c
@@ -610,3 +610,30 @@ void printarrayblock(LispPTR base) {
   addr++;
   for (; addr < (LispPTR *)trailer_np + 20; addr++) printf("%16p (0x%8x) %8x\n", (void *)addr, LAddrFromNative(addr), *addr);
 }
+
+static void printfreeblockchainhead(int index)
+{
+  LispPTR fbl, freeblock;
+  LispPTR *fbl_np;
+
+  fbl = POINTERMASK & ((*FreeBlockBuckets_word) + (DLWORDSPER_CELL * index));
+  fbl_np = (LispPTR *)NativeAligned4FromLAddr(fbl);
+  /* lisp pointer to free block on chain */
+  freeblock = POINTERMASK & (*fbl_np);
+  if (freeblock == NIL) { /* no blocks in chain */
+    printf("Free block chain (bucket %d): NIL\n", index);
+  } else {
+    printf("Free block chain(bucket %d): 0x%x\n", index, freeblock);
+  }
+}
+
+void printfreeblockchainn(int arlen)
+{
+  if (arlen >= 0) {
+    printfreeblockchainhead(BucketIndex(arlen));
+    return;
+  } else
+    for (int i = 0; i <= MAXBUCKETINDEX; i++) {
+      printfreeblockchainhead(i);
+    }
+}

--- a/src/uraid.c
+++ b/src/uraid.c
@@ -168,6 +168,7 @@ static const char *URaid_summary2 =
     "\n-- Memory display commands\n\
 a litatom\t\tDisplays the top-level value of the litatom\n\
 B Xaddress\t\tPrint the contents of the arrayblock at that address.\n\
+F [size]\t\tPrint the head of the array free list chain for given size, or all\n\
 d litatom\t\tDisplays the definition cell for the litatom\n\
 M\t\t\tDisplays TOS,CSP,PVAR,IVAR,PC\n\
 m func1 func2\t\tMOVD func1 to func2\n\
@@ -201,6 +202,7 @@ l [type]\t\tDisplays backtrace for specified type of stack. (k|m|r|g|p|u|<null>)
 \n-- Memory display commands\n\
 a litatom\t\tDisplays the top-level value of the litatom\n\
 B Xaddress\t\tDisplays the contents of the arrayblock at that address.\n\
+F [size]\t\tPrint the head of the array free list chain for given size, or all\n\
 d litatom\t\tDisplays the definition cell of the litatom\n\
 M\t\t\tDisplays TOS,CSP,PVAR,IVAR,PC\n\
 m func1 func2\t\tMoves definition of func1 to func2 (MOVD)\n\
@@ -464,6 +466,26 @@ LispPTR uraid_commands(void) {
         return (T);
       }
       printarrayblock(objaddr);
+    }
+    break;
+
+    case 'F': { /* print array block free list head(s) */
+      long size;
+      if (URaid_argnum != 1 && URaid_argnum != 2) {
+        printf("FREE-BLOCK-CHAIN: F [block-size (cells)]\n");
+        return (T);
+      }
+      if (URaid_argnum == 1) {
+        size = -1;
+      } else {
+        errno = 0;
+        size = (LispPTR)strtol(URaid_arg1, &endpointer, 0);
+        if (errno != 0 || *endpointer != '\0') {
+          printf("Arg not number\n");
+          return (T);
+        }
+      }
+      printfreeblockchainn(size);
     }
     break;
 


### PR DESCRIPTION
This set of changes adds a new URaid command, `F [size]`, which will display the address of the first block on the free list for the bucket holding the given size, or, if no size is specified, all 31 buckets.  For example,
```
< F
[...]
Free block chain (bucket 3): NIL
Free block chain(bucket 4): 0x3cffe2
Free block chain (bucket 5): NIL
Free block chain(bucket 6): 0x3fffbe
Free block chain(bucket 7): 0x40aeb6
Free block chain (bucket 8): NIL
Free block chain(bucket 9): 0x45061c
Free block chain (bucket 10): NIL
[...]
< F 500
Free block chain(bucket 9): 0x45061c
```
Using this, one can walk the free block chain using the (existing) `B address` command which dumps an array block header and some words around the beginning and end of the block:
```
< B 0x45061c
This array block: 0x45061c.  Previous: 0x450450.  Next: 0x450956.
        password: 0x1555     gctype: 0x0   in use: 0
      Free list: fwd 0x45061c bkwd 0x45061c
  Header  Length: 413 cells.

 Trailer  Length: 413 cells.
[...]
```
In addition to this added functionality, the changes
   * introduce a more consistent naming, in some of the GC code, of variables that represent the native pointer equivalent of a Lisp address (e.g., `base`/`base_np`, `trailer`/`trailer_np`).  This convention could be used generally through the code in the future.
   * improve the readability of some nested code in GC routines by rewriting `if (test) .../else return;` forms as `if (!test) return; ...` (the "early out" pattern)
