### PR TITLE
string handling cleanup

### DIFF
--- a/bin/makefile-tail
+++ b/bin/makefile-tail
@@ -674,7 +674,7 @@ $(OBJECTDIR)initsout.o: $(SRCDIR)initsout.c $(REQUIRED-INCS) \
 
 $(OBJECTDIR)kbdsubrs.o: $(SRCDIR)kbdsubrs.c $(REQUIRED-INCS) \
 	$(INCDIR)lispemul.h $(INCDIR)kbdsubrsdefs.h \
-	$(INCDIR)commondefs.h $(INCDIR)lisp2cdefs.h $(INCDIR)xwinmandefs.h \
+	$(INCDIR)commondefs.h $(INCDIR)xwinmandefs.h \
 	$(INCDIR)devif.h
 	$(CC) $(RFLAGS) $(SRCDIR)kbdsubrs.c -o $(OBJECTDIR)kbdsubrs.o
 

--- a/inc/locfile.h
+++ b/inc/locfile.h
@@ -78,66 +78,57 @@
 /*									*/
 /************************************************************************/
 #ifndef BYTESWAP
-#define	LispStringToCString(Lisp, C, MaxLen)				\
-  do {									\
-    OneDArray	*lf_arrayp;						\
-    char	*lf_base, *lf_dp;						\
-    short	*lf_sbase;							\
-    size_t		 lf_length;						\
-    lf_arrayp = (OneDArray *)NativeAligned4FromLAddr(Lisp);		\
-    lf_length = min(MaxLen, lf_arrayp->fillpointer);			\
-    switch(lf_arrayp->typenumber)						\
-      {									\
-	case THIN_CHAR_TYPENUMBER:					\
-		lf_base = ((char *)(NativeAligned2FromLAddr(lf_arrayp->base)))  	\
-		       + ((int)(lf_arrayp->offset));			\
-		strncpy(C, lf_base, lf_length);				\
-		(C)[lf_length] = '\0';					\
-		break;							\
-									\
-	case FAT_CHAR_TYPENUMBER:					\
-		lf_sbase = ((short *)(NativeAligned2FromLAddr(lf_arrayp->base)))	\
-		       + ((int)(lf_arrayp->offset));			\
-                lf_dp = C;						\
-		for(size_t lf_i=0;lf_i<(lf_length);lf_i++)		\
-		  *lf_dp++ = (char)(*lf_sbase++);			\
-		*lf_dp = '\0';						\
-		break;							\
-	default:							\
-		error("LispStringToCString: Not a character array.\n");	\
-      }									\
- } while (0)
+#define LispStringToCString(Lisp, C, MaxLen)                                                    \
+  do {                                                                                          \
+    OneDArray *lf_arrayp;                                                                       \
+    char *lf_base, *lf_dp;                                                                      \
+    short *lf_sbase;                                                                            \
+    size_t lf_length;                                                                           \
+    lf_arrayp = (OneDArray *)NativeAligned4FromLAddr(Lisp);                                     \
+    lf_length = min(MaxLen - 1, lf_arrayp->fillpointer);                                            \
+    lf_dp = (C);                                                                                \
+    switch (lf_arrayp->typenumber) {                                                            \
+      case THIN_CHAR_TYPENUMBER:                                                                \
+        lf_base =                                                                               \
+            ((char *)(NativeAligned2FromLAddr(lf_arrayp->base))) + ((int)(lf_arrayp->offset));  \
+        strncpy(lf_dp, lf_base, lf_length);                                                     \
+        lf_dp[lf_length] = '\0';                                                                \
+        break;                                                                                  \
+                                                                                                \
+      case FAT_CHAR_TYPENUMBER:                                                                 \
+        lf_sbase =                                                                              \
+            ((short *)(NativeAligned2FromLAddr(lf_arrayp->base))) + ((int)(lf_arrayp->offset)); \
+        for (size_t lf_i = 0; lf_i < (lf_length); lf_i++) *lf_dp++ = (char)(*lf_sbase++);       \
+        *lf_dp = '\0';                                                                          \
+        break;                                                                                  \
+      default: error("LispStringToCString: Not a character array.\n");                          \
+    }                                                                                           \
+  } while (0)
 #else  /* BYTESWAP == T CHANGED-BY-TAKE */
-#define	LispStringToCString(Lisp, C, MaxLen)				\
-  do {									\
-    OneDArray	*lf_arrayp;						\
-    char	*lf_base, *lf_dp;						\
-    short	*lf_sbase;							\
-    size_t 	lf_length;						\
-    lf_arrayp = (OneDArray *)(NativeAligned4FromLAddr(Lisp));			\
-    lf_length = min(MaxLen, lf_arrayp->fillpointer);			\
-    switch(lf_arrayp->typenumber)						\
-      {									\
-	case THIN_CHAR_TYPENUMBER:					\
-		lf_base = ((char *)(NativeAligned2FromLAddr(lf_arrayp->base)))  	\
-		       + ((int)(lf_arrayp->offset));			\
-                lf_dp = C;                                              \
-                for (size_t lf_i = 0; lf_i < lf_length; lf_i++)         \
-                  *lf_dp++ = GETBYTE(lf_base++);                            \
-		*lf_dp = '\0';					\
-		break;							\
-									\
-	case FAT_CHAR_TYPENUMBER:					\
-		lf_sbase = ((short *)(NativeAligned2FromLAddr(lf_arrayp->base)))	\
-		       + ((int)(lf_arrayp->offset));			\
-                lf_dp = C;						\
-		for(size_t lf_ii=0;lf_ii<(lf_length);lf_ii++,lf_sbase++)  \
-                    *lf_dp++ = (char)(GETWORD(lf_sbase));               \
-		*lf_dp = '\0';						\
-		break;							\
-	default:							\
-		error("LispStringToCString: Not a character array.\n");	\
-      }									\
+#define LispStringToCString(Lisp, C, MaxLen)                                                       \
+  do {                                                                                             \
+    OneDArray *lf_arrayp;                                                                          \
+    char *lf_base, *lf_dp;                                                                         \
+    short *lf_sbase;                                                                               \
+    size_t lf_length;                                                                              \
+    lf_arrayp = (OneDArray *)(NativeAligned4FromLAddr(Lisp));                                      \
+    lf_length = min(MaxLen - 1, lf_arrayp->fillpointer);                                               \
+    lf_dp = (C);                                                                                   \
+    switch (lf_arrayp->typenumber) {                                                               \
+      case THIN_CHAR_TYPENUMBER:                                                                   \
+        lf_base =                                                                                  \
+            ((char *)(NativeAligned2FromLAddr(lf_arrayp->base))) + ((int)(lf_arrayp->offset));     \
+        for (size_t lf_i = 0; lf_i < lf_length; lf_i++) *lf_dp++ = GETBYTE(lf_base++);             \
+        break;                                                                                     \
+                                                                                                   \
+      case FAT_CHAR_TYPENUMBER:                                                                    \
+        lf_sbase =                                                                                 \
+            ((short *)(NativeAligned2FromLAddr(lf_arrayp->base))) + ((int)(lf_arrayp->offset));    \
+        for (size_t lf_ii = 0; lf_ii < lf_length; lf_ii++) *lf_dp++ = (char)(GETWORD(lf_sbase++)); \
+        break;                                                                                     \
+      default: error("LispStringToCString: Not a character array.\n");                             \
+    }                                                                                              \
+    *lf_dp = '\0';                                                                                 \
   } while (0)
 
 #endif /* BYTESWAP */
@@ -300,7 +291,7 @@ do  {				\
  * Argument:	char	*pathname
  *				Xerox Lisp syntax pathname.
  *
- * Value:	If succeed, returns 1, otherwise 0.
+ * Value:	On success returns 1, otherwise 0.
  *
  * Side Effect:	The version part of pathname is destructively modified.
  *
@@ -313,7 +304,7 @@ do  {				\
  * code.
  * This macro should be called at the top of the routines which accept the
  * file name from lisp before converting it into UNIX file name, because
- * locating the version part, the informations about quoted characters are needed.
+ * locating the version part, the information about quoted characters are needed.
  * They might be lost in the course of the conversion.
  *
  */
@@ -338,19 +329,18 @@ do  {				\
  *				If 0, versionless file is converted to version 1.
  *				Otherwise, remains as versionless.
  *
- * Value:	If succeed, returns 1, otherwise 0.
+ * Value:	On success returns 1, otherwise 0.
  *
  * Side Effect:	The version part of pathname is destructively modified.
  *
  * Description:
  *
- * Destructively modify the version part of pathname which is following the
+ * Destructively modifies the version part of pathname which is following the
  * UNIX file naming convention to Xerox Lisp one.
  * This macro should be called, in the routines which convert the UNIX pathname
  * to Lisp one, just before it returns the result to Lisp, because converting
- * version field will append a semicolon and it might make the routine be
- * confused.
- * The file which has not a valid version field, that is ".~##~" form, is
+ * version field will append a semicolon which may confuse the routine
+ * The file which does not have a valid version field, that is ".~##~" form, is
  * dealt with as version 1. 
  */
 

--- a/inc/vmemsavedefs.h
+++ b/inc/vmemsavedefs.h
@@ -1,7 +1,6 @@
 #ifndef VMEMSAVEDEFS_H
 #define VMEMSAVEDEFS_H 1
-#include "lispemul.h" /* for LispPTR, DLword */
-int lispstringP(LispPTR Lisp);
+#include "lispemul.h" /* for LispPTR */
 LispPTR vmem_save(char *sysout_file_name);
 LispPTR vmem_save0(LispPTR *args);
 void lisp_finish(int exit_status);

--- a/src/dir.c
+++ b/src/dir.c
@@ -2159,7 +2159,7 @@ LispPTR COM_next_file(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, fp->lname, fp->lname_len);
 #else
-  StrNCpyFromCToLisp(base, fp->lname, fp->lname_len);
+  MemCpyToLispFromNative(base, fp->lname, fp->lname_len);
 #endif /* BYTESWAP	 */
 
   if (!propp) return (GetPosSmallp(fp->lname_len));
@@ -2175,7 +2175,7 @@ LispPTR COM_next_file(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, pp->author, pp->au_len);
 #else
-  StrNCpyFromCToLisp(base, pp->author, pp->au_len);
+  MemCpyToLispFromNative(base, pp->author, pp->au_len);
 #endif /* BYTESWAP	 */
 
   gfsp->aulen = pp->au_len;

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -1034,7 +1034,7 @@ LispPTR DSK_getfilename(LispPTR *args)
 #ifndef BYTESWAP
       strncpy(base, lfname, len + 1);
 #else
-      StrNCpyFromCToLisp(base, lfname, len + 1);
+      MemCpyToLispFromNative(base, lfname, len + 1);
 #endif /* BYTESWAP */
 
       return (GetPosSmallp(len));
@@ -1070,7 +1070,7 @@ LispPTR DSK_getfilename(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, lfname, len + 1);
 #else
-  StrNCpyFromCToLisp(base, lfname, len + 1);
+  MemCpyToLispFromNative(base, lfname, len + 1);
 #endif /* BYTESWAP */
 
   return (GetPosSmallp(len));
@@ -1509,7 +1509,7 @@ LispPTR DSK_directorynamep(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, dirname, len + 1);
 #else
-  StrNCpyFromCToLisp(base, dirname, len + 1);
+  MemCpyToLispFromNative(base, dirname, len + 1);
 #endif /* BYTESWAP */
 
   return (GetPosSmallp(len));
@@ -1671,7 +1671,7 @@ LispPTR COM_getfileinfo(LispPTR *args)
 #ifndef BYTESWAP
       strncpy(base, pwd->pw_name, len);
 #else
-      StrNCpyFromCToLisp(base, pwd->pw_name, len);
+      MemCpyToLispFromNative(base, pwd->pw_name, len);
 #endif /* BYTESWAP */
 #endif /* DOS */
       return (GetPosSmallp(len));
@@ -1710,7 +1710,7 @@ LispPTR COM_getfileinfo(LispPTR *args)
 #ifndef BYTESWAP
       strncpy(base, pwd->pw_name, len);
 #else
-      StrNCpyFromCToLisp(base, pwd->pw_name, len);
+      MemCpyToLispFromNative(base, pwd->pw_name, len);
 #endif /* BYTESWAP	 */
 #endif /* DOS */
       return (GetPosSmallp(len));

--- a/src/dsk.c
+++ b/src/dsk.c
@@ -1032,9 +1032,9 @@ LispPTR DSK_getfilename(LispPTR *args)
       len = strlen(lfname);
 
 #ifndef BYTESWAP
-      strncpy(base, lfname, len + 1);
+      strncpy(base, lfname, len);
 #else
-      MemCpyToLispFromNative(base, lfname, len + 1);
+      MemCpyToLispFromNative(base, lfname, len);
 #endif /* BYTESWAP */
 
       return (GetPosSmallp(len));
@@ -1068,9 +1068,9 @@ LispPTR DSK_getfilename(LispPTR *args)
   len = strlen(lfname);
 
 #ifndef BYTESWAP
-  strncpy(base, lfname, len + 1);
+  strncpy(base, lfname, len);
 #else
-  MemCpyToLispFromNative(base, lfname, len + 1);
+  MemCpyToLispFromNative(base, lfname, len);
 #endif /* BYTESWAP */
 
   return (GetPosSmallp(len));
@@ -1507,9 +1507,9 @@ LispPTR DSK_directorynamep(LispPTR *args)
   STRING_BASE(args[1], base);
 
 #ifndef BYTESWAP
-  strncpy(base, dirname, len + 1);
+  strncpy(base, dirname, len);
 #else
-  MemCpyToLispFromNative(base, dirname, len + 1);
+  MemCpyToLispFromNative(base, dirname, len);
 #endif /* BYTESWAP */
 
   return (GetPosSmallp(len));

--- a/src/ether_nethub.c
+++ b/src/ether_nethub.c
@@ -468,7 +468,7 @@ LispPTR ether_get(LispPTR args[])
   log_debug(("ether_get() - begin\n"));
 
   target = (u_char *)NativeAligned2FromLAddr(args[1]);
-  maxByteCount = 2 * LispIntToCInt(args[0]); /* words to bytes */
+  maxByteCount = BYTESPER_DLWORD * LispIntToCInt(args[0]); /* words to bytes */
   log_debug(("  target = %p maxBytecount: %d bytes\n", (void *)target, maxByteCount));
 
   ether_buf = target;
@@ -501,7 +501,7 @@ LispPTR ether_send(LispPTR args[])
   log_debug(("ether_send() - begin\n"));
 
   u_char *source = (u_char *)NativeAligned2FromLAddr(args[1]);
-  int byteCount = 2 * LispIntToCInt(args[0]); /* words to bytes */
+  int byteCount = BYTESPER_DLWORD * LispIntToCInt(args[0]); /* words to bytes */
 
   log_debug(("   source = %p , bytecount: %d bytes\n", (void *)source, byteCount));
 

--- a/src/ether_sunos.c
+++ b/src/ether_sunos.c
@@ -366,7 +366,7 @@ LispPTR ether_get(LispPTR args[])
   LispPTR MaxByteCount;
   sigset_t signals;
 
-  MaxByteCount = 2 * (0xFFFF & args[0]); /* words to bytes */
+  MaxByteCount = BYTERSPER_DLWORD * (0xFFFF & args[0]); /* words to bytes */
 
   DBPRINT(("Ether Get.  "));
 
@@ -408,7 +408,7 @@ LispPTR ether_send(LispPTR args[])
   LispPTR MaxByteCount;
   u_char *BufferAddr; /* buffer address pointer(in native address) */
 
-  MaxByteCount = 2 * (0xFFFF & args[0]); /* words to bytes */
+  MaxByteCount = BYTESPER_DLWORD * (0xFFFF & args[0]); /* words to bytes */
   BufferAddr = (u_char *)NativeAligned2FromLAddr(args[1]);
 
   if (ether_fd > 0) {

--- a/src/kbdsubrs.c
+++ b/src/kbdsubrs.c
@@ -28,7 +28,6 @@
 #include "kbdsubrsdefs.h"
 #include "commondefs.h"
 #ifdef XWINDOW
-#include "lisp2cdefs.h"
 #include "xwinmandefs.h"
 #endif
 

--- a/src/kprint.c
+++ b/src/kprint.c
@@ -98,10 +98,12 @@ void prindatum(LispPTR x) {
       break;
     case TYPE_ONED_ARRAY:
     case TYPE_GENERAL_ARRAY:
+      /* this should probably use array.h's arrayheader */
       newstring = (NEWSTRINGP *)NativeAligned4FromLAddr(x);
       if (newstring->stringp) {
         print_NEWstring(x);
       }
+      /* it would be useful to print non-string arrays, too */
       break;
     default: dtd_base = (struct dtd *)GetDTD(typen); printf("{");
 #ifdef BIGVM
@@ -173,14 +175,20 @@ void print_string(LispPTR x) {
 void print_NEWstring(LispPTR x) {
   NEWSTRINGP *string_point;
   DLword st_length;
+  DLword st_offset;
   DLbyte *string_base;
 
   int i;
 
   string_point = (NEWSTRINGP *)NativeAligned4FromLAddr(x);
   st_length = string_point->fillpointer;
+  st_offset = string_point->offset;
+  if (string_point->indirectp) {
+    /* base points to another array header not the raw storage */
+    string_point = (NEWSTRINGP *)NativeAligned4FromLAddr(string_point->base);
+  }
   string_base = (DLbyte *)NativeAligned2FromLAddr(string_point->base);
-  string_base += string_point->offset;
+  string_base += st_offset;
 
   printf("%c", DOUBLEQUOTE); /* print %" */
 

--- a/src/ldsout.c
+++ b/src/ldsout.c
@@ -216,8 +216,8 @@ unsigned sysout_loader(const char *sysout_file_name, unsigned sys_size) {
   }
 
   if ((stat_buf.st_size & (BYTESPER_PAGE - 1)) != 0)
-    printf("CAUTION::not an integral number of pages.  sysout & 0x1ff = 0x%x\n",
-           (int)(stat_buf.st_size & (BYTESPER_PAGE - 1)));
+    printf("CAUTION::not an integral number of pages.  sysout & 0x%x = 0x%x\n",
+           BYTESPER_PAGE - 1, (int)(stat_buf.st_size & (BYTESPER_PAGE - 1)));
 
   if (ifpage.nactivepages != (sysout_size / 2)) {
     printf("sysout_loader:IFPAGE says sysout size is %d\n", ifpage.nactivepages);

--- a/src/lisp2c.c
+++ b/src/lisp2c.c
@@ -38,6 +38,8 @@ int LispStringSimpleLength(LispPTR lispstring) {
   return (arrayp->fillpointer);
 }
 
+/* XXX: this string conversion is NOT useable on byte-swapped (little-endian) machines
+ */
 void LispStringToCStr(LispPTR lispstring, char *cstring) {
   OneDArray *arrayp;
   char *base;

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -233,15 +233,13 @@ LispPTR mess_read(LispPTR *args)
   struct stat sbuf;
   int size, save_size;
   char *base;
-  LispPTR *naddress;
   int i;
   static char temp_buf[MESSAGE_BUFFER_SIZE];
 
   SETJMP(NIL);
 
   /* Get buff address from LISP */
-  naddress = (LispPTR *)(NativeAligned4FromLAddr(args[0]));
-  base = (char *)(NativeAligned2FromLAddr(((OneDArray *)naddress)->base));
+  STRING_BASE(args[0], base);
 
   close(log_id);
   TIMEOUT(log_id = open(logfile, O_RDONLY));

--- a/src/osmsg.c
+++ b/src/osmsg.c
@@ -283,7 +283,7 @@ LispPTR mess_read(LispPTR *args)
     if (temp_buf[i] == '\n') temp_buf[i] = '\000';
   }
   /* COPY actual Lisp Buffer(for BYTESWAP magic) */
-  StrNCpyFromCToLisp(base, temp_buf, size);
+  MemCpyToLispFromNative(base, temp_buf, size);
 
   return (GetSmallp(size));
 #else

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -216,9 +216,9 @@ LispPTR UFS_getfilename(LispPTR *args)
   len = strlen(lfname);
 
 #ifndef BYTESWAP
-  strncpy(base, lfname, len + 1);
+  strncpy(base, lfname, len);
 #else
-  MemCpyToLispFromNative(base, lfname, len + 1);
+  MemCpyToLispFromNative(base, lfname, len);
 #endif /* BYTESWAP */
 
   return (GetSmallp(len));
@@ -420,9 +420,9 @@ LispPTR UFS_directorynamep(LispPTR *args)
   STRING_BASE(args[1], base);
 
 #ifndef BYTESWAP
-  strncpy(base, dirname, len + 1);
+  strncpy(base, dirname, len);
 #else
-  MemCpyToLispFromNative(base, dirname, len + 1);
+  MemCpyToLispFromNative(base, dirname, len);
 #endif /* BYTESWAP */
 
   return (GetSmallp(len));

--- a/src/ufs.c
+++ b/src/ufs.c
@@ -218,7 +218,7 @@ LispPTR UFS_getfilename(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, lfname, len + 1);
 #else
-  StrNCpyFromCToLisp(base, lfname, len + 1);
+  MemCpyToLispFromNative(base, lfname, len + 1);
 #endif /* BYTESWAP */
 
   return (GetSmallp(len));
@@ -422,7 +422,7 @@ LispPTR UFS_directorynamep(LispPTR *args)
 #ifndef BYTESWAP
   strncpy(base, dirname, len + 1);
 #else
-  StrNCpyFromCToLisp(base, dirname, len + 1);
+  MemCpyToLispFromNative(base, dirname, len + 1);
 #endif /* BYTESWAP */
 
   return (GetSmallp(len));

--- a/src/vmemsave.c
+++ b/src/vmemsave.c
@@ -92,7 +92,7 @@ extern int please_fork;
 /*									*/
 /************************************************************************/
 
-int lispstringP(LispPTR Lisp)
+static int lispstringP(LispPTR Lisp)
 {
   switch (((OneDArray *)(NativeAligned4FromLAddr(Lisp)))->typenumber) {
     case THIN_CHAR_TYPENUMBER:


### PR DESCRIPTION
Start at cleaning up some of the string handling in Maiko.  So far this only eliminates one routine (StrNCpyFromLispToC).

There should be no change in the normal operation of the code, the only new feature is that passing an indirect string (such as generated by a displaced array substring on a string) to URaid will print it correctly as the generic object printer will decode indirect strings.