### PR TITLE
Call SDL_StopTextInput() during SDL2 initialization

### DIFF
--- a/src/sdl.c
+++ b/src/sdl.c
@@ -1646,7 +1646,11 @@ int init_SDL(char *windowtitle, int w, int h, int s) {
       sdl_displaywidth * sdl_bytesperpixel, sdl_pixelformat->format);
 #endif
 #endif
+#if SDL_MAJOR_VERSION == 2
   SDL_StopTextInput();
+#else
+  SDL_StopTextInput(sdl_window);
+#endif
   printf("SDL initialised\n");
   return 0;
 }

--- a/src/sdl.c
+++ b/src/sdl.c
@@ -1646,6 +1646,7 @@ int init_SDL(char *windowtitle, int w, int h, int s) {
       sdl_displaywidth * sdl_bytesperpixel, sdl_pixelformat->format);
 #endif
 #endif
+  SDL_StopTextInput();
   printf("SDL initialised\n");
   return 0;
 }


### PR DESCRIPTION
I recently switched to Fedora 44 Linux KDE Plasma edition, and discovered that when I run Medley Interlisp on my laptop, Medley is not receiving any keyboard input, SDL is just swallowing the key events and dropping them, they weren't making it to the `process_SDLevents()` handler! I was very puzzled. Eventually, I learned that calling `SDL_StopTextInput()` during initialization allows the handler to receive these events.

I am not at all certain that this change is safe. At the moment I *only* have Fedora 44 to test on, so at the very least this change should be tested on multiple platforms to ensure it's not going to break the world.